### PR TITLE
Replacement for in-process inspection in the Dart plugin

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -165,6 +165,8 @@
     <editorNotificationProvider implementation="com.jetbrains.lang.dart.ide.actions.DartEditorNotificationsProvider"/>
     <codeInspection.InspectionExtension id="dartGlobalInspection"
                                         implementation="com.jetbrains.lang.dart.ide.inspections.analyzer.DartInspectionExtensionsFactory"/>
+    <!--<codeInspection.InspectionExtension id="dartGlobalInspection"-->
+                                        <!--implementation="com.jetbrains.lang.dart.ide.inspections.analyzer.DartAnalysisServerInspectionExtensionsFactory"/>-->
 
     <consoleFilterProvider implementation="com.jetbrains.lang.dart.ide.runner.DartConsoleFilterProvider" order="first"/>
 
@@ -187,6 +189,13 @@
                       enabledByDefault="true"
                       level="WARNING"
                       implementationClass="com.jetbrains.lang.dart.ide.inspections.analyzer.DartGlobalInspectionTool"/>
+    <!--<globalInspection shortName="DartAnalysisServerGlobalInspectionTool"-->
+                      <!--bundle="com.jetbrains.lang.dart.DartBundle"-->
+                      <!--key="dart.analyzer.inspection.display.name"-->
+                      <!--groupName="Dart"-->
+                      <!--enabledByDefault="true"-->
+                      <!--level="WARNING"-->
+                      <!--implementationClass="com.jetbrains.lang.dart.ide.inspections.analyzer.DartAnalysisServerGlobalInspectionTool"/>-->
 
     <localInspection bundle="com.jetbrains.lang.dart.DartBundle" key="dart.sdk.is.not.configured"
                      groupName="Dart" enabledByDefault="true" level="WARNING"

