### PR TITLE
Remove check for declared library directive in test scripts.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/unittest/DartUnitRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/unittest/DartUnitRunningState.java
@@ -111,15 +111,7 @@ public class DartUnitRunningState extends CommandLineState {
   public GeneralCommandLine getCommand() throws ExecutionException {
     final GeneralCommandLine commandLine = new GeneralCommandLine();
 
-    Project project = getEnvironment().getProject();
     VirtualFile realFile = VirtualFileManager.getInstance().findFileByUrl(VfsUtilCore.pathToUrl(myUnitParameters.getFilePath()));
-    PsiFile psiFile = realFile != null ? PsiManager.getInstance(project).findFile(realFile) : null;
-    if (psiFile != null) {
-      String libraryName = DartResolveUtil.getLibraryName(psiFile);
-      if (libraryName == null || libraryName.endsWith(".dart")) {
-        throw new ExecutionException("Missing library statement in " + psiFile.getName());
-      }
-    }
 
     commandLine.setExePath(DartSdkUtil.getDartExePath(myDartSdk));
     if (realFile != null) {


### PR DESCRIPTION
Fix for http://youtrack.jetbrains.com/issue/WEB-10299 (Dart Plugin - Can't run test unless test is a library).

Tests do not need to declare a library so this check is not desirable.  

(Aside: I'm not entirely sure but it's possible that when this support was written this may in fact have been a requirement.  That said, it should be safe to remove now.)
