### PR TITLE
IDEA-134890: added support for hook annotations

### DIFF
--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaAllFeaturesInFolderRunConfigurationProducer.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaAllFeaturesInFolderRunConfigurationProducer.java
@@ -19,13 +19,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * User: avokin
- * Date: 10/12/12
+ * @author Andrey.Vokin
+ * @author Sebastian Gr&ouml;bler
+ * @since 10/12/12
  */
 public class CucumberJavaAllFeaturesInFolderRunConfigurationProducer extends CucumberJavaRunConfigurationProducer {
   @Override
   protected NullableComputable<String> getGlue(@NotNull final PsiElement element) {
-    final Set<String> glues = new HashSet<String>();
+    final Set<String> hookGlue = getHookGlue(element);
+    final Set<String> glues = new HashSet<String>(hookGlue);
     if (element instanceof PsiDirectory) {
       final PsiDirectory dir = (PsiDirectory)element;
       final CucumberJvmExtensionPoint[] extensions = Extensions.getExtensions(CucumberJvmExtensionPoint.EP_NAME);

--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaFeatureRunConfigurationProducer.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaFeatureRunConfigurationProducer.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 /**
  * @author Andrey.Vokin
+ * @author Sebastian Gr&ouml;bler
  * @since 8/6/12
  */
 public class CucumberJavaFeatureRunConfigurationProducer extends CucumberJavaRunConfigurationProducer {
@@ -34,9 +35,10 @@ public class CucumberJavaFeatureRunConfigurationProducer extends CucumberJavaRun
         public String compute() {
           final Set<String> glues = new LinkedHashSet<String>();
 
+          final Set<String> hookGlue = getHookGlue(element);
           final CucumberJvmExtensionPoint[] extensions = Extensions.getExtensions(CucumberJvmExtensionPoint.EP_NAME);
           for (CucumberJvmExtensionPoint extension : extensions) {
-            glues.addAll(extension.getGlues((GherkinFile)file, null));
+            glues.addAll(extension.getGlues((GherkinFile) file, hookGlue));
           }
 
           return StringUtil.join(glues, " ");

--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaRunConfigurationProducer.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaRunConfigurationProducer.java
@@ -1,5 +1,8 @@
 package org.jetbrains.plugins.cucumber.java.run;
 
+import java.util.Collection;
+import java.util.Set;
+
 import com.intellij.execution.JavaExecutionUtil;
 import com.intellij.execution.JavaRunConfigurationExtensionManager;
 import com.intellij.execution.Location;
@@ -14,16 +17,25 @@ import com.intellij.openapi.util.NullableComputable;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiDirectory;
-import com.intellij.psi.PsiElement;
+import com.intellij.psi.*;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.searches.AnnotatedElementsSearch;
+import com.intellij.util.Query;
+import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Andrey.Vokin
+ * @author Sebastian Gr&ouml;bler
  * @since 8/6/12
  */
 public abstract class CucumberJavaRunConfigurationProducer extends JavaRunConfigurationProducerBase<CucumberJavaRunConfiguration> implements Cloneable {
+
+  public static final Set<String> HOOK_ANNOTATION_NAMES = ContainerUtil.newHashSet("cucumber.annotation.Before",
+                                                                                   "cucumber.annotation.After",
+                                                                                   "cucumber.api.java.Before",
+                                                                                   "cucumber.api.java.After");
   public static final String FORMATTER_OPTIONS = " --format org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter --monochrome";
   public static final String CUCUMBER_1_0_MAIN_CLASS = "cucumber.cli.Main";
   public static final String CUCUMBER_1_1_MAIN_CLASS = "cucumber.api.cli.Main";
@@ -127,5 +139,34 @@ public abstract class CucumberJavaRunConfigurationProducer extends JavaRunConfig
     }
 
     return true;
+  }
+
+  protected Set<String> getHookGlue(final PsiElement element) {
+
+    final JavaPsiFacade javaPsiFacade = JavaPsiFacade.getInstance(element.getProject());
+    final Set<String> packages = ContainerUtil.newLinkedHashSet();
+    for (final String fullyQualifiedAnnotationName : HOOK_ANNOTATION_NAMES) {
+      final PsiClass psiClass = javaPsiFacade.findClass(fullyQualifiedAnnotationName, GlobalSearchScope.allScope(element.getProject()));
+
+      if (psiClass != null) {
+        final Query<PsiMethod> psiMethods = AnnotatedElementsSearch.searchPsiMethods(psiClass, GlobalSearchScope.allScope(element.getProject()));
+        final Collection<PsiMethod> methods = psiMethods.findAll();
+        addPackagesOfMethods(methods, packages);
+      }
+    }
+
+    return packages;
+  }
+
+  private Set<String> addPackagesOfMethods(final Collection<PsiMethod> psiMethods, final Set<String> packages) {
+
+    for (final PsiMethod psiMethod : psiMethods) {
+      final PsiClassOwner file = (PsiClassOwner) psiMethod.getContainingFile();
+      final String packageName = file.getPackageName();
+      if (StringUtil.isNotEmpty(packageName)) {
+        packages.add(packageName);
+      }
+    }
+    return packages;
   }
 }


### PR DESCRIPTION
ticket: https://youtrack.jetbrains.com/issue/IDEA-134890

this pull request adds support for cucumber hooks (```@Before```, ```@After```) for cucumber version 1.0.x, to 1.2.x. previously hooks defined in separate files outside of the step package weren't recognized by the logic which creates run configurations. now hooks are supported for running a single scenario, a single feature and multiple features.

I am not so much familiar with writing idea plugins. Actually it was pretty tough just to get everything up and running, so I could debug properly. I am unsure how to test my changes programmatically, so if anyone could help out I would be quite thankful.