### PR TITLE
More Dart formatter work.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -164,6 +164,9 @@ public class DartIndentProcessor {
         return Indent.getContinuationIndent();
       }
     }
+    if (elementType == VAR_DECLARATION_LIST_PART) {
+      return Indent.getContinuationIndent();
+    }
     return Indent.getNoneIndent();
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
@@ -97,6 +97,8 @@ public class DartSpacingProcessor {
           lineFeeds = 0;
         } else if (parentType == WHILE_STATEMENT && mySettings.KEEP_SIMPLE_BLOCKS_IN_ONE_LINE) {
           lineFeeds = 0;
+        } else if (parentType == DO_WHILE_STATEMENT && mySettings.KEEP_SIMPLE_BLOCKS_IN_ONE_LINE) {
+          lineFeeds = 0;
         } else if (parentType == TRY_STATEMENT && mySettings.KEEP_SIMPLE_BLOCKS_IN_ONE_LINE) {
           lineFeeds = 0;
         } else if (parentType == FINALLY_PART && mySettings.KEEP_SIMPLE_BLOCKS_IN_ONE_LINE) {
@@ -375,7 +377,7 @@ public class DartSpacingProcessor {
     }
 
     if (type1 == COMMA) {
-      return addSingleSpaceIf(mySettings.SPACE_AFTER_COMMA);
+      return addSingleSpaceIf(mySettings.SPACE_AFTER_COMMA && type2 != RBRACE);
     }
 
     if (type2 == COMMA) {
@@ -471,6 +473,10 @@ public class DartSpacingProcessor {
     }
     if (type1 == TYPE_ARGUMENTS && (type2 == LBRACKET || type2 == LBRACE)) {
       return noSpace(); // Might want a user setting to control space before/after type
+    }
+
+    if (type2 == RBRACE && type1 == MAP_LITERAL_ENTRY) {
+      return  noSpace();
     }
 
     return Spacing.createSpacing(0, 1, 0, mySettings.KEEP_LINE_BREAKS, mySettings.KEEP_BLANK_LINES_IN_CODE);

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartWrappingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartWrappingProcessor.java
@@ -133,6 +133,26 @@ public class DartWrappingProcessor {
       return createWrap(true);
     }
 
+    if (childType == VAR_DECLARATION_LIST && elementType != FOR_LOOP_PARTS) {
+      if (varDeclListContainsVarInit(child)) {
+        return Wrap.createWrap(WrapType.ALWAYS, true);
+      } else {
+        return Wrap.createWrap(WrapType.CHOP_DOWN_IF_LONG, true);
+      }
+    }
+    if (childType == VAR_DECLARATION_LIST_PART) {
+      ASTNode parent = myNode.getTreeParent();
+      if (parent != null && parent.getElementType() == FOR_LOOP_PARTS) {
+        return Wrap.createWrap(WrapType.NORMAL, true);
+      } else {
+        if (varDeclListContainsVarInit(myNode)) {
+          return Wrap.createWrap(WrapType.ALWAYS, true);
+        } else {
+          return Wrap.createWrap(WrapType.CHOP_DOWN_IF_LONG, true);
+        }
+      }
+    }
+
     return defaultWrap;
   }
 
@@ -161,5 +181,15 @@ public class DartWrappingProcessor {
       return Wrap.createWrap(WrapType.ALWAYS, true);
     }
     return Wrap.createWrap(WrapType.NONE, true);
+  }
+
+  private static boolean varDeclListContainsVarInit(ASTNode decl) {
+    if (decl.findChildByType(VAR_INIT) != null) return true;
+    ASTNode child = decl.getFirstChildNode();
+    while (child != null) {
+      if (child.findChildByType(VAR_INIT) != null) return true;
+      child = child.getTreeNext();
+    }
+    return false;
   }
 }

