### PR TITLE
Format Dart cascades and string literals

### DIFF
--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -45,13 +45,11 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/expressions:97  conditional operands are nested");
     KNOWN_TO_FAIL.add("splitting/expressions:107  index expressions can split after \"[\"");
     KNOWN_TO_FAIL.add("splitting/expressions:112  index arguments nest");
-    KNOWN_TO_FAIL.add("whitespace/expressions:14  is!");
     KNOWN_TO_FAIL.add("whitespace/expressions:18  generic list literal");
     KNOWN_TO_FAIL.add("whitespace/expressions:22");
     KNOWN_TO_FAIL.add("whitespace/expressions:27  empty map literal (dartbug.com/16382)");
     KNOWN_TO_FAIL.add("whitespace/expressions:35  generic map literal");
     KNOWN_TO_FAIL.add("whitespace/expressions:47  long string literal");
-    KNOWN_TO_FAIL.add("whitespace/expressions:64  DO use a space after : in named arguments.");
     KNOWN_TO_FAIL.add("whitespace/expressions:72  sequential \"-\" operators are not joined");
     KNOWN_TO_FAIL.add("whitespace/expressions:76  a \"-\" operator before a negative integer is not joined");
     KNOWN_TO_FAIL.add("whitespace/expressions:80  a \"-\" operator before a negative floating point number is not joined");


### PR DESCRIPTION
@alexander-doroshko I didn't have your latest changes to DartStyleTest when I made the other pull request. Since the changes to spacing already cause some dart_style tests to pass I need to update that. Here you are!