### PR TITLE
Fold type arguments in Dart that are in instance creations

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/folding/DartFoldingBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/folding/DartFoldingBuilder.java
@@ -20,9 +20,13 @@ import com.jetbrains.lang.dart.util.DartResolveUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAware {
+
+  private static final String SMILEY = "<~>";
+
   protected void buildLanguageFoldRegions(@NotNull final List<FoldingDescriptor> descriptors,
                                           @NotNull final PsiElement root,
                                           @NotNull final Document document,
@@ -34,6 +38,11 @@ public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAwar
     foldComments(descriptors, root, fileHeaderRange);                                        // 3. Comments and comment sequences
     foldClassBodies(descriptors, (DartFile)root);                                            // 4. Class body
     foldFunctionBodies(descriptors, root);                                                   // 5. Function body
+    foldTypeArguments(descriptors, root);                                                    // 6. Type arguments
+  }
+
+  public DartFoldingBuilder() {
+    super();
   }
 
   protected String getLanguagePlaceholderText(@NotNull final ASTNode node, @NotNull final TextRange range) {
@@ -48,6 +57,7 @@ public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAwar
     if (elementType == DartTokenTypesSets.SINGLE_LINE_COMMENT) return "//...";       // 3.4. Consequent single line comments
     if (psiElement instanceof DartClassBody) return "{...}";                         // 4.   Class body
     if (psiElement instanceof DartFunctionBody) return "{...}";                      // 5.   Function body
+    if (psiElement instanceof DartTypeArguments) return SMILEY;                      // 6.   Type arguments
 
     return "...";
   }
@@ -57,15 +67,17 @@ public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAwar
     final PsiElement psiElement = node.getPsi();
     final CodeFoldingSettings settings = CodeFoldingSettings.getInstance();
 
-    if (psiElement instanceof DartFile) return settings.COLLAPSE_FILE_HEADER;                // 1. File header
-    if (psiElement instanceof DartImportOrExportStatement) return settings.COLLAPSE_IMPORTS; // 2. Import and export statements
+    if (psiElement instanceof DartFile) return settings.COLLAPSE_FILE_HEADER;                      // 1. File header
+    if (psiElement instanceof DartImportOrExportStatement) return settings.COLLAPSE_IMPORTS;       // 2. Import and export statements
 
-    if (elementType == DartTokenTypesSets.MULTI_LINE_DOC_COMMENT ||                          // 3.1. Multiline doc comments
-        elementType == DartTokenTypesSets.SINGLE_LINE_DOC_COMMENT) {                         // 3.3. Consequent single line doc comments
-      return settings.COLLAPSE_DOC_COMMENTS;                                                 // 3.2 and 3.4 never collapsed by default
+    if (elementType == DartTokenTypesSets.MULTI_LINE_DOC_COMMENT ||                                // 3.1. Multiline doc comments
+        elementType ==
+        DartTokenTypesSets.SINGLE_LINE_DOC_COMMENT) {                                              // 3.3. Consequent single line doc comments
+      return settings.COLLAPSE_DOC_COMMENTS;                                                       // 3.2 and 3.4 never collapsed by default
     }
-    //                                                                                          4. Class body never collapsed by default
-    if (psiElement instanceof DartFunctionBody) return settings.COLLAPSE_METHODS;            // 5. Function body
+    //                                                                                                4. Class body never collapsed by default
+    if (psiElement instanceof DartFunctionBody) return settings.COLLAPSE_METHODS;                  // 5. Function body
+    if (psiElement instanceof DartTypeArguments) return settings.COLLAPSE_CUSTOM_FOLDING_REGIONS;  // 6. Type arguments
 
     return false;
   }
@@ -96,7 +108,8 @@ public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAwar
       if (nextAfterComments.equals(firstComment)) return null;
       final TextRange fileHeaderCommentsRange = new UnfairTextRange(firstComment.getTextOffset(), nextAfterComments.getTextOffset());
       if (fileHeaderCommentsRange.getLength() > 1 &&
-          document.getLineNumber(fileHeaderCommentsRange.getEndOffset()) > document.getLineNumber(fileHeaderCommentsRange.getStartOffset())) {
+          document.getLineNumber(fileHeaderCommentsRange.getEndOffset()) >
+          document.getLineNumber(fileHeaderCommentsRange.getStartOffset())) {
         if (!containsCustomRegionMarker) {
           descriptors.add(new FoldingDescriptor(dartFile, fileHeaderCommentsRange));
         }
@@ -213,6 +226,16 @@ public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAwar
     final DartBlock block = functionBody == null ? null : functionBody.getBlock();
     if (block != null && block.getTextLength() > 2) {
       descriptors.add(new FoldingDescriptor(functionBody, block.getTextRange()));
+    }
+  }
+
+  private static void foldTypeArguments(@NotNull final List<FoldingDescriptor> descriptors, @NotNull final PsiElement root) {
+    Collection<DartTypeArguments> dartTypeArgumentsList = PsiTreeUtil.collectElementsOfType(root, DartTypeArguments.class);
+    for (DartTypeArguments dartTypeArguments : dartTypeArgumentsList) {
+      if (PsiTreeUtil.getParentOfType(dartTypeArguments, DartNewExpression.class) != null) {
+        descriptors.add(new FoldingDescriptor(dartTypeArguments, TextRange
+          .create(dartTypeArguments.getTextOffset(), dartTypeArguments.getTextRange().getEndOffset())));
+      }
     }
   }
 }

