### PR TITLE
Stagehand integration for Dart project template creation (WEB-13936).

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -80,7 +80,6 @@ dart.pub.get.title=Pub: Get Dependencies
 dart.pub.upgrade.title=Pub: Upgrade Dependencies
 dart.pub.build.title=Pub: Build
 dart.pub.stagehand.exception.no.sdk=Unable to run stagehand -- no SDK configured
-dart.pub.stagehand.exception.invalid.basedir.path=Unable to run stagehand -- invalid base directory
 pub.build.mode.not.specified=Pub build mode not specified
 dart.pub.cache.repair.title=Pub: Repair Cache
 dart.pub.cache.repair.message=<html>The <a href='https://www.dartlang.org/tools/pub/cmd/pub-cache.html'>pub cache repair</a> command performs a clean reinstall<br/>of all hosted and git packages in the system cache.<br/><br/>Start cache repair?</html>

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartCmdLineAppGenerator.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartCmdLineAppGenerator.java
@@ -3,7 +3,6 @@ package com.jetbrains.lang.dart.projectWizard;
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartBundle;
@@ -27,7 +26,7 @@ public class DartCmdLineAppGenerator extends DartEmptyProjectGenerator {
   }
 
   @NotNull
-  protected VirtualFile[] doGenerateProject(final Project project, final Module module, final VirtualFile baseDir) throws IOException {
+  protected VirtualFile[] doGenerateProject(@NotNull final Module module, final VirtualFile baseDir) throws IOException {
     final VirtualFile pubspecFile = baseDir.createChildData(this, PubspecYamlUtil.PUBSPEC_YAML);
     pubspecFile.setBinaryContent(("name: " + module.getName() + "\n" +
                                   "version: 0.0.1\n" +

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartEmptyProjectGenerator.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartEmptyProjectGenerator.java
@@ -74,7 +74,7 @@ public class DartEmptyProjectGenerator extends WebProjectTemplate<DartProjectWiz
       public void run() {
         setupSdkAndDartium(module, data);
         try {
-          final VirtualFile[] filesToOpen = doGenerateProject(project, module, baseDir);
+          final VirtualFile[] filesToOpen = doGenerateProject(module, baseDir);
           if (filesToOpen.length > 0) {
             scheduleFilesOpeningAndPubGet(project, filesToOpen);
           }
@@ -90,7 +90,7 @@ public class DartEmptyProjectGenerator extends WebProjectTemplate<DartProjectWiz
   }
 
   @NotNull
-  protected VirtualFile[] doGenerateProject(final Project project, final Module module, final VirtualFile baseDir) throws IOException {
+  protected VirtualFile[] doGenerateProject(@NotNull final Module module, final VirtualFile baseDir) throws IOException {
     return VirtualFile.EMPTY_ARRAY;
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartTemplatesFactory.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartTemplatesFactory.java
@@ -18,8 +18,8 @@ public class DartTemplatesFactory extends ProjectTemplatesFactory {
 
   private static final String GROUP_NAME = "Dart";
 
-  private static final Stagehand myStagehand = new Stagehand();
-  private static List<DartEmptyProjectGenerator> myTemplateCache;
+  private static final Stagehand STAGEHAND = new Stagehand();
+  private static List<DartEmptyProjectGenerator> ourTemplateCache;
 
   @NotNull
   @Override
@@ -39,7 +39,7 @@ public class DartTemplatesFactory extends ProjectTemplatesFactory {
     final List<DartEmptyProjectGenerator> templates = getStagehandTemplates();
 
     if (!templates.isEmpty()) {
-      return templates.toArray(StagehandTemplateGenerator.EMPTY_ARRAY);
+      return templates.toArray(new ProjectTemplate[templates.size()]);
     }
 
     // Fall back
@@ -52,42 +52,42 @@ public class DartTemplatesFactory extends ProjectTemplatesFactory {
 
   private static List<DartEmptyProjectGenerator> getStagehandTemplates() {
 
-    if (myTemplateCache != null) {
-      return myTemplateCache;
+    if (ourTemplateCache != null) {
+      return ourTemplateCache;
     }
 
     boolean doUpgradeCheck = true;
 
-    if (!myStagehand.isInstalled()) {
+    if (!STAGEHAND.isInstalled()) {
       doUpgradeCheck = false;
-      myStagehand.install();
+      STAGEHAND.install();
     }
 
-    List<StagehandTuple> templates = myStagehand.getAvailableTemplates();
+    List<StagehandTuple> templates = STAGEHAND.getAvailableTemplates();
 
     // Make sure we're on a reasonably latest version of Stagehand.
     if (doUpgradeCheck) {
       new Thread() {
         @Override
         public void run() {
-          myStagehand.upgrade();
+          STAGEHAND.upgrade();
         }
       }.start();
     }
 
-    myTemplateCache = new ArrayList<DartEmptyProjectGenerator>();
+    ourTemplateCache = new ArrayList<DartEmptyProjectGenerator>();
 
     for (StagehandTuple template : templates) {
-      myTemplateCache.add(new StagehandTemplateGenerator(
-        myStagehand,
+      ourTemplateCache.add(new StagehandTemplateGenerator(
+        STAGEHAND,
         template.myId,
         template.myDescription,
         template.myEntrypoint));
     }
 
-    Collections.sort(myTemplateCache);
+    Collections.sort(ourTemplateCache);
 
-    return myTemplateCache;
+    return ourTemplateCache;
   }
 
 

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartWebAppGenerator.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartWebAppGenerator.java
@@ -7,7 +7,6 @@ import com.intellij.ide.browsers.impl.WebBrowserServiceImpl;
 import com.intellij.javascript.debugger.execution.JavaScriptDebugConfiguration;
 import com.intellij.javascript.debugger.execution.JavascriptDebugConfigurationType;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -35,7 +34,7 @@ public class DartWebAppGenerator extends DartEmptyProjectGenerator {
   }
 
   @NotNull
-  protected VirtualFile[] doGenerateProject(final Project project, final Module module, final VirtualFile baseDir) throws IOException {
+  protected VirtualFile[] doGenerateProject(@NotNull final Module module, final VirtualFile baseDir) throws IOException {
     final String projectTitle = StringUtil.toTitleCase(module.getName());
     final String lowercaseName = module.getName().toLowerCase(Locale.US);
 

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/Stagehand.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/Stagehand.java
@@ -2,14 +2,13 @@ package com.jetbrains.lang.dart.projectWizard;
 
 
 import com.intellij.execution.ExecutionException;
-import com.intellij.execution.Output;
-import com.intellij.execution.OutputListener;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.CapturingProcessHandler;
+import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
@@ -20,7 +19,6 @@ import org.json.JSONObject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 
 public class Stagehand {
@@ -57,18 +55,18 @@ public class Stagehand {
 
   private static final class PubRunner {
 
-    final CountDownLatch myLatch = new CountDownLatch(1);
-    private final File myWorkingDirectory;
+    private final String myWorkingDirectory;
 
     PubRunner() {
-      this(null);
+      myWorkingDirectory = null;
     }
 
-    PubRunner(final File workingDirectory) {
-      myWorkingDirectory = workingDirectory;
+    PubRunner(final VirtualFile workingDirectory) {
+      myWorkingDirectory = workingDirectory.getCanonicalPath();
     }
 
-    Output runSync(String... pubParameters) throws StagehandException {
+    ProcessOutput runSync(ProgressIndicator indicator, String... pubParameters) throws StagehandException {
+
       final GeneralCommandLine command = new GeneralCommandLine().withWorkDirectory(myWorkingDirectory);
       DartSdk sdk = DartSdk.getGlobalDartSdk();
       if (sdk == null) {
@@ -77,38 +75,28 @@ public class Stagehand {
       final File pubFile = new File(DartSdkUtil.getPubPath(sdk));
       command.setExePath(pubFile.getPath());
       command.addParameters(pubParameters);
-      final OSProcessHandler processHandler;
+
       try {
-        processHandler = new OSProcessHandler(command);
+        if (indicator != null) {
+          return new CapturingProcessHandler(command).runProcessWithProgressIndicator(indicator);
+        }
+        return new CapturingProcessHandler(command).runProcess();
       }
       catch (ExecutionException e) {
         throw new StagehandException(e);
       }
-      final OutputListener outputListener = new OutputListener();
-      processHandler.addProcessListener(outputListener);
-      processHandler.addProcessListener(new ProcessAdapter() {
-        @Override
-        public void processTerminated(final ProcessEvent event) {
-          myLatch.countDown();
-        }
-      });
 
-      processHandler.startNotify();
-
-      try {
-        myLatch.await();
-      }
-      catch (InterruptedException e) {
-        // Ignore
-      }
-
-      return outputListener.getOutput();
     }
+
+    ProcessOutput runSync(String... pubParameters) throws StagehandException {
+      return runSync(null, pubParameters);
+    }
+
   }
 
 
-  public void generateInto(File projectDirectory, String templateId) throws StagehandException {
-    final Output output = new PubRunner(projectDirectory).runSync("global", "run", "stagehand", templateId);
+  public void generateInto(VirtualFile projectDirectory, String templateId) throws StagehandException {
+    final ProcessOutput output = new PubRunner(projectDirectory).runSync("global", "run", "stagehand", templateId);
     if (output.getExitCode() != 0) {
       throw new StagehandException(output.getStderr());
     }
@@ -118,7 +106,7 @@ public class Stagehand {
   public List<StagehandTuple> getAvailableTemplates() {
 
     try {
-      final Output output = new PubRunner().runSync("global", "run", "stagehand", "--machine");
+      final ProcessOutput output = new PubRunner().runSync("global", "run", "stagehand", "--machine");
       int exitCode = output.getExitCode();
 
       if (exitCode != 0) {
@@ -141,10 +129,10 @@ public class Stagehand {
       return result;
     }
     catch (StagehandException e) {
-      LOG.error(e);
+      LOG.info(e);
     }
     catch (JSONException e) {
-      LOG.error(e);
+      LOG.info(e);
     }
 
     return EMPTY;
@@ -154,7 +142,7 @@ public class Stagehand {
   public boolean isInstalled() {
 
     try {
-      final Output output = new PubRunner().runSync("global", "list");
+      final ProcessOutput output = new PubRunner().runSync("global", "list");
       if (output.getExitCode() != 0) {
         return false;
       }
@@ -168,7 +156,7 @@ public class Stagehand {
     }
     catch (StagehandException e) {
       // Log and fall through
-      LOG.error(e);
+      LOG.info(e);
     }
 
     return false;
@@ -176,10 +164,11 @@ public class Stagehand {
 
   public void install() {
     try {
+      //TODO: pass in a progress indicator
       new PubRunner().runSync("global", "activate", "stagehand");
     }
     catch (StagehandException e) {
-      LOG.error(e);
+      LOG.info(e);
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/StagehandTemplateGenerator.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/StagehandTemplateGenerator.java
@@ -3,12 +3,10 @@ package com.jetbrains.lang.dart.projectWizard;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.projectWizard.Stagehand.StagehandException;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,14 +37,10 @@ public class StagehandTemplateGenerator extends DartEmptyProjectGenerator {
   }
 
   @NotNull
-  protected VirtualFile[] doGenerateProject(final Project project, final Module module, final VirtualFile baseDir) throws IOException {
+  protected VirtualFile[] doGenerateProject(@NotNull final Module module, final VirtualFile baseDir) throws IOException {
 
     try {
-      final String path = baseDir.getCanonicalPath();
-      if (path == null) {
-        throw new IOException(DartBundle.message("dart.pub.stagehand.exception.invalid.basedir.path"));
-      }
-      myStagehand.generateInto(new File(path), myId);
+      myStagehand.generateInto(baseDir, myId);
     }
     catch (StagehandException e) {
       throw new IOException(e);
@@ -54,10 +48,10 @@ public class StagehandTemplateGenerator extends DartEmptyProjectGenerator {
 
     List<VirtualFile> projectFiles = new ArrayList<VirtualFile>();
 
-    addIfExists(projectFiles, project, myEntrypoint);
-    addIfExists(projectFiles, project, PubspecYamlUtil.PUBSPEC_YAML);
+    addIfExists(projectFiles, module.getProject(), myEntrypoint);
+    addIfExists(projectFiles, module.getProject(), PubspecYamlUtil.PUBSPEC_YAML);
 
-    return projectFiles.toArray(VirtualFile.EMPTY_ARRAY);
+    return projectFiles.toArray(new VirtualFile[projectFiles.size()]);
   }
 
 


### PR DESCRIPTION
Defers to stagehand for template creation.  In case stagehand is not available (e.g., in the unlikely event the SDK is pre 1.6 and we can't run pub global activate) or an error occurs in querying it we fall back on pre-existing static templates.  The main entry point file and pubspec are opened post creation (like the other templates) and similarly, pub operations are run.

More context in associated issue here: https://youtrack.jetbrains.com/issue/WEB-13936
