### PR TITLE
Group node navigation fixes for DartUnit tests.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/unittest/DartTestLocationProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/unittest/DartTestLocationProvider.java
@@ -72,7 +72,7 @@ public class DartTestLocationProvider implements TestLocationProvider {
 
           if (element instanceof DartCallExpression) {
             DartCallExpression expression = (DartCallExpression)element;
-            if (DartUnitRunConfigurationProducer.isTest(expression)) {
+            if (DartUnitRunConfigurationProducer.isTest(expression) || DartUnitRunConfigurationProducer.isGroup(expression)) {
               if (nameMatches(expression, nodes[nodes.length - 1])) {
                 boolean matches = true;
                 for (int i = nodes.length - 2; i >= 0 && matches; --i) {

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/unittest/DartTestLocationProviderTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/unittest/DartTestLocationProviderTest.java
@@ -106,4 +106,13 @@ public class DartTestLocationProviderTest extends DartCodeInsightFixtureTestCase
                       "}");
   }
 
+
+  public void testGroup() throws Exception {
+    doTest("foo", "main() {\n" +
+                      "  <caret>group('foo', () {\n" +
+                      "    test('bar', () => expect(true, true));\n" +
+                      "  });\n" +
+                      "}");
+  }
+
 }


### PR DESCRIPTION
Follow up to fixes for jump to test source navigation (WEB-1588) to support navigation to test groups.

(Aside: Obviously this approach is far from ideal and I'm more and more incentivized to pushing on the unittest/testrunner rewrite to address this at the Dart library level.)
