### PR TITLE
Dart Plugin: have PubListPackageDirsAction create a new AnalysisContext with optimizing options to crawl/analyze the entire project to compute the set of files that should be added to the IntelliJ index.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalyzerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalyzerService.java
@@ -134,11 +134,6 @@ public class DartAnalyzerService {
     });
   }
 
-  public AnalysisContext createFreshContext() {
-    // A HACK --- rather than reaching in for the cached reference, we want a fresh context
-    return SoftReference.dereference(myAnalysisContextRef);
-  }
-
   @NotNull
   public static DartAnalyzerService getInstance(final @NotNull Project project) {
     return ServiceManager.getService(project, DartAnalyzerService.class);


### PR DESCRIPTION
This change unblocks users who require pub list for analysis.  There will be some cleanup after this lands, including some refactoring (Alex, is there a better way to implement getAllDartFilesFromRoot()?), I also want to modify the UI.
