### PR TITLE
Dart Analysis Server usage bug fix- priority files can only be set on files in the analysis roots

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerAnnotator.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerAnnotator.java
@@ -91,6 +91,8 @@ public class DartAnalysisServerAnnotator
 
     if (!DartAnalysisServerService.getInstance().serverReadyForRequest(module.getProject(), sdk)) return null;
 
+    DartAnalysisServerService.getInstance().virtualFileOpened(annotatedFile);
+
     DartAnalysisServerService.getInstance().updateFilesContent();
 
     return new AnnotatorInfo(psiFile.getProject(), annotatedFile.getPath());


### PR DESCRIPTION
By adding files only called via the annotator, and by always removing them, if added, when the a file is closed, the correct set of priority files will always be in sync with the Dart Analysis Server.