--- a/Dart/testData/formatter/EmptyBlocks.dart
+++ b/Dart/testData/formatter/EmptyBlocks.dart
@@ -9,6 +9,7 @@ f(){
   try{}catch(e){}finally{}
   var l=[];
   var m={};
+  do{}while(x);
 }
 class Q{
   m(){

--- a/Dart/testData/formatter/EmptyBlocks_after.dart
+++ b/Dart/testData/formatter/EmptyBlocks_after.dart
@@ -14,6 +14,7 @@ f() {
   try {} catch (e) {} finally {}
   var l = [];
   var m = {};
+  do {} while (x);
 }
 
 class Q {

--- a/Dart/testData/formatter/VarDecl.dart
+++ b/Dart/testData/formatter/VarDecl.dart
@@ -1,0 +1,5 @@
+var longVariableNameOne, longVariableNameTwo, longVariableNameThree, longVariableNameFour;
+var uksi, kaksi, kolme, nelja;
+var ichi=1,ni=2,san=3,yon=4;
+var eins, zwei, drei, vier=4;
+var un=1, deux, trois, quatre;

--- a/Dart/testData/formatter/VarDecl_after.dart
+++ b/Dart/testData/formatter/VarDecl_after.dart
@@ -1,0 +1,17 @@
+var longVariableNameOne,
+    longVariableNameTwo,
+    longVariableNameThree,
+    longVariableNameFour;
+var uksi, kaksi, kolme, nelja;
+var ichi = 1,
+    ni = 2,
+    san = 3,
+    yon = 4;
+var eins,
+    zwei,
+    drei,
+    vier = 4;
+var un = 1,
+    deux,
+    trois,
+    quatre;

--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -83,16 +83,13 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/loops.stmt:52  split in for-in loop");
     KNOWN_TO_FAIL.add("splitting/loops.stmt:57  split in while condition");
     KNOWN_TO_FAIL.add("splitting/maps.stmt:10");
-    KNOWN_TO_FAIL.add("splitting/maps.stmt:18  nested unsplit map");
     KNOWN_TO_FAIL.add("splitting/maps.stmt:23  nested split map");
     KNOWN_TO_FAIL.add("splitting/maps.stmt:37  force multi-line because of contained block");
     KNOWN_TO_FAIL.add("splitting/maps.stmt:47  containing comments");
     KNOWN_TO_FAIL.add("splitting/maps.stmt:54  const");
-    KNOWN_TO_FAIL.add("splitting/maps.stmt:61  dangling comma");
     KNOWN_TO_FAIL.add("splitting/maps.stmt:65  dangling comma multiline");
     KNOWN_TO_FAIL.add("comments/mixed.unit:2  block comment");
     KNOWN_TO_FAIL.add("comments/mixed.unit:32  mixed doc and line comments");
-    KNOWN_TO_FAIL.add("comments/mixed.unit:48  mixed comments");
     KNOWN_TO_FAIL.add("comments/maps.stmt:10  line comment on opening line");
     KNOWN_TO_FAIL.add("comments/maps.stmt:25  block comment with trailing newline");
     KNOWN_TO_FAIL.add("comments/maps.stmt:39  inline block comment");
@@ -113,7 +110,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("comments/statements.stmt:32  do with line comment");
     KNOWN_TO_FAIL.add("regression/25.stmt:1");
     KNOWN_TO_FAIL.add("regression/25.stmt:13  (indent 8)");
-    KNOWN_TO_FAIL.add("whitespace/do.stmt:2  empty");
     KNOWN_TO_FAIL.add("whitespace/if.stmt:2  indentation");
     KNOWN_TO_FAIL.add("whitespace/if.stmt:34  single-expression then body");
     KNOWN_TO_FAIL.add("whitespace/if.stmt:44  single-expression else body");
@@ -125,7 +121,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("whitespace/functions.unit:63  DO use a spaces around = in optional positional parameters.");
     KNOWN_TO_FAIL.add("whitespace/functions.unit:67  async*");
     KNOWN_TO_FAIL.add("whitespace/functions.unit:73  sync* functions");
-    KNOWN_TO_FAIL.add("whitespace/directives.unit:18  collapse any other newlines");
     KNOWN_TO_FAIL.add("whitespace/directives.unit:49  no spaces between library identifiers");
     KNOWN_TO_FAIL.add("comments/expressions.stmt:2  trailing line comment after split");
     KNOWN_TO_FAIL.add("comments/expressions.stmt:9  trailing line comment after non-split");
@@ -133,7 +128,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("comments/expressions.stmt:23  inside argument list");
     KNOWN_TO_FAIL.add("comments/expressions.stmt:31  space on left between block comment and \",\"");
     KNOWN_TO_FAIL.add("comments/expressions.stmt:35  space between block comment and other tokens");
-    KNOWN_TO_FAIL.add("comments/expressions.stmt:39  preserve space before comment in expression");
     KNOWN_TO_FAIL.add("comments/expressions.stmt:61  hard line caused by a comment before a nested line");
     KNOWN_TO_FAIL.add("splitting/parameters.stmt:2  parameters fit but ) does not");
     KNOWN_TO_FAIL.add("splitting/parameters.stmt:11  parameters fit but } does not");
@@ -182,8 +176,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/variables.stmt:27  long function call initializer");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:32  long binary expression initializer");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:37  lots of variables with no initializers");
-    KNOWN_TO_FAIL.add("splitting/variables.stmt:44  multiple variables get their own line if any has an initializer #16849");
-    KNOWN_TO_FAIL.add("splitting/variables.stmt:49");
     KNOWN_TO_FAIL.add("splitting/variables.stmt:58  dartbug.com/16379");
     KNOWN_TO_FAIL.add("whitespace/cascades.stmt:6  long single cascade forces multi-line");
     KNOWN_TO_FAIL.add("whitespace/cascades.stmt:30  cascades indent contained blocks (and force multi-line)");
@@ -209,7 +201,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/assignments.stmt:24  initializer doesn't fit one line, cannot be split");
     KNOWN_TO_FAIL.add("splitting/assignments.stmt:29  long function call initializer");
     KNOWN_TO_FAIL.add("splitting/assignments.stmt:34  long binary expression initializer");
-    KNOWN_TO_FAIL.add("whitespace/blocks.stmt:10  allow an extra newline between statements");
     KNOWN_TO_FAIL.add("whitespace/blocks.stmt:24  collapse any other newlines");
     KNOWN_TO_FAIL.add("splitting/statements.stmt:6  wrapped assert");
     KNOWN_TO_FAIL.add("splitting/statements.stmt:11  split in do-while condition");
@@ -262,15 +253,8 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/invocations.stmt:38  allow an inline chain before a hard newline but not after");
     KNOWN_TO_FAIL.add("splitting/invocations.stmt:49  allow an inline chain after a hard newline but not before");
     KNOWN_TO_FAIL.add("splitting/invocations.stmt:60  nest calls one more than target");
-    KNOWN_TO_FAIL.add("whitespace/script.unit:8  multiple lines between script and library");
-    KNOWN_TO_FAIL.add("whitespace/script.unit:24  multiple lines between script and import");
-    KNOWN_TO_FAIL.add("whitespace/script.unit:40  multiple lines between script and line comment");
-    KNOWN_TO_FAIL.add("whitespace/script.unit:56  multiple lines between script and block comment");
-    KNOWN_TO_FAIL.add("whitespace/switch.stmt:11  allow an extra newline between statements in a case");
     KNOWN_TO_FAIL.add("whitespace/switch.stmt:26  collapse any other newlines in a case");
-    KNOWN_TO_FAIL.add("whitespace/switch.stmt:60  allow an extra newline between statements in a default");
     KNOWN_TO_FAIL.add("whitespace/switch.stmt:75  collapse any other newlines in a default");
-    KNOWN_TO_FAIL.add("whitespace/switch.stmt:109  allow an extra newline between cases");
     KNOWN_TO_FAIL.add("whitespace/switch.stmt:123  collapse any other newlines in a case");
     KNOWN_TO_FAIL.add("selections/selections.stmt:22  includes added whitespace");
     KNOWN_TO_FAIL.add("selections/selections.stmt:26  inside comment");
@@ -286,7 +270,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("selections/selections.unit:34  in soft space split whitespace");
     KNOWN_TO_FAIL.add("selections/selections.unit:43  in hard split whitespace");
     KNOWN_TO_FAIL.add("selections/selections.unit:53  across lines that get split separately");
-    KNOWN_TO_FAIL.add("selections/selections.unit:74  only whitespace in double newline selected");
     KNOWN_TO_FAIL.add("splitting/strings.stmt:50  wrap first line if needed");
     KNOWN_TO_FAIL.add("whitespace/compilation_unit.unit:38  collapse extra newlines between declarations");
     KNOWN_TO_FAIL.add("whitespace/compilation_unit.unit:64  require at least a single newline between declarations");
@@ -531,6 +514,7 @@ public class DartStyleTest extends FormatterTestCase {
       final CommonCodeStyleSettings settings = getSettings(DartLanguage.INSTANCE);
       settings.RIGHT_MARGIN = pageWidth;
       settings.KEEP_LINE_BREAKS = false; // TODO Decide whether this should be the default -- risky!
+      settings.KEEP_BLANK_LINES_IN_CODE = 1;
 
       while (i < lines.length) {
         String description = (dirName + "/" + testFileName + ":" + (i + 1) + " " + lines[i++].replaceAll(">>>", "")).trim();
@@ -554,7 +538,7 @@ public class DartStyleTest extends FormatterTestCase {
         while (!lines[i].startsWith("<<<")) {
           String line = lines[i++];
           if (leadingIndent > 0) line = line.substring(leadingIndent);
-          if (!isCompilationUnit) line = "  " + line;
+          if (!isCompilationUnit && !line.isEmpty()) line = "  " + line;
           input += line + "\n";
         }
 
@@ -568,7 +552,7 @@ public class DartStyleTest extends FormatterTestCase {
         while (i < lines.length && !lines[i].startsWith(">>>")) {
           String line = lines[i++];
           if (leadingIndent > 0) line = line.substring(leadingIndent);
-          if (!isCompilationUnit) line = "  " + line;
+          if (!isCompilationUnit && !line.isEmpty()) line = "  " + line;
           expectedOutput += line + "\n";
         }
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/formatter/DartFormatterTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/formatter/DartFormatterTest.java
@@ -224,5 +224,10 @@ public class DartFormatterTest extends FormatterTestCase {
     settings.RIGHT_MARGIN = 40;
     //doTest();
   }
-}
 
+  public void testVarDecl() throws Exception {
+    final CommonCodeStyleSettings settings = getSettings(DartLanguage.INSTANCE);
+    settings.RIGHT_MARGIN = 40;
+    doTest();
+  }
+}


### PR DESCRIPTION
@alexander-doroshko Since dart_style expects one blank line, not two, I changed the setting in the test runner, which made a few more tests pass. Turns out that adding indentation to blank lines is also a bad idea, so I fixed that.

Variable declaration lists are getting formatted as they are supposed to now. Most of the time, anyway. I think I saw some problem when running IDEA but it didn't happen in a unit test.

Also found another empty block that wasn't being handled.

Fixed spacing prior to closing brace of map literal.