### PR TITLE
Basic Dart template macros (className, methodName, methodParams).

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartClassNameMacro.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartClassNameMacro.java
@@ -1,0 +1,47 @@
+package com.jetbrains.lang.dart.ide.template.macro;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.intellij.codeInsight.template.Expression;
+import com.intellij.codeInsight.template.ExpressionContext;
+import com.intellij.codeInsight.template.Result;
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.codeInsight.template.TextResult;
+import com.intellij.codeInsight.template.macro.ClassNameMacro;
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.ide.template.DartTemplateContextType;
+import com.jetbrains.lang.dart.psi.DartClassDefinition;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import com.jetbrains.lang.dart.psi.DartComponentName;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DartClassNameMacro extends ClassNameMacro {
+
+  @Override
+  public Result calculateResult(@NotNull Expression[] params, final ExpressionContext context) {
+    final String containingFunctionName = getContainingClassName(context.getPsiElementAtStartOffset());
+    return containingFunctionName == null ? null : new TextResult(containingFunctionName);
+  }
+
+  @Override
+  public boolean isAcceptableInContext(final TemplateContextType context) {
+    return context instanceof DartTemplateContextType;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  public String getContainingClassName(final PsiElement element) {
+    if (element == null) return null;
+    final DartComponent parent = (DartComponent)PsiTreeUtil.findFirstParent(element, new Condition<PsiElement>() {
+      @Override
+      public boolean value(final PsiElement element) {
+        return element instanceof DartClassDefinition;
+      }
+    });
+    if (parent == null) return null;
+    final DartComponentName componentName = parent.getComponentName();
+    return componentName == null ? null : componentName.getName();
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartMethodNameMacro.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartMethodNameMacro.java
@@ -1,0 +1,51 @@
+package com.jetbrains.lang.dart.ide.template.macro;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.intellij.codeInsight.template.Expression;
+import com.intellij.codeInsight.template.ExpressionContext;
+import com.intellij.codeInsight.template.Result;
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.codeInsight.template.TextResult;
+import com.intellij.codeInsight.template.macro.MethodNameMacro;
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.ide.template.DartTemplateContextType;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import com.jetbrains.lang.dart.psi.DartComponentName;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBody;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DartMethodNameMacro extends MethodNameMacro {
+
+  @Override
+  public Result calculateResult(@NotNull Expression[] params, final ExpressionContext context) {
+    final String containingFunctionName = getContainingFunctionName(context.getPsiElementAtStartOffset());
+    return containingFunctionName == null ? null : new TextResult(containingFunctionName);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  public String getContainingFunctionName(@Nullable final PsiElement element) {
+    if (element == null) return null;
+    final DartComponent parent = (DartComponent)PsiTreeUtil.findFirstParent(element, new Condition<PsiElement>() {
+      @Override
+      public boolean value(final PsiElement element) {
+        return element instanceof DartFunctionDeclarationWithBodyOrNative || element instanceof DartFunctionDeclarationWithBody ||
+               element instanceof DartMethodDeclaration;
+      }
+    });
+    if (parent == null) return null;
+    final DartComponentName componentName = parent.getComponentName();
+    return componentName == null ? null : componentName.getName();
+  }
+
+  @Override
+  public boolean isAcceptableInContext(final TemplateContextType context) {
+    return context instanceof DartTemplateContextType;
+  }
+}
+

--- a/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartMethodParametersMacro.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartMethodParametersMacro.java
@@ -1,0 +1,102 @@
+package com.jetbrains.lang.dart.ide.template.macro;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.intellij.codeInsight.template.Expression;
+import com.intellij.codeInsight.template.ExpressionContext;
+import com.intellij.codeInsight.template.ListResult;
+import com.intellij.codeInsight.template.Result;
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.codeInsight.template.TextResult;
+import com.intellij.codeInsight.template.macro.MethodParametersMacro;
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.ide.template.DartTemplateContextType;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import com.jetbrains.lang.dart.psi.DartComponentName;
+import com.jetbrains.lang.dart.psi.DartDefaultFormalNamedParameter;
+import com.jetbrains.lang.dart.psi.DartFormalParameterList;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBody;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
+import com.jetbrains.lang.dart.psi.DartFunctionSignature;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
+import com.jetbrains.lang.dart.psi.DartNamedFormalParameters;
+import com.jetbrains.lang.dart.psi.DartNormalFormalParameter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class DartMethodParametersMacro extends MethodParametersMacro {
+
+  @Override
+  public Result calculateResult(@NotNull Expression[] params, final ExpressionContext context) {
+
+    final List<String> parameterNames = getContainingMethodParameterNames(context.getPsiElementAtStartOffset());
+    if (parameterNames == null) {
+      return null;
+    }
+
+
+    List<Result> result = Lists.newArrayList();
+    for (String name : parameterNames) {
+      result.add(new TextResult(name));
+    }
+
+    return new ListResult(result);
+  }
+
+  @Override
+  public boolean isAcceptableInContext(final TemplateContextType context) {
+    return context instanceof DartTemplateContextType;
+  }
+
+  @Nullable
+  @VisibleForTesting
+  public List<String> getContainingMethodParameterNames(@Nullable final PsiElement element) {
+    if (element == null) return null;
+
+    final DartComponent parent = (DartComponent)PsiTreeUtil.findFirstParent(element, new Condition<PsiElement>() {
+      @Override
+      public boolean value(final PsiElement element) {
+        return element instanceof DartFunctionDeclarationWithBodyOrNative || element instanceof DartFunctionDeclarationWithBody ||
+               element instanceof DartMethodDeclaration;
+      }
+    });
+    if (parent == null) return null;
+
+    final DartFormalParameterList parameterList = PsiTreeUtil.getChildOfType(parent, DartFormalParameterList.class);
+    if (parameterList == null) return null;
+
+    List<String> results = Lists.newArrayList();
+
+    final List<DartNormalFormalParameter> normalFormalParameters = parameterList.getNormalFormalParameterList();
+    for (DartNormalFormalParameter parameter : normalFormalParameters) {
+      final DartFunctionSignature signature = parameter.getFunctionSignature();
+      if (signature != null) {
+        final String name = signature.getName();
+        if (name != null) {
+          results.add(name);
+        }
+      }
+    }
+
+    final DartNamedFormalParameters namedFormalParameters = parameterList.getNamedFormalParameters();
+    if (namedFormalParameters != null) {
+      for (DartDefaultFormalNamedParameter parameter : namedFormalParameters.getDefaultFormalNamedParameterList()) {
+        final DartComponentName componentName = parameter.getNormalFormalParameter().findComponentName();
+        if (componentName != null) {
+          final String name = componentName.getName();
+          if (name != null) {
+            results.add(name);
+          }
+        }
+      }
+      
+    }
+
+    return results;
+  }
+
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartMethodParametersMacro.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/template/macro/DartMethodParametersMacro.java
@@ -2,27 +2,13 @@ package com.jetbrains.lang.dart.ide.template.macro;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.intellij.codeInsight.template.Expression;
-import com.intellij.codeInsight.template.ExpressionContext;
-import com.intellij.codeInsight.template.ListResult;
-import com.intellij.codeInsight.template.Result;
-import com.intellij.codeInsight.template.TemplateContextType;
-import com.intellij.codeInsight.template.TextResult;
+import com.intellij.codeInsight.template.*;
 import com.intellij.codeInsight.template.macro.MethodParametersMacro;
 import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.ide.template.DartTemplateContextType;
-import com.jetbrains.lang.dart.psi.DartComponent;
-import com.jetbrains.lang.dart.psi.DartComponentName;
-import com.jetbrains.lang.dart.psi.DartDefaultFormalNamedParameter;
-import com.jetbrains.lang.dart.psi.DartFormalParameterList;
-import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBody;
-import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
-import com.jetbrains.lang.dart.psi.DartFunctionSignature;
-import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
-import com.jetbrains.lang.dart.psi.DartNamedFormalParameters;
-import com.jetbrains.lang.dart.psi.DartNormalFormalParameter;
+import com.jetbrains.lang.dart.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,12 +24,10 @@ public class DartMethodParametersMacro extends MethodParametersMacro {
       return null;
     }
 
-
     List<Result> result = Lists.newArrayList();
     for (String name : parameterNames) {
       result.add(new TextResult(name));
     }
-
     return new ListResult(result);
   }
 
@@ -71,32 +55,28 @@ public class DartMethodParametersMacro extends MethodParametersMacro {
 
     List<String> results = Lists.newArrayList();
 
-    final List<DartNormalFormalParameter> normalFormalParameters = parameterList.getNormalFormalParameterList();
-    for (DartNormalFormalParameter parameter : normalFormalParameters) {
-      final DartFunctionSignature signature = parameter.getFunctionSignature();
-      if (signature != null) {
-        final String name = signature.getName();
-        if (name != null) {
-          results.add(name);
-        }
-      }
+    for (DartNormalFormalParameter parameter : parameterList.getNormalFormalParameterList()) {
+      findAndAddName(results, parameter);
     }
 
     final DartNamedFormalParameters namedFormalParameters = parameterList.getNamedFormalParameters();
     if (namedFormalParameters != null) {
       for (DartDefaultFormalNamedParameter parameter : namedFormalParameters.getDefaultFormalNamedParameterList()) {
-        final DartComponentName componentName = parameter.getNormalFormalParameter().findComponentName();
-        if (componentName != null) {
-          final String name = componentName.getName();
-          if (name != null) {
-            results.add(name);
-          }
-        }
+        findAndAddName(results, parameter.getNormalFormalParameter());
       }
-      
     }
 
     return results;
+  }
+
+  private static void findAndAddName(@NotNull final List<String> results, @NotNull final DartNormalFormalParameter parameter) {
+    final DartComponentName componentName = parameter.findComponentName();
+    if (componentName != null) {
+      final String name = componentName.getName();
+      if (name != null) {
+        results.add(name);
+      }
+    }
   }
 
 }

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/DartTemplateMacrosTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/DartTemplateMacrosTest.java
@@ -1,0 +1,89 @@
+package com.jetbrains.lang.dart.ide;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
+import com.jetbrains.lang.dart.ide.template.macro.DartClassNameMacro;
+import com.jetbrains.lang.dart.ide.template.macro.DartMethodNameMacro;
+import com.jetbrains.lang.dart.ide.template.macro.DartMethodParametersMacro;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DartTemplateMacrosTest extends DartCodeInsightFixtureTestCase {
+
+  @NotNull
+  private PsiElement findElementAtCaret(@NotNull final String source) {
+    final int caretOffset = source.indexOf("<caret>");
+    assertTrue(caretOffset != -1);
+    final String contents = source.substring(0, caretOffset) + source.substring(caretOffset + "<caret>".length());
+    final PsiFile psiFile = myFixture.addFileToProject("test.dart", contents);
+    final PsiElement psiElement = psiFile.findElementAt(caretOffset);
+    assertNotNull(psiElement);
+    return psiElement;
+  }
+
+  private void assertContainingClassNameEquals(final String className, final String source) {
+    assertEquals(className, new DartClassNameMacro().getContainingClassName(findElementAtCaret(source)));
+  }
+
+  private void assertContainingFunctionNameEquals(final String functionName, final String source) {
+    assertEquals(functionName, new DartMethodNameMacro().getContainingFunctionName(findElementAtCaret(source)));
+  }
+
+  private void assertContainingFunctionParameterNamesEqual(final String [] params, final String source) {
+    final List<String> parameterNames = new DartMethodParametersMacro().getContainingMethodParameterNames(findElementAtCaret(source));
+    if (params == null) {
+      assertNull(parameterNames);
+      return;
+    }
+    assertNotNull(parameterNames);
+    assertContainsElements(Arrays.asList(params), parameterNames);
+  }
+
+  public void testClassNameMacro0() {
+    assertContainingClassNameEquals(null,  "f() { <caret> }");
+  }
+
+  public void testClassNameMacro1() {
+    assertContainingClassNameEquals("A",  "class A { f() { <caret> } }");
+  }
+
+  public void testMethodNameMacro0() {
+    assertContainingFunctionNameEquals(null, "class A { <caret> }");
+  }
+
+  public void testMethodNameMacro1() {
+    assertContainingFunctionNameEquals("f", "f() { <caret> }");
+  }
+
+  public void testMethodNameMacro2() {
+    assertContainingFunctionNameEquals("f", "class A { f() { <caret> } }");
+  }
+
+  public void testMethodNameMacro3() {
+    assertContainingFunctionNameEquals("g", "g(f()) => g(() => <caret> null);");
+  }
+
+  public void testMethodParametersMacro0() {
+    assertContainingFunctionParameterNamesEqual(null, "class A { <caret> }");
+  }
+
+  public void testMethodParametersMacro1() {
+    assertContainingFunctionParameterNamesEqual(new String[]{"a", "b"}, "f(a, b) { <caret> }");
+  }
+
+  public void testMethodParametersMacro2() {
+    assertContainingFunctionParameterNamesEqual(new String[]{"a", "b"}, "f(a, {b}) { <caret> }");
+  }
+
+  public void testMethodParametersMacro3() {
+    assertContainingFunctionParameterNamesEqual(new String[]{"a", "b"}, "f(a, [b]) { <caret> }");
+  }
+
+  public void testMethodParametersMacro4() {
+    assertContainingFunctionParameterNamesEqual(new String[]{}, "f() { <caret> }");
+  }
+
+}


### PR DESCRIPTION
Basic macro building blocks for live templates (https://youtrack.jetbrains.com/issue/WEB-14603).

For example, with these in place, the following could be used to print method params:

`groovyScript("'\"' + _1.collect { it + ' = [\" + ' + it + ' + \"]'}.join(', ') + '\"'", methodParameters())`

Printing method name and class name are equally easy.

