### PR TITLE
Change Dart cascade parser to build flatter tree

### DIFF
--- a/Dart/gen com/jetbrains/lang/dart/psi/impl/DartValueExpressionImpl.java
+++ b/Dart/gen com/jetbrains/lang/dart/psi/impl/DartValueExpressionImpl.java
@@ -11,21 +11,21 @@ import static com.jetbrains.lang.dart.DartTokenTypes.*;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 
-public class DartCascadeReferenceExpressionImpl extends DartReferenceImpl implements DartCascadeReferenceExpression {
+public class DartValueExpressionImpl extends DartExpressionImpl implements DartValueExpression {
 
-  public DartCascadeReferenceExpressionImpl(ASTNode node) {
+  public DartValueExpressionImpl(ASTNode node) {
     super(node);
   }
 
   public void accept(@NotNull PsiElementVisitor visitor) {
-    if (visitor instanceof DartVisitor) ((DartVisitor)visitor).visitCascadeReferenceExpression(this);
+    if (visitor instanceof DartVisitor) ((DartVisitor)visitor).visitValueExpression(this);
     else super.accept(visitor);
   }
 
   @Override
-  @Nullable
-  public DartExpression getExpression() {
-    return findChildByClass(DartExpression.class);
+  @NotNull
+  public List<DartExpression> getExpressionList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, DartExpression.class);
   }
 
 }

--- a/Dart/gen/com/jetbrains/lang/dart/DartParser.java
+++ b/Dart/gen/com/jetbrains/lang/dart/DartParser.java
@@ -1038,12 +1038,12 @@ public class DartParser implements PsiParser {
     if (!recursion_guard_(b, l, "cascadeReferenceExpression")) return false;
     if (!nextTokenIs(b, DOT_DOT)) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _LEFT_, null);
+    Marker m = enter_section_(b);
     r = consumeToken(b, DOT_DOT);
     r = r && cascadeStopper(b, l + 1);
     r = r && cascadeReferenceExpression_2(b, l + 1);
     r = r && varInitWrapper(b, l + 1);
-    exit_section_(b, l, m, CASCADE_REFERENCE_EXPRESSION, r, false, null);
+    exit_section_(b, m, CASCADE_REFERENCE_EXPRESSION, r);
     return r;
   }
 

--- a/Dart/gen/com/jetbrains/lang/dart/psi/DartCascadeReferenceExpression.java
+++ b/Dart/gen/com/jetbrains/lang/dart/psi/DartCascadeReferenceExpression.java
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface DartCascadeReferenceExpression extends DartExpression, DartReference {
 
-  @NotNull
-  List<DartExpression> getExpressionList();
+  @Nullable
+  DartExpression getExpression();
 
 }

--- a/Dart/gen/com/jetbrains/lang/dart/psi/DartValueExpression.java
+++ b/Dart/gen/com/jetbrains/lang/dart/psi/DartValueExpression.java
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface DartValueExpression extends DartExpression {
 
-  @Nullable
-  DartExpression getExpression();
+  @NotNull
+  List<DartExpression> getExpressionList();
 
 }

--- a/Dart/src/com/jetbrains/lang/dart/Dart.bnf
+++ b/Dart/src/com/jetbrains/lang/dart/Dart.bnf
@@ -567,7 +567,7 @@ referenceExpression ::= << nonStrictID >>
 {mixin="com.jetbrains.lang.dart.psi.impl.DartReferenceImpl" implements="com.jetbrains.lang.dart.psi.DartReference"}
 
 left qualifiedReferenceExpression ::= '.' referenceExpression {elementType="referenceExpression"}
-left cascadeReferenceExpression ::= '..' << cascadeStopper >> (arrayAccess | refOrThisOrSuperOrParenExpression callOrArrayAccessOrQualifiedRefExpression) << varInitWrapper >>
+cascadeReferenceExpression ::= '..' << cascadeStopper >> (arrayAccess | refOrThisOrSuperOrParenExpression callOrArrayAccessOrQualifiedRefExpression) << varInitWrapper >>
 {mixin="com.jetbrains.lang.dart.psi.impl.DartReferenceImpl" implements="com.jetbrains.lang.dart.psi.DartReference"}
 
 simpleQualifiedReferenceExpression ::= referenceExpression qualifiedReferenceExpression* {elementType="referenceExpression"}

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
@@ -370,7 +370,12 @@ public class DartSpacingProcessor {
       return addSingleSpaceIf(true);
     }
 
