### PR TITLE
Dart documentation arrow rendering OS special-casing (WEB-14847).

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/util/DartPresentableUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartPresentableUtil.java
@@ -2,6 +2,7 @@ package com.jetbrains.lang.dart.util;
 
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.template.*;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartTokenTypes;
@@ -17,7 +18,7 @@ import java.util.Set;
 
 public class DartPresentableUtil {
 
-  @NonNls public static final String RIGHT_ARROW = "\u2192";
+  @NonNls public static final String RIGHT_ARROW = SystemInfo.isMac ? "\u2192" : "->";
   @NonNls private static final String SPACE = " ";
 
   public static String setterGetterName(String name) {


### PR DESCRIPTION
A workaround for non-Mac OSes.  I haven't been able to fully verify that this works  (I can't change Java versions or have access to a non-Mac machine ATM) but I'm working on a hunch.   It would be great if this could be smoke tested on merge.  If not, let's just play it safe and make the change read instead like this:

`@NonNls public static final String RIGHT_ARROW = "->";`