### PR TITLE
Format cascade

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
@@ -102,8 +102,6 @@ public class DartBlock extends AbstractBlock implements BlockWithParent {
         if (receiver != null && cascade != null) {
           cascade.setParent(receiver);
           receiver.getSubBlocks().add(cascade);
-        } else {
-          throw new NullPointerException(); // TODO Remove after debugging.
         }
         parent.putUserData(DART_RECEIVER_KEY, null);
         parent.putUserData(DART_CASCADE_KEY, null);

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -125,8 +125,12 @@ public class DartIndentProcessor {
         (prevSiblingType == RPAREN || (prevSiblingType == ELSE && elementType != IF_STATEMENT))) {
       return Indent.getNormalIndent();
     }
-    if (prevSiblingType != DOT && elementType == DOT_DOT && parentType == CASCADE_REFERENCE_EXPRESSION) {
-      return Indent.getNormalIndent();
+    // TODO Remove this old code if it is not needed.
+    //if (prevSiblingType != DOT && elementType == DOT_DOT && parentType == CASCADE_REFERENCE_EXPRESSION) {
+    //  return Indent.getNormalIndent(true);
+    //}
+    if (elementType == CASCADE_REFERENCE_EXPRESSION) {
+      return Indent.getNormalIndent(true);
     }
     return Indent.getNoneIndent();
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -125,12 +125,8 @@ public class DartIndentProcessor {
         (prevSiblingType == RPAREN || (prevSiblingType == ELSE && elementType != IF_STATEMENT))) {
       return Indent.getNormalIndent();
     }
-    // TODO Remove this old code if it is not needed.
-    //if (prevSiblingType != DOT && elementType == DOT_DOT && parentType == CASCADE_REFERENCE_EXPRESSION) {
-    //  return Indent.getNormalIndent(true);
-    //}
     if (elementType == CASCADE_REFERENCE_EXPRESSION) {
-      return Indent.getNormalIndent(true);
+      return Indent.getNormalIndent();
     }
     return Indent.getNoneIndent();
   }


### PR DESCRIPTION
@alexander-doroshko This fixes some of the worst problems with cascade formatting. Nested cascades are now indented as they would by dartfmt. If multiple cascades call the same method they will be kept on the same line. At least for now, if they are already on separate lines the lines will not be combined, unlike dartfmt.