### PR TITLE
Add built-in Handlebars helpers completion tests

### DIFF
--- a/handlebars/test/src/com/dmarcotte/handlebars/completion/HbKeywordCompletionTest.java
+++ b/handlebars/test/src/com/dmarcotte/handlebars/completion/HbKeywordCompletionTest.java
@@ -4,8 +4,6 @@ import com.dmarcotte.handlebars.file.HbFileType;
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
 
-import java.util.Arrays;
-
 public class HbKeywordCompletionTest extends LightPlatformCodeInsightFixtureTestCase {
   public void doBasicTest(String text, String... expected) {
     myFixture.configureByText(HbFileType.INSTANCE, text);
@@ -13,7 +11,15 @@ public class HbKeywordCompletionTest extends LightPlatformCodeInsightFixtureTest
     assertContainsElements(myFixture.getLookupElementStrings(), expected);
   }
 
-  public void testSimple() {
-    doBasicTest("{{#<caret>}}", "if", "each");
+  public void testMustacheCompletions() {
+    doBasicTest("{{<caret>}}", "log");
+  }
+
+  public void testBlockCompletions() {
+    doBasicTest("{{#<caret>}}", "if", "each", "unless", "with");
+  }
+
+  public void testElseCompletion() {
+    doBasicTest("{{#if}}{{<caret>}}{{/if}}", "else", "log");
   }
 }


### PR DESCRIPTION
Hey @fkorotkov, here's the tests I promised you.  These cover all the built-in Handlebars helpers.  These are pulled from the `Handlebars.registerHelper` helper calls in the Handlebars source ([for example](https://github.com/wycats/handlebars.js/blob/master/lib/handlebars/base.js#L100)).  I'll let you merge them in once you've got them passing.

Note that users (and libraries like Emberjs) can add custom helpers using `Handlebars.registerHelper` so potentially this can be replaced/enhanced in the future using Javascript references (thought it might be nice to leave the defaults in for Community Edition users).

Hope this helps!