-    if (type1 != DOT && type2 == DOT_DOT && elementType == CASCADE_REFERENCE_EXPRESSION) {
+    if (elementType == VALUE_EXPRESSION && type2 == CASCADE_REFERENCE_EXPRESSION) {
+      //if (type1 == CASCADE_REFERENCE_EXPRESSION) {
+      //  if (((AbstractBlock)child1).getNode().getLastChildNode().getElementType() == CALL_EXPRESSION) {
+      //    // TODO if child1 message name == child2 message name, do not add line break
+      //  }
+      //}
       return addLineBreak();
     }
 

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
@@ -140,9 +140,12 @@ public class DartReferenceImpl extends DartExpressionImpl implements DartReferen
       }
     }
     if (this instanceof DartCascadeReferenceExpression) {
-      DartReference[] children = PsiTreeUtil.getChildrenOfType(this, DartReference.class);
-      if (children != null && children.length == 2) {
-        return children[0].resolveDartClass();
+      PsiElement parent = this.getParent();
+      if (parent instanceof DartValueExpression) {
+        DartReference child = (DartReference) parent.getFirstChild();
+        if (child != null) {
+          return child.resolveDartClass();
+        }
       }
     }
     return DartResolveUtil.getDartClassResolveResult(resolve(), tryGetLeftResolveResult(this).getSpecialization());

--- a/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
@@ -468,12 +468,14 @@ public class DartResolveUtil {
     }
     DartReference reference = PsiTreeUtil.getParentOfType(node, DartReference.class, false);
     while (reference != null) {
-      final PsiElement parent = reference.getParent();
+      PsiElement parent = reference.getParent();
       if (parent instanceof DartCascadeReferenceExpression) {
-        DartReference[] references = PsiTreeUtil.getChildrenOfType(parent, DartReference.class);
-        DartReference result = references != null && references.length == 2 ? references[0] : null;
-        // if not starts with node
-        return !PsiTreeUtil.isAncestor(result, node, false) ? result : null;
+        parent = parent.getParent();
+        if (parent instanceof DartValueExpression) {
+          return (DartReference) parent.getFirstChild();
+        }
+        // Invalid tree shape
+        return null;
       }
       else if (parent instanceof DartReference && parent.getFirstChild() == reference) {
         reference = (DartReference)parent;

--- a/Dart/testData/parsing/Cascades.txt
+++ b/Dart/testData/parsing/Cascades.txt
@@ -18,17 +18,17 @@ Dart File
                   PsiElement(IDENTIFIER)('person')
             VAR_INIT
               PsiElement(=)('=')
-              CASCADE_REFERENCE_EXPRESSION
+              VALUE_EXPRESSION
+                NEW_EXPRESSION
+                  PsiElement(new)('new')
+                  TYPE
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('Person')
+                  ARGUMENTS
+                    PsiElement(()('(')
+                    PsiElement())(')')
                 CASCADE_REFERENCE_EXPRESSION
-                  NEW_EXPRESSION
-                    PsiElement(new)('new')
-                    TYPE
-                      REFERENCE_EXPRESSION
-                        ID
-                          PsiElement(IDENTIFIER)('Person')
-                    ARGUMENTS
-                      PsiElement(()('(')
-                      PsiElement())(')')
                   PsiElement(..)('..')
                   REFERENCE_EXPRESSION
                     ID
@@ -39,16 +39,16 @@ Dart File
                       PsiElement(OPEN_QUOTE)(''')
                       PsiElement(REGULAR_STRING_PART)('Bob Smith')
                       PsiElement(CLOSING_QUOTE)(''')
-                PsiElement(..)('..')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('address')
-                VAR_INIT
-                  PsiElement(=)('=')
-                  PARENTHESIZED_EXPRESSION
-                    PsiElement(()('(')
-                    CASCADE_REFERENCE_EXPRESSION
-                      CASCADE_REFERENCE_EXPRESSION
+                CASCADE_REFERENCE_EXPRESSION
+                  PsiElement(..)('..')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('address')
+                  VAR_INIT
+                    PsiElement(=)('=')
+                    PARENTHESIZED_EXPRESSION
+                      PsiElement(()('(')
+                      VALUE_EXPRESSION
                         NEW_EXPRESSION
                           PsiElement(new)('new')
                           TYPE
@@ -58,27 +58,29 @@ Dart File
                           ARGUMENTS
                             PsiElement(()('(')
                             PsiElement())(')')
-                        PsiElement(..)('..')
-                        REFERENCE_EXPRESSION
-                          ID
-                            PsiElement(IDENTIFIER)('city')
-                        VAR_INIT
-                          PsiElement(=)('=')
-                          STRING_LITERAL_EXPRESSION
-                            PsiElement(OPEN_QUOTE)(''')
-                            PsiElement(REGULAR_STRING_PART)('Springfield')
-                            PsiElement(CLOSING_QUOTE)(''')
-                      PsiElement(..)('..')
-                      REFERENCE_EXPRESSION
-                        ID
-                          PsiElement(IDENTIFIER)('zip')
-                      VAR_INIT
-                        PsiElement(=)('=')
-                        STRING_LITERAL_EXPRESSION
-                          PsiElement(OPEN_QUOTE)(''')
-                          PsiElement(REGULAR_STRING_PART)('99999')
-                          PsiElement(CLOSING_QUOTE)(''')
-                    PsiElement())(')')
+                        CASCADE_REFERENCE_EXPRESSION
+                          PsiElement(..)('..')
+                          REFERENCE_EXPRESSION
+                            ID
+                              PsiElement(IDENTIFIER)('city')
+                          VAR_INIT
+                            PsiElement(=)('=')
+                            STRING_LITERAL_EXPRESSION
+                              PsiElement(OPEN_QUOTE)(''')
+                              PsiElement(REGULAR_STRING_PART)('Springfield')
+                              PsiElement(CLOSING_QUOTE)(''')
+                        CASCADE_REFERENCE_EXPRESSION
+                          PsiElement(..)('..')
+                          REFERENCE_EXPRESSION
+                            ID
+                              PsiElement(IDENTIFIER)('zip')
+                          VAR_INIT
+                            PsiElement(=)('=')
+                            STRING_LITERAL_EXPRESSION
+                              PsiElement(OPEN_QUOTE)(''')
+                              PsiElement(REGULAR_STRING_PART)('99999')
+                              PsiElement(CLOSING_QUOTE)(''')
+                      PsiElement())(')')
           PsiElement(;)(';')
           VAR_DECLARATION_LIST
             VAR_ACCESS_DECLARATION
@@ -88,17 +90,17 @@ Dart File
                   PsiElement(IDENTIFIER)('map')
             VAR_INIT
               PsiElement(=)('=')
-              CASCADE_REFERENCE_EXPRESSION
+              VALUE_EXPRESSION
+                NEW_EXPRESSION
+                  PsiElement(new)('new')
+                  TYPE
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('Map')
+                  ARGUMENTS
+                    PsiElement(()('(')
+                    PsiElement())(')')
                 CASCADE_REFERENCE_EXPRESSION
-                  NEW_EXPRESSION
-                    PsiElement(new)('new')
-                    TYPE
-                      REFERENCE_EXPRESSION
-                        ID
-                          PsiElement(IDENTIFIER)('Map')
-                    ARGUMENTS
-                      PsiElement(()('(')
-                      PsiElement())(')')
                   PsiElement(..)('..')
                   PsiElement([)('[')
                   LITERAL_EXPRESSION
@@ -108,17 +110,18 @@ Dart File
                     PsiElement(=)('=')
                     LITERAL_EXPRESSION
                       PsiElement(NUMBER)('1')
-                PsiElement(..)('..')
-                PsiElement([)('[')
-                LITERAL_EXPRESSION
-                  PsiElement(NUMBER)('2')
-                PsiElement(])(']')
-                VAR_INIT
-                  PsiElement(=)('=')
+                CASCADE_REFERENCE_EXPRESSION
+                  PsiElement(..)('..')
+                  PsiElement([)('[')
                   LITERAL_EXPRESSION
                     PsiElement(NUMBER)('2')
+                  PsiElement(])(']')
+                  VAR_INIT
+                    PsiElement(=)('=')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('2')
           PsiElement(;)(';')
-          CASCADE_REFERENCE_EXPRESSION
+          VALUE_EXPRESSION
             AS_EXPRESSION
               CALL_EXPRESSION
                 REFERENCE_EXPRESSION
@@ -137,14 +140,15 @@ Dart File
                 REFERENCE_EXPRESSION
                   ID
                     PsiElement(IDENTIFIER)('CCC')
-            PsiElement(..)('..')
-            CALL_EXPRESSION
-              REFERENCE_EXPRESSION
-                ID
-                  PsiElement(IDENTIFIER)('ddd')
-              ARGUMENTS
-                PsiElement(()('(')
-                PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('ddd')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  PsiElement())(')')
           PsiElement(;)(';')
         PsiElement(})('}')
   CLASS_DEFINITION
@@ -662,267 +666,267 @@ Dart File
                       PsiElement(NUMBER)('2')
                   PsiElement())(')')
           PsiElement(;)(';')
-          CASCADE_REFERENCE_EXPRESSION
+          VALUE_EXPRESSION
+            REFERENCE_EXPRESSION
+              ID
+                PsiElement(IDENTIFIER)('a')
             CASCADE_REFERENCE_EXPRESSION
-              CASCADE_REFERENCE_EXPRESSION
-                CASCADE_REFERENCE_EXPRESSION
-                  CASCADE_REFERENCE_EXPRESSION
-                    CASCADE_REFERENCE_EXPRESSION
-                      CASCADE_REFERENCE_EXPRESSION
-                        CASCADE_REFERENCE_EXPRESSION
-                          CASCADE_REFERENCE_EXPRESSION
-                            CASCADE_REFERENCE_EXPRESSION
-                              CASCADE_REFERENCE_EXPRESSION
-                                CASCADE_REFERENCE_EXPRESSION
-                                  CASCADE_REFERENCE_EXPRESSION
-                                    CASCADE_REFERENCE_EXPRESSION
-                                      CASCADE_REFERENCE_EXPRESSION
-                                        CASCADE_REFERENCE_EXPRESSION
-                                          CASCADE_REFERENCE_EXPRESSION
-                                            CASCADE_REFERENCE_EXPRESSION
-                                              CASCADE_REFERENCE_EXPRESSION
-                                                CASCADE_REFERENCE_EXPRESSION
-                                                  REFERENCE_EXPRESSION
-                                                    ID
-                                                      PsiElement(IDENTIFIER)('a')
-                                                  PsiElement(..)('..')
-                                                  CALL_EXPRESSION
-                                                    REFERENCE_EXPRESSION
-                                                      ID
-                                                        PsiElement(IDENTIFIER)('check')
-                                                    ARGUMENTS
-                                                      PsiElement(()('(')
-                                                      ARGUMENT_LIST
-                                                        LITERAL_EXPRESSION
-                                                          PsiElement(NUMBER)('1')
-                                                        PsiElement(,)(',')
-                                                        LITERAL_EXPRESSION
-                                                          PsiElement(NUMBER)('2')
-                                                      PsiElement())(')')
-                                                PsiElement(..)('..')
-                                                CALL_EXPRESSION
-                                                  REFERENCE_EXPRESSION
-                                                    ID
-                                                      PsiElement(IDENTIFIER)('swap')
-                                                  ARGUMENTS
-                                                    PsiElement(()('(')
-                                                    PsiElement())(')')
-                                              PsiElement(..)('..')
-                                              CALL_EXPRESSION
-                                                REFERENCE_EXPRESSION
-                                                  ID
-                                                    PsiElement(IDENTIFIER)('check')
-                                                ARGUMENTS
-                                                  PsiElement(()('(')
-                                                  ARGUMENT_LIST
-                                                    LITERAL_EXPRESSION
-                                                      PsiElement(NUMBER)('2')
-                                                    PsiElement(,)(',')
-                                                    LITERAL_EXPRESSION
-                                                      PsiElement(NUMBER)('1')
-                                                  PsiElement())(')')
-                                            PsiElement(..)('..')
-                                            REFERENCE_EXPRESSION
-                                              ID
-                                                PsiElement(IDENTIFIER)('x')
-                                            VAR_INIT
-                                              PsiElement(=)('=')
-                                              LITERAL_EXPRESSION
-                                                PsiElement(NUMBER)('4')
-                                          PsiElement(..)('..')
-                                          REFERENCE_EXPRESSION
-                                            ID
-                                              PsiElement(IDENTIFIER)('y')
-                                          VAR_INIT
-                                            PsiElement(=)('=')
-                                            LITERAL_EXPRESSION
-                                              PsiElement(NUMBER)('9')
-                                        PsiElement(..)('..')
-                                        CALL_EXPRESSION
-                                          REFERENCE_EXPRESSION
-                                            ID
-                                              PsiElement(IDENTIFIER)('check')
-                                          ARGUMENTS
-                                            PsiElement(()('(')
-                                            ARGUMENT_LIST
-                                              LITERAL_EXPRESSION
-                                                PsiElement(NUMBER)('4')
-                                              PsiElement(,)(',')
-                                              LITERAL_EXPRESSION
-                                                PsiElement(NUMBER)('9')
-                                            PsiElement())(')')
-                                      PsiElement(..)('..')
-                                      CALL_EXPRESSION
-                                        REFERENCE_EXPRESSION
-                                          ID
-                                            PsiElement(IDENTIFIER)('setX')
-                                        ARGUMENTS
-                                          PsiElement(()('(')
-                                          ARGUMENT_LIST
-                                            LITERAL_EXPRESSION
-                                              PsiElement(NUMBER)('10')
-                                          PsiElement())(')')
-                                    PsiElement(..)('..')
-                                    CALL_EXPRESSION
-                                      REFERENCE_EXPRESSION
-                                        ID
-                                          PsiElement(IDENTIFIER)('check')
-                                      ARGUMENTS
-                                        PsiElement(()('(')
-                                        ARGUMENT_LIST
-                                          LITERAL_EXPRESSION
-                                            PsiElement(NUMBER)('10')
-                                          PsiElement(,)(',')
-                                          LITERAL_EXPRESSION
-                                            PsiElement(NUMBER)('9')
-                                        PsiElement())(')')
-                                  PsiElement(..)('..')
-                                  REFERENCE_EXPRESSION
-                                    ID
-                                      PsiElement(IDENTIFIER)('y')
-                                  VAR_INIT
-                                    PsiElement(=)('=')
-                                    LITERAL_EXPRESSION
-                                      PsiElement(NUMBER)('5')
-                                PsiElement(..)('..')
-                                CALL_EXPRESSION
-                                  REFERENCE_EXPRESSION
-                                    ID
-                                      PsiElement(IDENTIFIER)('check')
-                                  ARGUMENTS
-                                    PsiElement(()('(')
-                                    ARGUMENT_LIST
-                                      LITERAL_EXPRESSION
-                                        PsiElement(NUMBER)('10')
-                                      PsiElement(,)(',')
-                                      LITERAL_EXPRESSION
-                                        PsiElement(NUMBER)('5')
-                                    PsiElement())(')')
-                              PsiElement(..)('..')
-                              CALL_EXPRESSION
-                                CALL_EXPRESSION
-                                  CALL_EXPRESSION
-                                    REFERENCE_EXPRESSION
-                                      ID
-                                        PsiElement(IDENTIFIER)('swap')
-                                    ARGUMENTS
-                                      PsiElement(()('(')
-                                      PsiElement())(')')
-                                  ARGUMENTS
-                                    PsiElement(()('(')
-                                    PsiElement())(')')
-                                ARGUMENTS
-                                  PsiElement(()('(')
-                                  PsiElement())(')')
-                            PsiElement(..)('..')
-                            CALL_EXPRESSION
-                              REFERENCE_EXPRESSION
-                                ID
-                                  PsiElement(IDENTIFIER)('check')
-                              ARGUMENTS
-                                PsiElement(()('(')
-                                ARGUMENT_LIST
-                                  LITERAL_EXPRESSION
-                                    PsiElement(NUMBER)('5')
-                                  PsiElement(,)(',')
-                                  LITERAL_EXPRESSION
-                                    PsiElement(NUMBER)('10')
-                                PsiElement())(')')
-                          PsiElement(..)('..')
-                          CALL_EXPRESSION
-                            REFERENCE_EXPRESSION
-                              ID
-                                PsiElement(IDENTIFIER)('check')
-                            ARGUMENTS
-                              PsiElement(()('(')
-                              ARGUMENT_LIST
-                                LITERAL_EXPRESSION
-                                  PsiElement(NUMBER)('2')
-                                PsiElement(,)(',')
-                                LITERAL_EXPRESSION
-                                  PsiElement(NUMBER)('10')
-                              PsiElement())(')')
-                        PsiElement(..)('..')
-                        CALL_EXPRESSION
-                          REFERENCE_EXPRESSION
-                            CALL_EXPRESSION
-                              REFERENCE_EXPRESSION
-                                ID
-                                  PsiElement(IDENTIFIER)('setX')
-                              ARGUMENTS
-                                PsiElement(()('(')
-                                ARGUMENT_LIST
-                                  LITERAL_EXPRESSION
-                                    PsiElement(NUMBER)('10')
-                                PsiElement())(')')
-                            PsiElement(.)('.')
-                            REFERENCE_EXPRESSION
-                              ID
-                                PsiElement(IDENTIFIER)('setY')
-                          ARGUMENTS
-                            PsiElement(()('(')
-                            ARGUMENT_LIST
-                              LITERAL_EXPRESSION
-                                PsiElement(NUMBER)('3')
-                            PsiElement())(')')
-                      PsiElement(..)('..')
-                      CALL_EXPRESSION
-                        REFERENCE_EXPRESSION
-                          ID
-                            PsiElement(IDENTIFIER)('check')
-                        ARGUMENTS
-                          PsiElement(()('(')
-                          ARGUMENT_LIST
-                            LITERAL_EXPRESSION
-                              PsiElement(NUMBER)('10')
-                            PsiElement(,)(',')
-                            LITERAL_EXPRESSION
-                              PsiElement(NUMBER)('3')
-                          PsiElement())(')')
-                    PsiElement(..)('..')
-                    CALL_EXPRESSION
-                      ARRAY_ACCESS_EXPRESSION
-                        CALL_EXPRESSION
-                          REFERENCE_EXPRESSION
-                            ID
-                              PsiElement(IDENTIFIER)('setX')
-                          ARGUMENTS
-                            PsiElement(()('(')
-                            ARGUMENT_LIST
-                              LITERAL_EXPRESSION
-                                PsiElement(NUMBER)('7')
-                            PsiElement())(')')
-                        PsiElement([)('[')
-                        STRING_LITERAL_EXPRESSION
-                          PsiElement(OPEN_QUOTE)('"')
-                          PsiElement(REGULAR_STRING_PART)('swap')
-                          PsiElement(CLOSING_QUOTE)('"')
-                        PsiElement(])(']')
-                      ARGUMENTS
-                        PsiElement(()('(')
-                        PsiElement())(')')
-                  PsiElement(..)('..')
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('1')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('2')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('swap')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('2')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('1')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              REFERENCE_EXPRESSION
+                ID
+                  PsiElement(IDENTIFIER)('x')
+              VAR_INIT
+                PsiElement(=)('=')
+                LITERAL_EXPRESSION
+                  PsiElement(NUMBER)('4')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              REFERENCE_EXPRESSION
+                ID
+                  PsiElement(IDENTIFIER)('y')
+              VAR_INIT
+                PsiElement(=)('=')
+                LITERAL_EXPRESSION
+                  PsiElement(NUMBER)('9')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('4')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('9')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('setX')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('10')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('10')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('9')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              REFERENCE_EXPRESSION
+                ID
+                  PsiElement(IDENTIFIER)('y')
+              VAR_INIT
+                PsiElement(=)('=')
+                LITERAL_EXPRESSION
+                  PsiElement(NUMBER)('5')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('10')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('5')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                CALL_EXPRESSION
                   CALL_EXPRESSION
                     REFERENCE_EXPRESSION
                       ID
-                        PsiElement(IDENTIFIER)('check')
+                        PsiElement(IDENTIFIER)('swap')
+                    ARGUMENTS
+                      PsiElement(()('(')
+                      PsiElement())(')')
+                  ARGUMENTS
+                    PsiElement(()('(')
+                    PsiElement())(')')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('5')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('10')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('2')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('10')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  CALL_EXPRESSION
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('setX')
                     ARGUMENTS
                       PsiElement(()('(')
                       ARGUMENT_LIST
                         LITERAL_EXPRESSION
-                          PsiElement(NUMBER)('3')
-                        PsiElement(,)(',')
+                          PsiElement(NUMBER)('10')
+                      PsiElement())(')')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('setY')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('3')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('10')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('3')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                ARRAY_ACCESS_EXPRESSION
+                  CALL_EXPRESSION
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('setX')
+                    ARGUMENTS
+                      PsiElement(()('(')
+                      ARGUMENT_LIST
                         LITERAL_EXPRESSION
                           PsiElement(NUMBER)('7')
                       PsiElement())(')')
-                PsiElement(..)('..')
-                CALL_EXPRESSION
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(import)('import')
-                  ARGUMENTS
-                    PsiElement(()('(')
-                    PsiElement())(')')
+                  PsiElement([)('[')
+                  STRING_LITERAL_EXPRESSION
+                    PsiElement(OPEN_QUOTE)('"')
+                    PsiElement(REGULAR_STRING_PART)('swap')
+                    PsiElement(CLOSING_QUOTE)('"')
+                  PsiElement(])(']')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('3')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('7')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(import)('import')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
               PsiElement(..)('..')
               CALL_EXPRESSION
                 REFERENCE_EXPRESSION
@@ -937,20 +941,21 @@ Dart File
                     LITERAL_EXPRESSION
                       PsiElement(NUMBER)('7')
                   PsiElement())(')')
-            PsiElement(..)('..')
-            CALL_EXPRESSION
-              REFERENCE_EXPRESSION
-                ID
-                  PsiElement(IDENTIFIER)('check')
-              ARGUMENTS
-                PsiElement(()('(')
-                ARGUMENT_LIST
-                  LITERAL_EXPRESSION
-                    PsiElement(NUMBER)('7')
-                  PsiElement(,)(',')
-                  LITERAL_EXPRESSION
-                    PsiElement(NUMBER)('4')
-                PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('check')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  ARGUMENT_LIST
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('7')
+                    PsiElement(,)(',')
+                    LITERAL_EXPRESSION
+                      PsiElement(NUMBER)('4')
+                  PsiElement())(')')
           PsiElement(;)(';')
         PsiElement(})('}')
   VAR_DECLARATION_LIST
