### PR TITLE
Support whitespace control syntax from handlebars

### DIFF
--- a/handlebars/src/com/dmarcotte/handlebars/parsing/handlebars.flex
+++ b/handlebars/src/com/dmarcotte/handlebars/parsing/handlebars.flex
@@ -106,22 +106,22 @@ WhiteSpace = {LineTerminator} | [ \t\f]
 }
 
 <mu> {
-  "{{>" { return HbTokenTypes.OPEN_PARTIAL; }
-  "{{#" { return HbTokenTypes.OPEN_BLOCK; }
-  "{{/" { return HbTokenTypes.OPEN_ENDBLOCK; }
-  "{{^" { return HbTokenTypes.OPEN_INVERSE; }
+  "{{"\~?">" { return HbTokenTypes.OPEN_PARTIAL; }
+  "{{"\~?"#" { return HbTokenTypes.OPEN_BLOCK; }
+  "{{"\~?"/" { return HbTokenTypes.OPEN_ENDBLOCK; }
+  "{{"\~?"^" { return HbTokenTypes.OPEN_INVERSE; }
   // NOTE: a standard Handlebars lexer would check for "{{else" here.  We instead want to lex it as two tokens to highlight the "{{" and the "else" differently.  See where we make an HbTokens.ELSE below.
   "{{{" { return HbTokenTypes.OPEN_UNESCAPED; }
-  "{{&" { return HbTokenTypes.OPEN; }
+  "{{"\~?"&" { return HbTokenTypes.OPEN; }
   "{{!" { yypushback(3); yypopState(); yypushState(comment); }
-  "{{" { return HbTokenTypes.OPEN; }
+  "{{"\~? { return HbTokenTypes.OPEN; }
   "=" { return HbTokenTypes.EQUALS; }
   "."/["}"\t \n\x0B\f\r] { return HbTokenTypes.ID; }
   ".." { return HbTokenTypes.ID; }
   [\/.] { return HbTokenTypes.SEP; }
   [\t \n\x0B\f\r]* { return HbTokenTypes.WHITE_SPACE; }
   "}}}" { yypopState(); return HbTokenTypes.CLOSE_UNESCAPED; }
-  "}}" { yypopState(); return HbTokenTypes.CLOSE; }
+  \~?"}}" { yypopState(); return HbTokenTypes.CLOSE; }
   \"([^\"\\]|\\.)*\" { return HbTokenTypes.STRING; }
   '([^'\\]|\\.)*' { return HbTokenTypes.STRING; }
   "@" { return HbTokenTypes.DATA_PREFIX; }


### PR DESCRIPTION
see http://handlebarsjs.com/block_helpers.html at bottom section
„whitespace control“

Opening and closing curled braces allow an optional "~"-character in order to not mark this syntax as an error. 

Tried to write some unit tests for this, but couldn't make the project compile with the version of the master branch. Templates using this syntax pre compile successfully. 

Handlebars supports this feature since 1.1.0
https://github.com/wycats/handlebars.js/blob/master/release-notes.md#v110---november-3rd-2013 
