### PR TITLE
Minor improvement to cascade formatting

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -120,7 +120,13 @@ public class DartIndentProcessor {
       return Indent.getNormalIndent();
     }
     if (prevSiblingType != DOT && elementType == DOT && parentType == CASCADE_REFERENCE_EXPRESSION) {
-      return Indent.getNormalIndent();
+      if (node.getTreeNext() != null && node.getTreeNext().getElementType() == DOT) {
+        return Indent.getContinuationIndent();
+      }
+    }
+    if (prevSiblingType == DOT && elementType == REFERENCE_EXPRESSION && parentType == CASCADE_REFERENCE_EXPRESSION) {
+      // This makes DartTypingTest.testCascadeAlignAfterReturn2() succeed.
+      return Indent.getContinuationIndent();
     }
     return Indent.getNoneIndent();
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -121,12 +121,12 @@ public class DartIndentProcessor {
     }
     if (prevSiblingType != DOT && elementType == DOT && parentType == CASCADE_REFERENCE_EXPRESSION) {
       if (node.getTreeNext() != null && node.getTreeNext().getElementType() == DOT) {
-        return Indent.getContinuationIndent();
+        return Indent.getNormalIndent();
       }
     }
     if (prevSiblingType == DOT && elementType == REFERENCE_EXPRESSION && parentType == CASCADE_REFERENCE_EXPRESSION) {
       // This makes DartTypingTest.testCascadeAlignAfterReturn2() succeed.
-      return Indent.getContinuationIndent();
+      return Indent.getNormalIndent();
     }
     return Indent.getNoneIndent();
   }

--- a/Dart/testData/formatter/Default_after.dart
+++ b/Dart/testData/formatter/Default_after.dart
@@ -59,14 +59,14 @@ class Foo {
 
 void main() {
   query("#text")
-      ..text = "Click me!"
-      ..onClick.listen(reverseText)
-      ..onMouseOver.listen(colorText);
+    ..text = "Click me!"
+    ..onClick.listen(reverseText)
+    ..onMouseOver.listen(colorText);
 
   query("#text")
-      ..text = "Click me!"
-      ..onClick.listen(reverseText)
-      ..onMouseOver.listen(colorText);
+    ..text = "Click me!"
+    ..onClick.listen(reverseText)
+    ..onMouseOver.listen(colorText);
 
   if (true)
     print("1");

--- a/Dart/testData/formatter/Default_after.dart
+++ b/Dart/testData/formatter/Default_after.dart
@@ -59,14 +59,14 @@ class Foo {
 
 void main() {
   query("#text")
-    ..text = "Click me!"
-    ..onClick.listen(reverseText)
-    ..onMouseOver.listen(colorText);
+      ..text = "Click me!"
+      ..onClick.listen(reverseText)
+      ..onMouseOver.listen(colorText);
 
   query("#text")
-    ..text = "Click me!"
-    ..onClick.listen(reverseText)
-    ..onMouseOver.listen(colorText);
+      ..text = "Click me!"
+      ..onClick.listen(reverseText)
+      ..onMouseOver.listen(colorText);
 
   if (true)
     print("1");

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -361,7 +361,7 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "}",
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      <caret>..c;\n" +
+                 "    <caret>..c;\n" +
                  "}");
   }
 
@@ -369,14 +369,14 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
     doTypingTest('\n',
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      ..c\n" +
-                 "      ..d<caret>\n" +
+                 "    ..c\n" +
+                 "    ..d<caret>\n" +
                  "}",
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      ..c\n" +
-                 "      ..d\n" +
-                 "      <caret>\n" +
+                 "    ..c\n" +
+                 "    ..d\n" +
+                 "    <caret>\n" +
                  "}");
   }
 
@@ -384,14 +384,14 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
     doTypingTest('\n',
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      <caret>..c\n" +
-                 "      ..d\n" +
+                 "    <caret>..c\n" +
+                 "    ..d\n" +
                  "}",
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      \n" +
-                 "      <caret>..c\n" +
-                 "      ..d\n" +
+                 "    \n" +
+                 "    <caret>..c\n" +
+                 "    ..d\n" +
                  "}");
   }
 