@@ -961,7 +966,7 @@ Dart File
           PsiElement(IDENTIFIER)('BANG')
     VAR_INIT
       PsiElement(=)('=')
-      CASCADE_REFERENCE_EXPRESSION
+      VALUE_EXPRESSION
         NEW_EXPRESSION
           PsiElement(new)('new')
           TYPE
@@ -971,32 +976,34 @@ Dart File
           ARGUMENTS
             PsiElement(()('(')
             PsiElement())(')')
-        PsiElement(..)('..')
-        REFERENCE_EXPRESSION
-          ID
-            PsiElement(IDENTIFIER)('x')
-        VAR_INIT
-          PsiElement(=)('=')
-          LIST_LITERAL_EXPRESSION
-            PsiElement([)('[')
-            EXPRESSION_LIST
-              CASCADE_REFERENCE_EXPRESSION
-                STRING_LITERAL_EXPRESSION
-                  PsiElement(OPEN_QUOTE)('"')
-                  PsiElement(REGULAR_STRING_PART)('foo')
-                  PsiElement(CLOSING_QUOTE)('"')
-                PsiElement(..)('..')
-                CALL_EXPRESSION
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(IDENTIFIER)('padLeft')
-                  ARGUMENTS
-                    PsiElement(()('(')
-                    ARGUMENT_LIST
-                      LITERAL_EXPRESSION
-                        PsiElement(NUMBER)('1')
-                    PsiElement())(')')
-            PsiElement(])(']')
+        CASCADE_REFERENCE_EXPRESSION
+          PsiElement(..)('..')
+          REFERENCE_EXPRESSION
+            ID
+              PsiElement(IDENTIFIER)('x')
+          VAR_INIT
+            PsiElement(=)('=')
+            LIST_LITERAL_EXPRESSION
+              PsiElement([)('[')
+              EXPRESSION_LIST
+                VALUE_EXPRESSION
+                  STRING_LITERAL_EXPRESSION
+                    PsiElement(OPEN_QUOTE)('"')
+                    PsiElement(REGULAR_STRING_PART)('foo')
+                    PsiElement(CLOSING_QUOTE)('"')
+                  CASCADE_REFERENCE_EXPRESSION
+                    PsiElement(..)('..')
+                    CALL_EXPRESSION
+                      REFERENCE_EXPRESSION
+                        ID
+                          PsiElement(IDENTIFIER)('padLeft')
+                      ARGUMENTS
+                        PsiElement(()('(')
+                        ARGUMENT_LIST
+                          LITERAL_EXPRESSION
+                            PsiElement(NUMBER)('1')
+                        PsiElement())(')')
+              PsiElement(])(']')
   PsiElement(;)(';')
   VAR_DECLARATION_LIST
     VAR_ACCESS_DECLARATION
