### PR TITLE
Remove calls to the deprecated StringUtil.stripQuotesAroundValue in the Dart plugin

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/frame/DartValue.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/frame/DartValue.java
@@ -56,7 +56,7 @@ public class DartValue extends XNamedValue {
       presentation = new XRegularValuePresentation("null", null);
     }
     else if (myVmValue.isString()) {
-      presentation = new XStringValuePresentation(StringUtil.stripQuotesAroundValue(value));
+      presentation = new XStringValuePresentation(StringUtil.unquoteString(value));
     }
     else if (myVmValue.isNumber()) {
       presentation = new XNumericValuePresentation(value);
@@ -98,7 +98,7 @@ public class DartValue extends XNamedValue {
             return; // stay with existing presentation returned in computePresentation()
           }
 
-          final String text = StringUtil.stripQuotesAroundValue(result.getResult().getText());
+          final String text = StringUtil.unquoteString(result.getResult().getText());
           if (text.startsWith("IntelliJ marker:")) {
             try {
               final int collectionSize = Integer.parseInt(text.substring("IntelliJ marker:".length()));
@@ -144,7 +144,7 @@ public class DartValue extends XNamedValue {
           if (node.isObsolete()) return;
 
           if (!result.isError() && result.getResult() != null && "string".equals(result.getResult().getKind())) {
-            final String text = StringUtil.stripQuotesAroundValue(result.getResult().getText());
+            final String text = StringUtil.unquoteString(result.getResult().getText());
             if ("Map".equals(text)) {
               computeMapChildren(node);
               return;

--- a/Dart/src/com/jetbrains/lang/dart/psi/PubspecYamlReferenceContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/PubspecYamlReferenceContributor.java
@@ -60,7 +60,7 @@ public class PubspecYamlReferenceContributor extends PsiReferenceContributor {
       final boolean quoted = StringUtil.isQuotedString(text);
       final int startInElement = value.getStartOffsetInParent() + (quoted ? 1 : 0);
 
-      final FileReferenceSet fileReferenceSet = new FileReferenceSet(StringUtil.stripQuotesAroundValue(text), element, startInElement,
+      final FileReferenceSet fileReferenceSet = new FileReferenceSet(StringUtil.unquoteString(text), element, startInElement,
                                                                      this, SystemInfo.isFileSystemCaseSensitive, false) {
         @NotNull
         @Override


### PR DESCRIPTION
Remove calls to the deprecated StringUtil.stripQuotesAroundValue in the Dart plugin