### PR TITLE
More work on Dart formatting.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -5,6 +5,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.intellij.psi.formatter.FormatterUtil;
 import com.intellij.psi.tree.IElementType;
 import com.jetbrains.lang.dart.util.UsefulPsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
@@ -101,6 +102,13 @@ public class DartIndentProcessor {
     if (parentType == ARGUMENTS && elementType == ARGUMENT_LIST) {
       return Indent.getContinuationIndent();
     }
+    if (parentType == ARGUMENT_LIST) {
+      // TODO In order to handle some dart_style examples we need to set indent for each arg.
+      // However, it conflicts with the previous statement, causing too much indent.
+      // Removing the previous statement in favor of this one is actually a
+      // net win, but breaks existing tests.
+      //return Indent.getContinuationIndent();
+    }
     if (parentType == FORMAL_PARAMETER_LIST) {
       return Indent.getContinuationIndent();
     }
@@ -140,7 +148,23 @@ public class DartIndentProcessor {
     if (parentType == TERNARY_EXPRESSION && elementType == QUEST || elementType == COLON) {
       return Indent.getContinuationIndent();
     }
-    return Indent.getNoneIndent();
+    if (elementType == NAMED_ARGUMENT) {
+      return Indent.getContinuationIndent();
+    }
+    if (elementType == HIDE_COMBINATOR || elementType == SHOW_COMBINATOR) {
+      return Indent.getContinuationIndent();
+    }
+    if (parentType == FUNCTION_BODY) {
+      if (FormatterUtil.isPrecededBy(node, EXPRESSION_BODY_DEF)) {
+        return Indent.getContinuationIndent();
+      }
+    }
+    if (elementType == CALL_EXPRESSION) {
+      if (FormatterUtil.isPrecededBy(node, EXPRESSION_BODY_DEF)) {
+        return Indent.getContinuationIndent();
+      }
+    }
+      return Indent.getNoneIndent();
   }
 
   private static boolean isBetweenBraces(@NotNull final ASTNode node) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
@@ -17,7 +17,7 @@ public class DartSpacingProcessor {
   private static final TokenSet TOKENS_WITH_SPACE_AFTER = TokenSet
     .create(VAR, FINAL, STATIC, EXTERNAL, ABSTRACT, GET, SET, FACTORY, OPERATOR, PART, EXPORT, DEFERRED, AS, SHOW, HIDE, RETURN_TYPE);
 
-  private static final TokenSet KEYWORDS_WITH_SPACE_BEFORE = TokenSet.create(GET, SET, EXTENDS, IMPLEMENTS, DEFERRED, AS);
+  private static final TokenSet KEYWORDS_WITH_SPACE_BEFORE = TokenSet.create(GET, SET, EXTENDS, IMPLEMENTS, DEFERRED, AS, SHOW_COMBINATOR, HIDE_COMBINATOR);
 
   private static final TokenSet CASCADE_REFERENCE_EXPRESSION_SET = TokenSet.create(CASCADE_REFERENCE_EXPRESSION);
   private static final TokenSet REFERENCE_EXPRESSION_SET = TokenSet.create(REFERENCE_EXPRESSION);
@@ -376,7 +376,7 @@ public class DartSpacingProcessor {
           return Spacing.createSpacing(0, 0, 0, mySettings.KEEP_LINE_BREAKS, mySettings.KEEP_BLANK_LINES_IN_CODE);
         }
       }
-      else if (type1 == REFERENCE_EXPRESSION) {
+      else if (type1 == REFERENCE_EXPRESSION || isSimpleLiteral(type1)) {
         CompositeElement elem = (CompositeElement)myNode;
         ASTNode[] childs = elem.getChildren(CASCADE_REFERENCE_EXPRESSION_SET);
         if (childs.length == 1 || allCascadesAreSameMethod(childs)) {
@@ -512,5 +512,10 @@ public class DartSpacingProcessor {
     String op1 = node1.getText();
     String op2 = node2.getText();
     return op1.endsWith(op2.substring(op2.length() - 1));
+  }
+
+  private static boolean isSimpleLiteral(IElementType node) {
+    // Literals that can be cascade receivers, excluding map and list.
+    return node == STRING_LITERAL_EXPRESSION || node == NUMBER || node == TRUE || node == FALSE || node == NULL || node == THIS;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartWrappingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartWrappingProcessor.java
@@ -38,9 +38,10 @@ public class DartWrappingProcessor {
           return createWrap(true); // Allow first arg to wrap.
         }
         if (!mySettings.PREFER_PARAMETERS_WRAP && childWrap != null) {
+          // Not used; PREFER_PARAMETERS_WRAP cannot be changed in the UI.
           return Wrap.createChildWrap(childWrap, WrappingUtil.getWrapType(mySettings.CALL_PARAMETERS_WRAP), true);
         }
-        return Wrap.createWrap(WrappingUtil.getWrapType(mySettings.CALL_PARAMETERS_WRAP), true);
+        return Wrap.createWrap(WrappingUtil.getWrapType(mySettings.CALL_PARAMETERS_WRAP), false);
       }
     }
 
@@ -56,7 +57,18 @@ public class DartWrappingProcessor {
       }
     }
 
-    if (elementType == CALL_EXPRESSION) {
+    //
+    // Wrap after arrows.
+    //
+    if (elementType == FUNCTION_BODY) {
+      if (FormatterUtil.isPrecededBy(child, EXPRESSION_BODY_DEF)) {
+        return createWrap(true);
+      }
+    }
+    if (childType == CALL_EXPRESSION) {
+      if (FormatterUtil.isPrecededBy(child, EXPRESSION_BODY_DEF)) {
+        return createWrap(true);
+      }
       if (mySettings.CALL_PARAMETERS_WRAP != CommonCodeStyleSettings.DO_NOT_WRAP) {
         if (childType == RPAREN) {
           return createWrap(mySettings.CALL_PARAMETERS_RPAREN_ON_NEXT_LINE);
@@ -116,6 +128,11 @@ public class DartWrappingProcessor {
       }
       return Wrap.createWrap(WrapType.NONE, true);
     }
+
+    if (childType == HIDE_COMBINATOR || childType == SHOW_COMBINATOR) {
+      return createWrap(true);
+    }
+
     return defaultWrap;
   }
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -46,18 +46,12 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/expressions.stmt:97  conditional operands are nested");
     KNOWN_TO_FAIL.add("splitting/expressions.stmt:107  index expressions can split after \"[\"");
     KNOWN_TO_FAIL.add("splitting/expressions.stmt:112  index arguments nest");
-    KNOWN_TO_FAIL.add("splitting/exports.unit:6  export keeps shows on one line");
-    KNOWN_TO_FAIL.add("splitting/exports.unit:10  export moves all shows to next line");
     KNOWN_TO_FAIL.add("splitting/exports.unit:15  export moves all shows each to their own line");
-    KNOWN_TO_FAIL.add("splitting/exports.unit:27  export keeps hides on one line");
-    KNOWN_TO_FAIL.add("splitting/exports.unit:31  export moves hides to next line");
     KNOWN_TO_FAIL.add("splitting/exports.unit:36  export moves hides each to their own line");
-    KNOWN_TO_FAIL.add("splitting/exports.unit:48  single line both");
     KNOWN_TO_FAIL.add("splitting/exports.unit:52  multiline first");
     KNOWN_TO_FAIL.add("splitting/exports.unit:64  multiline second");
     KNOWN_TO_FAIL.add("splitting/exports.unit:76  multiline both");
     KNOWN_TO_FAIL.add("splitting/exports.unit:94  multiline both");
-    KNOWN_TO_FAIL.add("splitting/exports.unit:112  double line both");
     KNOWN_TO_FAIL.add("splitting/exports.unit:118  force both keywords to split even if first would fit on first line");
     KNOWN_TO_FAIL.add("splitting/exports.unit:124  force split in list");
     KNOWN_TO_FAIL.add("whitespace/for.stmt:2  DO place spaces around in, and after each ; in a loop.");
@@ -126,9 +120,7 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("comments/statements.stmt:14  continue with line comment");
     KNOWN_TO_FAIL.add("comments/statements.stmt:32  do with line comment");
     KNOWN_TO_FAIL.add("regression/25.stmt:1");
-    KNOWN_TO_FAIL.add("regression/25.stmt:7  (indent 8)");
     KNOWN_TO_FAIL.add("regression/25.stmt:13  (indent 8)");
-    KNOWN_TO_FAIL.add("regression/25.stmt:19  (indent 2)");
     KNOWN_TO_FAIL.add("whitespace/do.stmt:2  empty");
     KNOWN_TO_FAIL.add("whitespace/if.stmt:2  indentation");
     KNOWN_TO_FAIL.add("whitespace/if.stmt:34  single-expression then body");
@@ -205,7 +197,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("comments/functions.unit:106  before \"}\" in param list");
     KNOWN_TO_FAIL.add("comments/functions.unit:110  after \"{\" in param list");
     KNOWN_TO_FAIL.add("comments/functions.unit:114");
-    KNOWN_TO_FAIL.add("splitting/members.unit:2  prefers to wrap at => before params");
     KNOWN_TO_FAIL.add("whitespace/methods.unit:2");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:12  initializer doesn't fit one line, wrap inside, keep name");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:17  initializer fits one line");
@@ -216,7 +207,7 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/variables.stmt:44  multiple variables get their own line if any has an initializer #16849");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:49");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:58  dartbug.com/16379");
-    KNOWN_TO_FAIL.add("whitespace/cascades.stmt:2  single cascades on same line");
+    KNOWN_TO_FAIL.add("whitespace/cascades.stmt:6  long single cascade forces multi-line");
     KNOWN_TO_FAIL.add("whitespace/cascades.stmt:30  cascades indent contained blocks (and force multi-line)");
     KNOWN_TO_FAIL.add("comments/top_level.unit:8");
     KNOWN_TO_FAIL.add("comments/top_level.unit:17");
@@ -245,8 +236,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/assignments.stmt:24  initializer doesn't fit one line, cannot be split");
     KNOWN_TO_FAIL.add("splitting/assignments.stmt:29  long function call initializer");
     KNOWN_TO_FAIL.add("splitting/assignments.stmt:34  long binary expression initializer");
-    KNOWN_TO_FAIL.add("splitting/arrows.stmt:2  do not split after \"(\"");
-    KNOWN_TO_FAIL.add("splitting/arrows.unit:2");
     KNOWN_TO_FAIL.add("whitespace/blocks.stmt:10  allow an extra newline between statements");
     KNOWN_TO_FAIL.add("whitespace/blocks.stmt:24  collapse any other newlines");
     KNOWN_TO_FAIL.add("splitting/statements.stmt:6  wrapped assert");
@@ -278,22 +267,15 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/lists.stmt:62  dangling comma multiline");
     KNOWN_TO_FAIL.add("splitting/lists.stmt:73  nested lists are forced to split");
     KNOWN_TO_FAIL.add("splitting/imports.unit:6  wrap import at as");
-    KNOWN_TO_FAIL.add("splitting/imports.unit:11  import keeps shows on one line");
-    KNOWN_TO_FAIL.add("splitting/imports.unit:15  import moves all shows to next line");
     KNOWN_TO_FAIL.add("splitting/imports.unit:20  import moves all shows each to their own line");
-    KNOWN_TO_FAIL.add("splitting/imports.unit:32  import keeps hides on one line");
-    KNOWN_TO_FAIL.add("splitting/imports.unit:36  import moves hides to next line");
     KNOWN_TO_FAIL.add("splitting/imports.unit:41  import moves hides each to their own line");
-    KNOWN_TO_FAIL.add("splitting/imports.unit:53  single line both");
     KNOWN_TO_FAIL.add("splitting/imports.unit:57  multiline first");
     KNOWN_TO_FAIL.add("splitting/imports.unit:69  multiline second");
     KNOWN_TO_FAIL.add("splitting/imports.unit:81  multiline both");
     KNOWN_TO_FAIL.add("splitting/imports.unit:99  multiline both");
-    KNOWN_TO_FAIL.add("splitting/imports.unit:117  double line both");
     KNOWN_TO_FAIL.add("splitting/imports.unit:123  force both keywords to split even if first would fit on first line");
     KNOWN_TO_FAIL.add("splitting/imports.unit:129  force split in list");
     KNOWN_TO_FAIL.add("splitting/mixed.stmt:7  prefers to wrap before \".\"");
-    KNOWN_TO_FAIL.add("splitting/mixed.stmt:14");
     KNOWN_TO_FAIL.add("splitting/mixed.stmt:19  nested expression indentation");
     KNOWN_TO_FAIL.add("splitting/mixed.stmt:26  does not extra indent when multiple levels of nesting happen on one line");
     KNOWN_TO_FAIL.add("splitting/mixed.stmt:33  forces extra indent and lines, if later line needs it");
@@ -384,7 +366,7 @@ public class DartStyleTest extends FormatterTestCase {
     runTestInDirectory("comments");
   }
 
-  @Bombed(year = 2015, month = Calendar.NOVEMBER, day = 12, user = "alexander.doroshko",
+  @Bombed(year = 2015, month = Calendar.MAY, day = 12, user = "alexander.doroshko",
     description = "The test behaves completely different on build server compared to local run")
   public void testSelections() throws Exception {
     runTestInDirectory("selections");
@@ -549,7 +531,7 @@ public class DartStyleTest extends FormatterTestCase {
    * Run a test defined in "*.unit" or "*.stmt" file inside directory <code>dirName</code>.
    */
   private void runTestInDirectory(String dirName) throws Exception {
-    Pattern indentPattern = Pattern.compile("^\\(indent (\\d+)\\)\\s*");
+    Pattern indentPattern = Pattern.compile("^.*\\s\\(indent (\\d+)\\)\\s*");
 
     String testName = getTestName(true);
     if (Character.isLetter(testName.charAt(0)) && Character.isDigit(testName.charAt(testName.length() - 1))) {
@@ -583,7 +565,7 @@ public class DartStyleTest extends FormatterTestCase {
         i = 1;
       }
 
-      System.out.println("\nTest: " + dirName + "/" + testFileName + ext + ", Right margin: " + pageWidth);
+      System.out.println("\nTest: " + dirName + "/" + testFileName + ", Right margin: " + pageWidth);
       final CommonCodeStyleSettings settings = getSettings(DartLanguage.INSTANCE);
       settings.RIGHT_MARGIN = pageWidth;
       settings.KEEP_LINE_BREAKS = false; // TODO Decide whether this should be the default -- risky!
@@ -599,13 +581,13 @@ public class DartStyleTest extends FormatterTestCase {
         if (matcher.matches()) {
           // The leadingIndent is only used by some tests in 'regression'.
           leadingIndent = Integer.parseInt(matcher.group(1));
-          description = description.substring(matcher.end());
+          settings.RIGHT_MARGIN = pageWidth - leadingIndent;
         }
 
         String input = "";
         // If the input isn't a top-level form, wrap everything in a function.
         // The formatter fails horribly otherwise.
-        if (!isCompilationUnit) input += "m() {\n";
+        if (!isCompilationUnit)  input += "m() {\n";
 
         while (!lines[i].startsWith("<<<")) {
           String line = lines[i++];


### PR DESCRIPTION
@alexander-doroshko There's a problem with wrapping and indenting arguments. I left a TODO in DartIndentProcessor explaining what's going on, but I don't know how to fix it yet. Having more context in the indenter, like the wrapper has with childWrap, might help.

One dart_style test that previously was "passing" no longer is. In fact, it was passing because the cascade wrapping logic was incorrect. I'm still not convinced cascade receivers are being handled correctly, but it is certainly better (as in: more tests pass).

DartStyleTest itself had some issues with the tests in 'regression'. Fixing that also caused more tests to pass, which is nice.