@@ -1006,63 +1013,66 @@ Dart File
           PsiElement(IDENTIFIER)('BANG2')
     VAR_INIT
       PsiElement(=)('=')
-      CASCADE_REFERENCE_EXPRESSION
+      VALUE_EXPRESSION
+        NEW_EXPRESSION
+          PsiElement(new)('new')
+          TYPE
+            REFERENCE_EXPRESSION
+              ID
+                PsiElement(IDENTIFIER)('B')
+          ARGUMENTS
+            PsiElement(()('(')
+            PsiElement())(')')
         CASCADE_REFERENCE_EXPRESSION
-          NEW_EXPRESSION
-            PsiElement(new)('new')
-            TYPE
-              REFERENCE_EXPRESSION
-                ID
-                  PsiElement(IDENTIFIER)('B')
-            ARGUMENTS
-              PsiElement(()('(')
-              PsiElement())(')')
           PsiElement(..)('..')
           REFERENCE_EXPRESSION
             ID
               PsiElement(IDENTIFIER)('x')
-        PsiElement(..)('..')
-        REFERENCE_EXPRESSION
-          ID
-            PsiElement(IDENTIFIER)('y')
-        VAR_INIT
-          PsiElement(=)('=')
-          MAP_LITERAL_EXPRESSION
-            PsiElement({)('{')
-            MAP_LITERAL_ENTRY
-              CASCADE_REFERENCE_EXPRESSION
-                STRING_LITERAL_EXPRESSION
-                  PsiElement(OPEN_QUOTE)('"')
-                  PsiElement(REGULAR_STRING_PART)('bar')
-                  PsiElement(CLOSING_QUOTE)('"')
-                PsiElement(..)('..')
-                CALL_EXPRESSION
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(IDENTIFIER)('padLeft')
-                  ARGUMENTS
-                    PsiElement(()('(')
-                    ARGUMENT_LIST
-                      LITERAL_EXPRESSION
-                        PsiElement(NUMBER)('1')
-                    PsiElement())(')')
-              PsiElement(:)(':')
-              CASCADE_REFERENCE_EXPRESSION
-                CASCADE_REFERENCE_EXPRESSION
+        CASCADE_REFERENCE_EXPRESSION
+          PsiElement(..)('..')
+          REFERENCE_EXPRESSION
+            ID
+              PsiElement(IDENTIFIER)('y')
+          VAR_INIT
+            PsiElement(=)('=')
+            MAP_LITERAL_EXPRESSION
+              PsiElement({)('{')
+              MAP_LITERAL_ENTRY
+                VALUE_EXPRESSION
+                  STRING_LITERAL_EXPRESSION
+                    PsiElement(OPEN_QUOTE)('"')
+                    PsiElement(REGULAR_STRING_PART)('bar')
+                    PsiElement(CLOSING_QUOTE)('"')
+                  CASCADE_REFERENCE_EXPRESSION
+                    PsiElement(..)('..')
+                    CALL_EXPRESSION
+                      REFERENCE_EXPRESSION
+                        ID
+                          PsiElement(IDENTIFIER)('padLeft')
+                      ARGUMENTS
+                        PsiElement(()('(')
+                        ARGUMENT_LIST
+                          LITERAL_EXPRESSION
+                            PsiElement(NUMBER)('1')
+                        PsiElement())(')')
+                PsiElement(:)(':')
+                VALUE_EXPRESSION
                   REFERENCE_EXPRESSION
                     ID
                       PsiElement(IDENTIFIER)('baz')
-                  PsiElement(..)('..')
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(IDENTIFIER)('q')
-                PsiElement(..)('..')
-                CALL_EXPRESSION
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(IDENTIFIER)('w')
-                  ARGUMENTS
-                    PsiElement(()('(')
-                    PsiElement())(')')
-            PsiElement(})('}')
+                  CASCADE_REFERENCE_EXPRESSION
+                    PsiElement(..)('..')
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('q')
+                  CASCADE_REFERENCE_EXPRESSION
+                    PsiElement(..)('..')
+                    CALL_EXPRESSION
+                      REFERENCE_EXPRESSION
+                        ID
+                          PsiElement(IDENTIFIER)('w')
+                      ARGUMENTS
+                        PsiElement(()('(')
+                        PsiElement())(')')
+              PsiElement(})('}')
   PsiElement(;)(';')

