### PR TITLE
Upgrade dart infos to weak warning annotations (WEB-11854).

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartInProcessAnnotator.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartInProcessAnnotator.java
@@ -169,7 +169,7 @@ public class DartInProcessAnnotator extends ExternalAnnotator<Pair<DartFileBased
       case NONE:
         return null;
       case INFO:
-        return holder.createInfoAnnotation(textRange, message.getMessage());
+        return holder.createWeakWarningAnnotation(textRange, message.getMessage());
       case WARNING:
         return holder.createWarningAnnotation(textRange, message.getMessage());
       case ERROR:


### PR DESCRIPTION
Improves discoverability of "info" level warnings reported by the Dart analyzer by upgrading them to "weak warnings".  This is consistent with DartEditor semantics.

See: http://youtrack.jetbrains.com/issue/WEB-11854