--- a/Dart/resources/inspectionDescriptions/DartAnalysisServerGlobalInspectionTool.html
+++ b/Dart/resources/inspectionDescriptions/DartAnalysisServerGlobalInspectionTool.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Standard Dart analyzer
+</body>
+</html>

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerAnnotator.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerAnnotator.java
@@ -5,7 +5,6 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.ExternalAnnotator;
-import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
@@ -31,7 +30,7 @@ import java.util.Map;
 public class DartAnalysisServerAnnotator
   extends ExternalAnnotator<DartAnalysisServerAnnotator.AnnotatorInfo, DartAnalysisServerAnnotator.ServerResult> {
 
-  static class AnnotatorInfo {
+  public static class AnnotatorInfo {
     @NotNull public final Project myProject;
     @NotNull public final String myFilePath;
 
@@ -57,9 +56,7 @@ public class DartAnalysisServerAnnotator
 
   @Nullable
   @Override
-  public AnnotatorInfo collectInformation(@NotNull final PsiFile psiFile, @NotNull final Editor editor, final boolean hasErrors) {
-    if (hasErrors) return null;
-
+  public AnnotatorInfo collectInformation(@NotNull final PsiFile psiFile) {
     if (psiFile instanceof DartExpressionCodeFragment) return null;
 
     final VirtualFile annotatedFile = DartResolveUtil.getRealVirtualFile(psiFile);
@@ -84,8 +81,8 @@ public class DartAnalysisServerAnnotator
     return new AnnotatorInfo(psiFile.getProject(), annotatedFile.getPath());
   }
 
-  @Override
   @Nullable
+  @Override
   public ServerResult doAnnotate(@NotNull final AnnotatorInfo info) {
     final AnalysisError[] errors = DartAnalysisServerService.getInstance().analysis_getErrors(info);
     if (errors == null || errors.length == 0) return null;
@@ -123,7 +120,7 @@ public class DartAnalysisServerAnnotator
     }
   }
 
-  private static boolean shouldIgnoreMessageFromDartAnalyzer(@NotNull final AnalysisError error) {
+  public static boolean shouldIgnoreMessageFromDartAnalyzer(@NotNull final AnalysisError error) {
     final String errorType = error.getType();
     // already done using IDE engine
     if (AnalysisErrorType.TODO.equals(errorType)) return true;

--- a/Dart/src/com/jetbrains/lang/dart/ide/inspections/analyzer/DartAnalysisServerGlobalInspectionContext.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/inspections/analyzer/DartAnalysisServerGlobalInspectionContext.java
@@ -1,0 +1,103 @@
+package com.jetbrains.lang.dart.ide.inspections.analyzer;
+
+import com.google.dart.server.generated.types.AnalysisError;
+import com.intellij.analysis.AnalysisScope;
+import com.intellij.codeInspection.GlobalInspectionContext;
+import com.intellij.codeInspection.ex.InspectionToolWrapper;
+import com.intellij.codeInspection.ex.Tools;
+import com.intellij.codeInspection.lang.GlobalInspectionContextExtension;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.util.ProgressWrapper;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.NullableComputable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerAnnotator;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import gnu.trove.THashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class DartAnalysisServerGlobalInspectionContext
+  implements GlobalInspectionContextExtension<DartAnalysisServerGlobalInspectionContext> {
+
+  static final Key<DartAnalysisServerGlobalInspectionContext> KEY = Key.create("DartAnalysisServerGlobalInspectionContext");
+
+  @NotNull private final Map<VirtualFile, AnalysisError[]> myVirtualFile2ErrorsMap = new THashMap<VirtualFile, AnalysisError[]>();
+
+  public Map<VirtualFile, AnalysisError[]> getVirtualFile2ErrorsMap() {
+    return myVirtualFile2ErrorsMap;
+  }
+
+  @NotNull
+  @Override
+  public Key<DartAnalysisServerGlobalInspectionContext> getID() {
+    return KEY;
+  }
+
+  @Override
+  public void performPreRunActivities(@NotNull final List<Tools> globalTools,
+                                      @NotNull final List<Tools> localTools,
+                                      @NotNull final GlobalInspectionContext context) {
+    final AnalysisScope analysisScope = context.getRefManager().getScope();
+    if (analysisScope == null) return;
+
+    final GlobalSearchScope scope = GlobalSearchScope.EMPTY_SCOPE.union(analysisScope.toSearchScope());
+    setIndicatorText("Looking for Dart files...");
+    final Collection<VirtualFile> dartFiles = FileTypeIndex.getFiles(DartFileType.INSTANCE, scope);
+
+    for (final VirtualFile dartFile : dartFiles) {
+      analyzeFile(dartFile, context.getProject());
+    }
+  }
+
+  private void analyzeFile(@NotNull final VirtualFile virtualFile, @NotNull final Project project) {
+    final DartAnalysisServerAnnotator annotator = new DartAnalysisServerAnnotator();
+
+    final DartAnalysisServerAnnotator.AnnotatorInfo annotatorInfo =
+      ApplicationManager.getApplication().runReadAction(new NullableComputable<DartAnalysisServerAnnotator.AnnotatorInfo>() {
+        @Nullable
+        public DartAnalysisServerAnnotator.AnnotatorInfo compute() {
+          final PsiFile psiFile = PsiManager.getInstance(project).findFile(virtualFile);
+          if (psiFile == null) return null;
+          return annotator.collectInformation(psiFile);
+        }
+      });
+    if (annotatorInfo == null) return;
+
+    setIndicatorText("Analyzing " + virtualFile.getName() + "...");
+
+    final AnalysisError[] errors = DartAnalysisServerService.getInstance().analysis_getErrors(annotatorInfo);
+    if (errors == null || errors.length == 0) return;
+
+    myVirtualFile2ErrorsMap.put(virtualFile, errors);
+  }
+
+  private static void setIndicatorText(@NotNull String text) {
+    final ProgressIndicator indicator = ProgressManager.getInstance().getProgressIndicator();
+    if (indicator != null) {
+      ProgressWrapper.unwrap(indicator).setText(text);
+    }
+  }
+
+  @Override
+  public void performPostRunActivities(@NotNull final List<InspectionToolWrapper> inspections,
+                                       @NotNull final GlobalInspectionContext context) {
+  }
+
+  @Override
+  public void cleanup() {
+    myVirtualFile2ErrorsMap.clear();
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/inspections/analyzer/DartAnalysisServerGlobalInspectionTool.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/inspections/analyzer/DartAnalysisServerGlobalInspectionTool.java
@@ -1,0 +1,119 @@
+package com.jetbrains.lang.dart.ide.inspections.analyzer;
+
+import com.google.dart.server.generated.types.AnalysisError;
+import com.google.dart.server.generated.types.AnalysisErrorSeverity;
+import com.google.dart.server.generated.types.Location;
+import com.intellij.analysis.AnalysisScope;
+import com.intellij.codeInspection.*;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerAnnotator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public class DartAnalysisServerGlobalInspectionTool extends GlobalInspectionTool {
+  @Override
+  public void runInspection(@NotNull AnalysisScope scope,
+                            @NotNull final InspectionManager manager,
+                            @NotNull final GlobalInspectionContext globalContext,
+                            @NotNull final ProblemDescriptionsProcessor problemDescriptionsProcessor) {
+    final DartAnalysisServerGlobalInspectionContext inspectionContext =
+      globalContext.getExtension(DartAnalysisServerGlobalInspectionContext.KEY);
+    if (inspectionContext == null) return;
+
+    ApplicationManager.getApplication().runReadAction(new Runnable() {
+      @Override
+      public void run() {
+        for (Map.Entry<VirtualFile, AnalysisError[]> entry : inspectionContext.getVirtualFile2ErrorsMap().entrySet()) {
+          final VirtualFile file = entry.getKey();
+          final AnalysisError[] analysisErrors = entry.getValue();
+          for (AnalysisError analysisError : analysisErrors) {
+            processMessage(file, analysisError, globalContext, manager, problemDescriptionsProcessor);
+          }
+        }
+      }
+    });
+  }
+
+  @Override
+  public boolean isGraphNeeded() {
+    return false;
+  }
+
+  protected void processMessage(final @NotNull VirtualFile file,
+                                final @NotNull AnalysisError analysisError,
+                                final @NotNull GlobalInspectionContext globalContext,
+                                final @NotNull InspectionManager manager,
+                                final @NotNull ProblemDescriptionsProcessor problemDescriptionsProcessor) {
+    if (DartAnalysisServerAnnotator.shouldIgnoreMessageFromDartAnalyzer(analysisError)) return;
+
+    final PsiFile psiFile = PsiManager.getInstance(globalContext.getProject()).findFile(file);
+    if (psiFile == null) return;
+
+    final ProblemDescriptor descriptor = computeProblemDescriptor(manager, psiFile, analysisError);
+    problemDescriptionsProcessor.addProblemElement(globalContext.getRefManager().getReference(psiFile), descriptor);
+  }
+
+  @NotNull
+  private static ProblemDescriptor computeProblemDescriptor(final @NotNull InspectionManager manager,
+                                                            final @NotNull PsiFile psiFile,
+                                                            final @NotNull AnalysisError analysisError) {
+    final Location location = analysisError.getLocation();
+    final int startOffset = location.getOffset();
+    final TextRange textRange = new TextRange(startOffset, startOffset + location.getLength());
+    PsiElement element = psiFile.findElementAt(startOffset + (location.getLength() / 2));
+    while (element != null && textRange.getStartOffset() < element.getTextOffset()) {
+      element = element.getParent();
+    }
+
+    if (element != null && textRange.equals(element.getTextRange())) {
+      return computeProblemDescriptor(manager, analysisError, element);
+    }
+    return computeProblemDescriptor(manager, analysisError, psiFile, textRange);
+  }
+
+  @NotNull
+  private static ProblemDescriptor computeProblemDescriptor(final @NotNull InspectionManager manager,
+                                                            final @NotNull AnalysisError analysisError,
+                                                            final @NotNull PsiElement element) {
+    return manager
+      .createProblemDescriptor(element, analysisError.getMessage(), (LocalQuickFix)null,
+                               convertHighlightingType(analysisError.getSeverity()), true);
+  }
+
+  @NotNull
+  private static ProblemDescriptor computeProblemDescriptor(final @NotNull InspectionManager manager,
+                                                            final @NotNull AnalysisError analysisError,
+                                                            final @NotNull PsiFile psiFile,
+                                                            final @NotNull TextRange range) {
+    return manager.createProblemDescriptor(
+      psiFile,
+      range,
+      analysisError.getMessage(),
+      convertHighlightingType(analysisError.getSeverity()),
+      true
+    );
+  }
+
+  @NotNull
+  private static ProblemHighlightType convertHighlightingType(@Nullable String severity) {
+    if (AnalysisErrorSeverity.INFO.equals(severity)) {
+      return ProblemHighlightType.WEAK_WARNING;
+    }
+    else if (AnalysisErrorSeverity.WARNING.equals(severity)) {
+      return ProblemHighlightType.GENERIC_ERROR_OR_WARNING;
+    }
+    else if (AnalysisErrorSeverity.ERROR.equals(severity)) {
+      return ProblemHighlightType.ERROR;
+    }
+    else {
+      return ProblemHighlightType.INFORMATION;
+    }
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/inspections/analyzer/DartAnalysisServerInspectionExtensionsFactory.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/inspections/analyzer/DartAnalysisServerInspectionExtensionsFactory.java
@@ -1,0 +1,43 @@
+package com.jetbrains.lang.dart.ide.inspections.analyzer;
+
+import com.intellij.codeInspection.HTMLComposer;
+import com.intellij.codeInspection.lang.GlobalInspectionContextExtension;
+import com.intellij.codeInspection.lang.HTMLComposerExtension;
+import com.intellij.codeInspection.lang.InspectionExtensionsFactory;
+import com.intellij.codeInspection.lang.RefManagerExtension;
+import com.intellij.codeInspection.reference.RefManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+public class DartAnalysisServerInspectionExtensionsFactory extends InspectionExtensionsFactory {
+  @Override
+  public GlobalInspectionContextExtension createGlobalInspectionContextExtension() {
+    return new DartAnalysisServerGlobalInspectionContext();
+  }
+
+  @Override
+  public RefManagerExtension createRefManagerExtension(RefManager refManager) {
+    return null;
+  }
+
+  @Override
+  public HTMLComposerExtension createHTMLComposerExtension(HTMLComposer composer) {
+    return null;
+  }
+
+  @Override
+  public boolean isToCheckMember(@NotNull PsiElement element, @NotNull String id) {
+    return true;
+  }
+
+  @Override
+  public String getSuppressedInspectionIdsIn(@NotNull PsiElement element) {
+    return null;
+  }
+
+  @Override
+  public boolean isProjectConfiguredToRunInspections(@NotNull Project project, boolean online) {
+    return true;
+  }
+}


### PR DESCRIPTION
Replacement for in-process inspection in the Dart plugin with the same utility from the Dart analysis server, the change will be transparent to users.