--- a/Dart/testData/parsing/Class2.txt
+++ b/Dart/testData/parsing/Class2.txt
@@ -207,18 +207,19 @@ Dart File
                     PsiElement(case)('case')
                     PARENTHESIZED_EXPRESSION
                       PsiElement(()('(')
-                      CASCADE_REFERENCE_EXPRESSION
+                      VALUE_EXPRESSION
                         REFERENCE_EXPRESSION
                           ID
                             PsiElement(IDENTIFIER)('a')
-                        PsiElement(..)('..')
-                        CALL_EXPRESSION
-                          REFERENCE_EXPRESSION
-                            ID
-                              PsiElement(IDENTIFIER)('b')
-                          ARGUMENTS
-                            PsiElement(()('(')
-                            PsiElement())(')')
+                        CASCADE_REFERENCE_EXPRESSION
+                          PsiElement(..)('..')
+                          CALL_EXPRESSION
+                            REFERENCE_EXPRESSION
+                              ID
+                                PsiElement(IDENTIFIER)('b')
+                            ARGUMENTS
+                              PsiElement(()('(')
+                              PsiElement())(')')
                       PsiElement())(')')
                     PsiElement(:)(':')
                     STATEMENTS

--- a/Dart/testData/parsing/HardCases2.txt
+++ b/Dart/testData/parsing/HardCases2.txt
@@ -530,17 +530,17 @@ Dart File
                   PsiElement(IDENTIFIER)('foo')
             VAR_INIT
               PsiElement(=)('=')
