### PR TITLE
Experimenting with dependent spacing

### DIFF
--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -116,7 +116,6 @@ public class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("splitting/parameters.stmt:11  parameters fit but } does not");
     KNOWN_TO_FAIL.add("splitting/parameters.unit:11  indent parameters more if body is a wrapped =>");
     KNOWN_TO_FAIL.add("splitting/constructors.unit:35  try to keep constructor call together");
-    KNOWN_TO_FAIL.add("splitting/constructors.unit:41  splits before \":\" if the parameter list does not fit on one line");
     KNOWN_TO_FAIL.add("splitting/constructors.unit:51  indent parameters more if body is a wrapped =>");
     KNOWN_TO_FAIL.add("whitespace/metadata.unit:2  force newline before directives");
     KNOWN_TO_FAIL.add("whitespace/metadata.unit:17  force newline before types");


### PR DESCRIPTION
@alexander-doroshko This isn't a real pull request. I just want to share some code for you to look at.

I promised recently to stop wasting time on conditional operator formatting. I should have kept that promise; instead I just wasted several hours trying to use dependent spacing to get the right format. It doesn't change anything. I did try changing the three default settings, too, but that had the same result as previously.

Could you take a look at the change for TERNARY_EXPRESSION and see if there's anything obviously wrong? I suspect something to do with text ranges. I tried to be careful about getting the boundaries of a text range to match existing ranges. Also, it looked like making a forward dependency should work, but I don't know if it is supposed to (it doesn't). That would cause ' ? ... ' to be reformatted if ' : ... ' changes linefeed status.

FWIW the dependent space works great for constructors.