--- a/Dart/testData/folding/TypeArguments.dart
+++ b/Dart/testData/folding/TypeArguments.dart
@@ -1,0 +1,11 @@
+library foo;
+sclass A<T>{}
+// verify the type arguments in class declarations aren't folded
+class B<T> extends A<T> {}
+
+List<String> list1 = new List<fold text='<~>' expand='true'><String></fold>();
+
+f() <fold text='{...}' expand='true'>{
+A<String> a = new A<fold text='<~>' expand='true'><String></fold>();
+}</fold>
+

--- a/Dart/testData/folding/TypeArgumentsByDefault.dart
+++ b/Dart/testData/folding/TypeArgumentsByDefault.dart
@@ -1,0 +1,11 @@
+library foo;
+class A<T>{}
+// verify the type arguments in class declarations aren't folded
+class B<T> extends A<T> {}
+
+List<String> list1 = new List<fold text='<~>' expand='false'><String></fold>();
+
+f() <fold text='{...}' expand='true'>{
+A<String> a = new A<fold text='<~>' expand='false'><String></fold>();
+}</fold>
+

--- a/Dart/testSrc/com/jetbrains/lang/dart/folding/DartFoldingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/folding/DartFoldingTest.java
@@ -87,4 +87,16 @@ public class DartFoldingTest extends DartCodeInsightFixtureTestCase {
   public void testCustomRegionsOverlappingWithCommentFoldings() throws Exception {
     doTest();
   }
+
+  public void testTypeArguments() throws Exception {
+    doTest();
+  }
+
+  public void testTypeArgumentsByDefault() throws Exception {
+    doTestWithSpecificSettings(new Consumer<CodeFoldingSettings>() {
+      public void consume(final CodeFoldingSettings settings) {
+        settings.COLLAPSE_CUSTOM_FOLDING_REGIONS = true;
+      }
+    });
+  }
 }


### PR DESCRIPTION
Fold type arguments in Dart that are in instance creations, such as "new A<B, C, D>" => "new A<~>"

The new fold is enabled and disabled by the CodeFoldingSettings.COLLAPSE_CUSTOM_FOLDING_REGIONS setting.  My assumption here is that until there are a few custom folding regions, all new folds are set with this setting?  Or should I create a new option for this fold like in the Java support?