-              CASCADE_REFERENCE_EXPRESSION
+              VALUE_EXPRESSION
+                NEW_EXPRESSION
+                  PsiElement(new)('new')
+                  TYPE
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('Foo')
+                  ARGUMENTS
+                    PsiElement(()('(')
+                    PsiElement())(')')
                 CASCADE_REFERENCE_EXPRESSION
-                  NEW_EXPRESSION
-                    PsiElement(new)('new')
-                    TYPE
-                      REFERENCE_EXPRESSION
-                        ID
-                          PsiElement(IDENTIFIER)('Foo')
-                    ARGUMENTS
-                      PsiElement(()('(')
-                      PsiElement())(')')
                   PsiElement(..)('..')
                   REFERENCE_EXPRESSION
                     ID
@@ -549,27 +549,28 @@ Dart File
                     PsiElement(=)('=')
                     LITERAL_EXPRESSION
                       PsiElement(NUMBER)('239')
-                PsiElement(..)('..')
-                CALL_EXPRESSION
-                  REFERENCE_EXPRESSION
-                    CALL_EXPRESSION
-                      REFERENCE_EXPRESSION
-                        REFERENCE_EXPRESSION
-                          ID
-                            PsiElement(IDENTIFIER)('baz')
-                        PsiElement(.)('.')
-                        REFERENCE_EXPRESSION
-                          ID
-                            PsiElement(IDENTIFIER)('getBar')
-                      ARGUMENTS
-                        PsiElement(()('(')
-                        PsiElement())(')')
-                    PsiElement(.)('.')
+                CASCADE_REFERENCE_EXPRESSION
+                  PsiElement(..)('..')
+                  CALL_EXPRESSION
                     REFERENCE_EXPRESSION
