### PR TITLE
Dart Type hierarchy improvements

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/type/DartSupertypesHierarchyTreeStructure.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/type/DartSupertypesHierarchyTreeStructure.java
@@ -45,6 +45,16 @@ public final class DartSupertypesHierarchyTreeStructure extends HierarchyTreeStr
       }
     }
 
+    if(supers.size() == 0) {
+      final DartClassResolveResult dartClassResolveResult = dartClass.getSuperClassResolvedOrObjectClass();
+      if(dartClassResolveResult != null) {
+        final DartClass superDartClass = dartClassResolveResult.getDartClass();
+        if (superDartClass != null && superDartClass.getName().equals(DartResolveUtil.OBJECT)) {
+          supers.add(superDartClass);
+        }
+      }
+    }
+
     final List<DartTypeHierarchyNodeDescriptor> descriptors = new ArrayList<DartTypeHierarchyNodeDescriptor>(supers.size());
     for (DartClass aSuper : supers) {
       descriptors.add(new DartTypeHierarchyNodeDescriptor(myProject, descriptor, aSuper, false));

--- a/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
@@ -189,16 +189,26 @@ public class DartResolveUtil {
 
   @Nullable
   public static String getLibraryName(@NotNull PsiFile psiFile) {
-    DartLibraryStatement libraryStatement = null;
-    for (PsiElement root : findDartRoots(psiFile)) {
-      libraryStatement = PsiTreeUtil.getChildOfType(root, DartLibraryStatement.class);
-      if (libraryStatement != null) break;
+    if(isLibraryRoot(psiFile)) {
+      DartLibraryStatement libraryStatement = null;
+      for (PsiElement root : findDartRoots(psiFile)) {
+        libraryStatement = PsiTreeUtil.getChildOfType(root, DartLibraryStatement.class);
+        if (libraryStatement != null) break;
+      }
+      final DartPartStatement[] sources = PsiTreeUtil.getChildrenOfType(psiFile, DartPartStatement.class);
+      if (libraryStatement == null && sources == null) {
+        return getMainFunction(psiFile) == null ? null : psiFile.getName();
+      }
+      return getLibraryName(psiFile, libraryStatement);
+    } else {
+      for (PsiElement root : findDartRoots(psiFile)) {
+        DartPartOfStatement partOfStatement = PsiTreeUtil.getChildOfType(root, DartPartOfStatement.class);
+        if (partOfStatement != null) {
+          return partOfStatement.getLibraryName();
+        }
+      }
+      return null;
     }
-    final DartPartStatement[] sources = PsiTreeUtil.getChildrenOfType(psiFile, DartPartStatement.class);
-    if (libraryStatement == null && sources == null) {
-      return getMainFunction(psiFile) == null ? null : psiFile.getName();
-    }
-    return getLibraryName(psiFile, libraryStatement);
   }
 
   @NotNull


### PR DESCRIPTION
Have 'Object' appear as the default superclass in the Dart hierarchy view, change DartResolveUtil.getLibraryName for part-of files.
