### PR TITLE
131

### DIFF
--- a/osmorc/src/org/osmorc/facet/maven/OsmorcFacetImporter.java
+++ b/osmorc/src/org/osmorc/facet/maven/OsmorcFacetImporter.java
@@ -99,8 +99,8 @@ public class OsmorcFacetImporter extends FacetImporter<OsmorcFacet, OsmorcFacetC
 
       // Check if there are any overrides set up in the maven plugin settings
       conf.setBundleSymbolicName(computeSymbolicName(mavenProject)); // IDEA-63243
-      conf.setBundleVersion("instructions." + Constants.BUNDLE_VERSION);
-      conf.setBundleActivator("instructions." + Constants.BUNDLE_ACTIVATOR);
+      conf.setBundleVersion(findConfigValue( mavenProject, "instructions." + Constants.BUNDLE_VERSION));
+      conf.setBundleActivator(findConfigValue( mavenProject, "instructions." + Constants.BUNDLE_ACTIVATOR));
 
 
       if (StringUtil.isEmptyOrSpaces(conf.getBundleVersion())) {  // IDEA-74272


### PR DESCRIPTION
Assuming branch 131 is the branch used for IDEA 13, there's a serious bug in Osmorc:
1. Import a Maven project that uses the maven-bundle-plugin (from Felix)
2. Go to Project Structure window
3. Enter a OSGi facet
4. Go to third tab "Manifest Generation"
5. The "Bundle-Version" field will contain the string "instructions.Bundle-Version" instead of its value from the POM

See the diff for the fix, probably caused by commit 42080979467b68eabe136598fbd1e7cc388411ef (August 2nd).

Please merge and apply - thanks!