-                      ID
-                        PsiElement(IDENTIFIER)('getBaz')
-                  ARGUMENTS
-                    PsiElement(()('(')
-                    PsiElement())(')')
+                      CALL_EXPRESSION
+                        REFERENCE_EXPRESSION
+                          REFERENCE_EXPRESSION
+                            ID
+                              PsiElement(IDENTIFIER)('baz')
+                          PsiElement(.)('.')
+                          REFERENCE_EXPRESSION
+                            ID
+                              PsiElement(IDENTIFIER)('getBar')
+                        ARGUMENTS
+                          PsiElement(()('(')
+                          PsiElement())(')')
+                      PsiElement(.)('.')
+                      REFERENCE_EXPRESSION
+                        ID
+                          PsiElement(IDENTIFIER)('getBaz')
+                    ARGUMENTS
+                      PsiElement(()('(')
+                      PsiElement())(')')
           PsiElement(;)(';')
         PsiElement(})('}')

--- a/Dart/testData/parsing/HardCases3.txt
+++ b/Dart/testData/parsing/HardCases3.txt
@@ -443,31 +443,32 @@ Dart File
             ARGUMENTS
               PsiElement(()('(')
               ARGUMENT_LIST
-                CASCADE_REFERENCE_EXPRESSION
+                VALUE_EXPRESSION
                   LIST_LITERAL_EXPRESSION
                     PsiElement([)('[')
                     PsiElement(])(']')
-                  PsiElement(..)('..')
-                  CALL_EXPRESSION
-                    REFERENCE_EXPRESSION
-                      ID
-                        PsiElement(IDENTIFIER)('addAll')
-                    ARGUMENTS
-                      PsiElement(()('(')
-                      ARGUMENT_LIST
-                        LIST_LITERAL_EXPRESSION
-                          PsiElement([)('[')
-                          EXPRESSION_LIST
-                            LITERAL_EXPRESSION
-                              PsiElement(NUMBER)('1')
-                            PsiElement(,)(',')
-                            LITERAL_EXPRESSION
-                              PsiElement(NUMBER)('2')
-                            PsiElement(,)(',')
-                            LITERAL_EXPRESSION
-                              PsiElement(NUMBER)('3')
-                          PsiElement(])(']')
-                      PsiElement())(')')
+                  CASCADE_REFERENCE_EXPRESSION
+                    PsiElement(..)('..')
+                    CALL_EXPRESSION
+                      REFERENCE_EXPRESSION
+                        ID
+                          PsiElement(IDENTIFIER)('addAll')
+                      ARGUMENTS
+                        PsiElement(()('(')
+                        ARGUMENT_LIST
+                          LIST_LITERAL_EXPRESSION
+                            PsiElement([)('[')
+                            EXPRESSION_LIST
+                              LITERAL_EXPRESSION
+                                PsiElement(NUMBER)('1')
+                              PsiElement(,)(',')
+                              LITERAL_EXPRESSION
+                                PsiElement(NUMBER)('2')
+                              PsiElement(,)(',')
+                              LITERAL_EXPRESSION
+                                PsiElement(NUMBER)('3')
+                            PsiElement(])(']')
+                        PsiElement())(')')
               PsiElement())(')')
           PsiElement(;)(';')
         PsiElement(})('}')

