### PR TITLE
Replaced the deprecated format options with --plugin, which is the way t...

### DIFF
--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaRunConfigurationProducer.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaRunConfigurationProducer.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
  * @since 8/6/12
  */
 public abstract class CucumberJavaRunConfigurationProducer extends JavaRunConfigurationProducerBase<CucumberJavaRunConfiguration> implements Cloneable {
-  public static final String FORMATTER_OPTIONS = " --format org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter --monochrome";
+  public static final String FORMATTER_OPTIONS = " --plugin pretty";
   public static final String CUCUMBER_1_0_MAIN_CLASS = "cucumber.cli.Main";
   public static final String CUCUMBER_1_1_MAIN_CLASS = "cucumber.api.cli.Main";
 


### PR DESCRIPTION
The old --format configuration for Cucumber is deprecated a long time ago. We should change this plugin to use --plugin instead. I have used pretty here since that looks the best. You might want to consider keeping --monochrome as the default since it is only IntelliJ IDEA 14.x that supports colors. That needs to be tested. 

The optimal solution would be if this plugin could be configured in preferences ("Select output format", "Enable color output").

It is possible to override the program arguments manually for every run, but that is not a good solution. 

So, I hope you will consider fixing this.

NB! I haven't run the tests, since I'm not sure how that is done for a plugin.
