### PR TITLE
WEB-15350 completion popup show private variables

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartReferenceCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartReferenceCompletionContributor.java
@@ -36,8 +36,12 @@ public class DartReferenceCompletionContributor extends CompletionContributor {
                final DartReference reference = PsiTreeUtil.getParentOfType(parameters.getPosition(), DartReference.class);
                if (reference != null) {
                  final THashSet<DartComponentName> variants = new THashSet<DartComponentName>();
+                 final boolean lookingForPrivate =  parameters.getPosition().getText().startsWith("_");
                  for (LookupElement element : DartReferenceCompletionContributor.addCompletionVariants(reference, variants)) {
-                   result.addElement(element);
+                   //only add private variables to the list if looking for it
+                   if (!element.toString().startsWith("_") || lookingForPrivate) {
+                     result.addElement(element);
+                   }
                  }
                  if (parameters.getInvocationCount() > 1 && DartResolveUtil.aloneOrFirstInChain(reference)) {
                    DartGlobalVariantsCompletionHelper.addAdditionalGlobalVariants(result, reference, variants, null);

--- a/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
@@ -299,6 +299,12 @@ public class DartResolveUtil {
       }
     }
 
+    //if looking for private variables, don't search for variables in imported libraries
+    //only look for variables that are part of the library
+    if (context.getText().startsWith("_")){
+      return true;
+    }
+
     for (String partUrl : DartPathIndex.getPaths(context.getProject(), virtualFile)) {
       if (fileNames != null && !fileNames.contains(PathUtil.getFileName(partUrl))) {
         continue;


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/WEB-15350

I've tried to fix it like this. I only show private variables if the user begins his search with `_`. See DartReferenceCompletionContributor.java.

And if the user does indeed begins his search with `_`, I try to make sure only variables that are part of the library are shown. See DartResolveUtil.java