### PR TITLE
Fix CucumberMissedExamplesInspection.

### DIFF
--- a/cucumber/src/org/jetbrains/plugins/cucumber/inspections/CucumberMissedExamplesInspection.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/inspections/CucumberMissedExamplesInspection.java
@@ -43,13 +43,8 @@ public class CucumberMissedExamplesInspection extends GherkinInspection {
 
         final GherkinExamplesBlockImpl block = PsiTreeUtil.getChildOfType(outline, GherkinExamplesBlockImpl.class);
         if (block == null) {
-          final PsiElement descriptionLine = outline.getShortDescriptionText();
-          if (descriptionLine != null) {
-            holder.registerProblem(outline,
-                                   new TextRange(0, descriptionLine.getTextRange().getEndOffset() - outline.getTextOffset()),
-                                   CucumberBundle.message("inspection.missed.example.msg.name"),
-                                   new CucumberCreateExamplesSectionFix());
-          }
+          holder.registerProblem(outline, new TextRange(0, outline.getTextOffset()),
+                                 CucumberBundle.message("inspection.missed.example.msg.name"), new CucumberCreateExamplesSectionFix());
         }
       }
     };


### PR DESCRIPTION
In the previous version of the inspection the following scenario outline does not trigger an error:

```
Scenario outline:
  Given step1
  Then step2
```

but this one does:

```
Scenario outline: scenario description
  Given step1
  Then step2
```

Triggering of the error must not be conditional to the presence of a description text since it is optional.

I decided to only  _highlight_ the "Scenario Outline:" part since code is simpler and it seems enough for the user to know that something is wrong. When present, we could also _highlight_ the description text but I don't see any obvious business value to this conditional.