--- a/Dart/testData/parsing/Milestone2.txt
+++ b/Dart/testData/parsing/Milestone2.txt
@@ -427,20 +427,20 @@ Dart File
                 PsiElement(IDENTIFIER)('f')
           VAR_INIT
             PsiElement(=)('=')
-            CASCADE_REFERENCE_EXPRESSION
+            VALUE_EXPRESSION
+              REFERENCE_EXPRESSION
+                ID
+                  PsiElement(IDENTIFIER)('g')
               CASCADE_REFERENCE_EXPRESSION
-                CASCADE_REFERENCE_EXPRESSION
+                PsiElement(..)('..')
+                CALL_EXPRESSION
                   REFERENCE_EXPRESSION
                     ID
-                      PsiElement(IDENTIFIER)('g')
-                  PsiElement(..)('..')
-                  CALL_EXPRESSION
-                    REFERENCE_EXPRESSION
-                      ID
-                        PsiElement(IDENTIFIER)('m1')
-                    ARGUMENTS
-                      PsiElement(()('(')
-                      PsiElement())(')')
+                      PsiElement(IDENTIFIER)('m1')
+                  ARGUMENTS
+                    PsiElement(()('(')
+                    PsiElement())(')')
+              CASCADE_REFERENCE_EXPRESSION
                 PsiElement(..)('..')
                 CALL_EXPRESSION
                   REFERENCE_EXPRESSION
@@ -449,15 +449,16 @@ Dart File
                   ARGUMENTS
                     PsiElement(()('(')
                     PsiElement())(')')
-              PsiElement(..)('..')
-              REFERENCE_EXPRESSION
+              CASCADE_REFERENCE_EXPRESSION
+                PsiElement(..)('..')
                 REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('f')
-                PsiElement(.)('.')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('a')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('f')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('a')
         PsiElement(;)(';')
       PsiElement(})('}')
   CLASS_DEFINITION
@@ -521,11 +522,11 @@ Dart File
                   PsiElement(()('(')
                   PsiElement())(')')
           PsiElement(;)(';')
-          CASCADE_REFERENCE_EXPRESSION
+          VALUE_EXPRESSION
+            REFERENCE_EXPRESSION
+              ID
+                PsiElement(IDENTIFIER)('a')
             CASCADE_REFERENCE_EXPRESSION
-              REFERENCE_EXPRESSION
-                ID
-                  PsiElement(IDENTIFIER)('a')
               PsiElement(..)('..')
               REFERENCE_EXPRESSION
                 ID
@@ -545,14 +546,15 @@ Dart File
                     PsiElement(OPEN_QUOTE)(''')
                     PsiElement(REGULAR_STRING_PART)('false')
                     PsiElement(CLOSING_QUOTE)(''')
-            PsiElement(..)('..')
-            CALL_EXPRESSION
-              REFERENCE_EXPRESSION
-                ID
-                  PsiElement(IDENTIFIER)('foo')
-              ARGUMENTS
-                PsiElement(()('(')
-                PsiElement())(')')
+            CASCADE_REFERENCE_EXPRESSION
+              PsiElement(..)('..')
+              CALL_EXPRESSION
+                REFERENCE_EXPRESSION
+                  ID
+                    PsiElement(IDENTIFIER)('foo')
+                ARGUMENTS
+                  PsiElement(()('(')
+                  PsiElement())(')')
           PsiElement(;)(';')
           FUNCTION_DECLARATION_WITH_BODY
             RETURN_TYPE


### PR DESCRIPTION
Change cascade parser to build flat tree with VALUE_EXPRESSION as head, receiver as first child, and CASCADE_REFERENCE_EXPRESSIONs as subsequent children representing messages sent to the receiver.

Most of this was straight-forward. There's work to be done in DartSpacingProcessor (see TODO), which will bring it into compliance with dart_style.

@alexander-doroshko Perhaps now I can fix that bug I started to look at a few months ago. It will still require some work in DartBlock, but at least it is bounded now.