### PR TITLE
Dart symbol literal highlighting (WEB-13476).

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -4,6 +4,7 @@ dart.color.settings.description.doc.comment=Documentation comment
 dart.color.settings.description.keyword=Keyword
 dart.color.settings.description.number=Number
 dart.color.settings.description.string=String
+dart.color.settings.description.symbol.literal=Symbol literal
 dart.color.settings.description.valid.string.escape=Escape sequence
 dart.color.settings.description.invalid.string.escape=Invalid escape sequence
 dart.color.settings.description.operator=Operator

--- a/Dart/src/com/jetbrains/lang/dart/highlight/DartColorsAndFontsPage.java
+++ b/Dart/src/com/jetbrains/lang/dart/highlight/DartColorsAndFontsPage.java
@@ -29,6 +29,7 @@ public class DartColorsAndFontsPage implements ColorSettingsPage {
       new AttributesDescriptor(DartBundle.message("dart.color.settings.description.keyword"), KEYWORD),
       new AttributesDescriptor(DartBundle.message("dart.color.settings.description.number"), NUMBER),
       new AttributesDescriptor(DartBundle.message("dart.color.settings.description.string"), STRING),
+      new AttributesDescriptor(DartBundle.message("dart.color.settings.description.symbol.literal"), SYMBOL_LITERAL),
       new AttributesDescriptor(DartBundle.message("dart.color.settings.description.valid.string.escape"), VALID_STRING_ESCAPE),
       new AttributesDescriptor(DartBundle.message("dart.color.settings.description.invalid.string.escape"), INVALID_STRING_ESCAPE),
       new AttributesDescriptor(DartBundle.message("dart.color.settings.description.operator"), OPERATION_SIGN),
@@ -79,6 +80,7 @@ public class DartColorsAndFontsPage implements ColorSettingsPage {
     ourTags.put("keyword", KEYWORD);
     ourTags.put("metadata", METADATA);
     ourTags.put("builtin", BUILTIN);
+    ourTags.put("symbol", SYMBOL_LITERAL);
     ourTags.put("instance.member.function", INSTANCE_MEMBER_FUNCTION);
     ourTags.put("instance.member.function.call", INSTANCE_MEMBER_FUNCTION_CALL);
     ourTags.put("static.member.function", STATIC_MEMBER_FUNCTION);
@@ -153,6 +155,7 @@ public class DartColorsAndFontsPage implements ColorSettingsPage {
            "  <builtin>int</builtin> g() => <abstract.call>f</abstract.call>();\n" +
            "  <builtin>int</builtin> f();\n" +
            "}\n\n" +
+           "const className = <symbol>#MyClass</symbol>;\n\n" +
            "var <top.level.var.decl>topLevelVar</top.level.var.decl> = new SomeClass(null).<inherited.call>g</inherited.call>();\n\n" +
            "<top.level.func.decl>main</top.level.func.decl>() {\n" +
            "  <top.level.func.call>print</top.level.func.call>(<top.level.var.call>topLevelVar</top.level.var.call>);\n" +

--- a/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
+++ b/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
@@ -49,6 +49,8 @@ public class DartSyntaxHighlighterColors {
   private static final String DART_DOT = "DART_DOT";
   private static final String DART_SEMICOLON = "DART_SEMICOLON";
   private static final String DART_BAD_CHARACTER = "DART_BAD_CHARACTER";
+  private static final String DART_SYMBOL_LITERAL = "DART_SYMBOL_LITERAL";
+
 
 
   public static final TextAttributesKey LINE_COMMENT =
@@ -69,6 +71,8 @@ public class DartSyntaxHighlighterColors {
     createTextAttributesKey(DART_VALID_STRING_ESCAPE, DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE);
   public static final TextAttributesKey INVALID_STRING_ESCAPE =
     createTextAttributesKey(DART_INVALID_STRING_ESCAPE, DefaultLanguageHighlighterColors.INVALID_STRING_ESCAPE);
+  public static final TextAttributesKey SYMBOL_LITERAL =
+    createTextAttributesKey(DART_SYMBOL_LITERAL, DefaultLanguageHighlighterColors.KEYWORD);
   public static final TextAttributesKey OPERATION_SIGN =
     createTextAttributesKey(DART_OPERATION_SIGN, DefaultLanguageHighlighterColors.OPERATION_SIGN);
   public static final TextAttributesKey PARENTHS =

--- a/Dart/src/com/jetbrains/lang/dart/ide/annotator/DartColorAnnotator.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/annotator/DartColorAnnotator.java
@@ -57,6 +57,11 @@ public class DartColorAnnotator implements Annotator {
       return;
     }
 
+    if (element instanceof DartSymbolLiteralExpression) {
+      createInfoAnnotation(holder, element, DartSyntaxHighlighterColors.SYMBOL_LITERAL);
+      return;
+    }
+
     if (element instanceof DartReference && element.getParent() instanceof DartType && "dynamic".equals(element.getText())) {
       createInfoAnnotation(holder, element, DartSyntaxHighlighterColors.DART_BUILTIN);
       return;

--- a/Dart/testData/highlighting/ColorAnnotator.dart
+++ b/Dart/testData/highlighting/ColorAnnotator.dart
@@ -35,3 +35,5 @@ class <info>C</info> extends <info>B</info> {
   <info>templateMethod</info>() => null;
   <info>c</info>() => <info textAttributesKey="DART_INHERITED_MEMBER_FUNCTION_CALL">f</info>();
 }
+
+const <info>className</info> = <info textAttributesKey="DART_SYMBOL_LITERAL">#MyClass</info>;


### PR DESCRIPTION
Symbol literal highlighting as per: https://www.dartlang.org/docs/dart-up-and-running/contents/ch02.html#ch02-symbols.

Associated bug: http://youtrack.jetbrains.com/issue/WEB-13476.