@@ -399,48 +399,48 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
     doTypingTest('\n',
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      ..c\n" +
-                 "      <caret>..d\n" +
+                 "    ..c\n" +
+                 "    <caret>..d\n" +
                  "}",
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      ..c\n" +
-                 "      \n" +
-                 "      <caret>..d\n" +
+                 "    ..c\n" +
+                 "    \n" +
+                 "    <caret>..d\n" +
                  "}");
   }
 
   public void testCascadeAlignAfterReturn5() throws Throwable {
     // TODO This test should fail as written but the code isn't quite
-    // right yet. It should insert 4 spaces before the caret.
+    // right yet. It should insert two spaces before the caret.
     doTypingTest('\n',
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      ..c<caret>\n" +
-                 "      ..d\n" +
+                 "    ..c<caret>\n" +
+                 "    ..d\n" +
                  "}",
                  "main(a) {\n" +
                  "  a.b\n" +
-                 "      ..c\n" +
+                 "    ..c\n" +
                  "  <caret>\n" +
-                 "      ..d\n" +
+                 "    ..d\n" +
                  "}");
   }
 
   public void testCascadeAlignAfterReturn6() throws Throwable {
     // TODO This test should fail as written but the code isn't quite
-    // right yet. It should insert 4 spaces before the caret.
+    // right yet. It should insert two spaces before the caret.
     doTypingTest('\n',
                  "main(a) {\n" +
                  "  a.b<caret>\n" +
-                 "      ..c\n" +
-                 "      ..d\n" +
+                 "    ..c\n" +
+                 "    ..d\n" +
                  "}",
                  "main(a) {\n" +
                  "  a.b\n" +
                  "  <caret>\n" +
-                 "      ..c\n" +
-                 "      ..d\n" +
+                 "    ..c\n" +
+                 "    ..d\n" +
                  "}");
   }
 }

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -113,14 +113,12 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testWEB_8315() throws Throwable {
-    doTypingTest('\n',
-                 "class X {\n" +
-                 "  num x;<caret>\n" +
-                 "}",
-                 "class X {\n" +
-                 "  num x;\n" +
-                 "  <caret>\n" +
-                 "}");
+    doTypingTest('\n', "class X {\n" +
+                       "  num x;<caret>\n" +
+                       "}", "class X {\n" +
+                            "  num x;\n" +
+                            "  <caret>\n" +
+                            "}");
   }
 
   public void testCaseAlignAfterColon1() throws Throwable {
@@ -354,5 +352,95 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
     doTypingTest('\n', "  ///   q  <caret>    z", "  ///   q  \n  ///   <caret> z");
     doTypingTest('\n', "///q<caret>z", "///q\n///<caret>z");
     doTypingTest('\n', " ///q<caret> \t ///z", " ///q \t \n ///<caret>z");
+  }
+
+  public void testCascadeAlignAfterReturn1() throws Throwable {
+    doTypingTest('\n',
+                 "main(a) {\n" +
+                 "  a.b<caret>..c;\n" +
+                 "}",
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      <caret>..c;\n" +
+                 "}");
+  }
+
+  public void testCascadeAlignAfterReturn2() throws Throwable {
+    doTypingTest('\n',
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      ..c\n" +
+                 "      ..d<caret>\n" +
+                 "}",
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      ..c\n" +
+                 "      ..d\n" +
+                 "      <caret>\n" +
+                 "}");
+  }
+
+  public void testCascadeAlignAfterReturn3() throws Throwable {
+    doTypingTest('\n',
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      <caret>..c\n" +
+                 "      ..d\n" +
+                 "}",
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      \n" +
+                 "      <caret>..c\n" +
+                 "      ..d\n" +
+                 "}");
+  }
+
+  public void testCascadeAlignAfterReturn4() throws Throwable {
+    doTypingTest('\n',
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      ..c\n" +
+                 "      <caret>..d\n" +
+                 "}",
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      ..c\n" +
+                 "      \n" +
+                 "      <caret>..d\n" +
+                 "}");
+  }
+
+  public void testCascadeAlignAfterReturn5() throws Throwable {
+    // TODO This test should fail as written but the code isn't quite
+    // right yet. It should insert 4 spaces before the caret.
+    doTypingTest('\n',
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      ..c<caret>\n" +
+                 "      ..d\n" +
+                 "}",
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "      ..c\n" +
+                 "  <caret>\n" +
+                 "      ..d\n" +
+                 "}");
+  }
+
+  public void testCascadeAlignAfterReturn6() throws Throwable {
+    // TODO This test should fail as written but the code isn't quite
+    // right yet. It should insert 4 spaces before the caret.
+    doTypingTest('\n',
+                 "main(a) {\n" +
+                 "  a.b<caret>\n" +
+                 "      ..c\n" +
+                 "      ..d\n" +
+                 "}",
+                 "main(a) {\n" +
+                 "  a.b\n" +
+                 "  <caret>\n" +
+                 "      ..c\n" +
+                 "      ..d\n" +
+                 "}");
   }
 }

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -113,12 +113,14 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testWEB_8315() throws Throwable {
-    doTypingTest('\n', "class X {\n" +
-                       "  num x;<caret>\n" +
-                       "}", "class X {\n" +
-                            "  num x;\n" +
-                            "  <caret>\n" +
-                            "}");
+    doTypingTest('\n',
+                  "class X {\n" +
+                  "  num x;<caret>\n" +
+                  "}",
+                  "class X {\n" +
+                  "  num x;\n" +
+                  "  <caret>\n" +
+                  "}");
   }
 
   public void testCaseAlignAfterColon1() throws Throwable {

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -114,13 +114,13 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
 
   public void testWEB_8315() throws Throwable {
     doTypingTest('\n',
-                  "class X {\n" +
-                  "  num x;<caret>\n" +
-                  "}",
-                  "class X {\n" +
-                  "  num x;\n" +
-                  "  <caret>\n" +
-                  "}");
+                 "class X {\n" +
+                 "  num x;<caret>\n" +
+                 "}",
+                 "class X {\n" +
+                 "  num x;\n" +
+                 "  <caret>\n" +
+                 "}");
   }
 
   public void testCaseAlignAfterColon1() throws Throwable {


### PR DESCRIPTION
@alexander-doroshko This is all that's left after many experiments that didn't work out. As I was putting together this PR I noticed the Dart style guide had recently been changed to recommend two spaces for cascades instead of four.