### PR TITLE
Formatname

### DIFF
--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -14,7 +14,7 @@ import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public abstract class DartStyleTest extends FormatterTestCase {
+public  class DartStyleTest extends FormatterTestCase {
 
   protected String getFileExtension() {
     return DartFileType.DEFAULT_EXTENSION;
@@ -260,7 +260,7 @@ public abstract class DartStyleTest extends FormatterTestCase {
         i = 1;
       }
 
-      System.out.println("Right margin: " + pageWidth);
+      System.out.println("\nTest: " + dirName + "/" + testName + ext + ", Right margin: " + pageWidth);
       final CommonCodeStyleSettings settings = getSettings(DartLanguage.INSTANCE);
       settings.RIGHT_MARGIN = pageWidth;
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -14,7 +14,7 @@ import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public  class DartStyleTest extends FormatterTestCase {
+public abstract class DartStyleTest extends FormatterTestCase {
 
   protected String getFileExtension() {
     return DartFileType.DEFAULT_EXTENSION;


### PR DESCRIPTION
@alexander-doroshko I'd like to see the path to the test file in the output. Some of the names are ambiguous and it is easier to find the original file when it's path is visible in the test output.

Is there really no way to keep this from running as part of the system tests other than making it abstract? Maybe I forgot to mention it but I prefer not to modify files unnecessarily. AFAIK I can't run the dart_style test as-is without modifying it; is there another way to run it?