### PR TITLE
Null-aware operators get syntax highlighting and completion.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartTokenTypesSets.java
+++ b/Dart/src/com/jetbrains/lang/dart/DartTokenTypesSets.java
@@ -99,15 +99,16 @@ public interface DartTokenTypesSets {
   TokenSet OPERATORS = TokenSet.create(
     MINUS, MINUS_EQ, MINUS_MINUS, PLUS, PLUS_PLUS, PLUS_EQ, DIV, DIV_EQ, MUL, MUL_EQ, INT_DIV, INT_DIV_EQ, REM_EQ, REM, BIN_NOT, NOT,
     EQ, EQ_EQ, NEQ, GT, GT_EQ, GT_GT_EQ, LT, LT_EQ, LT_LT, LT_LT_EQ, OR, OR_EQ, OR_OR, XOR, XOR_EQ, AND,
-    AND_EQ, AND_AND, LBRACKET, RBRACKET, AS
+    AND_EQ, AND_AND, LBRACKET, RBRACKET, AS, QUEST_QUEST
   );
 
   TokenSet ASSIGNMENT_OPERATORS = TokenSet.create(
-    // '=' | '*=' | '/=' | '~/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '&=' | '^=' | '|='
-    EQ, MUL_EQ, DIV_EQ, INT_DIV_EQ, REM_EQ, PLUS_EQ, MINUS_EQ, LT_LT_EQ, GT_GT_EQ, AND_EQ, XOR_EQ, OR_EQ
+    // '=' | '*=' | '/=' | '~/=' | '%=' | '+=' | '-=' | '<<=' | '>>=' | '&=' | '^=' | '|=' | '??='
+    EQ, MUL_EQ, DIV_EQ, INT_DIV_EQ, REM_EQ, PLUS_EQ, MINUS_EQ, LT_LT_EQ, GT_GT_EQ, AND_EQ, XOR_EQ, OR_EQ, QUEST_QUEST_EQ
   );
 
   TokenSet BINARY_EXPRESSIONS = TokenSet.create(
+    IF_NULL_EXPRESSION,
     LOGIC_OR_EXPRESSION,
     LOGIC_AND_EXPRESSION,
     COMPARE_EXPRESSION,
@@ -117,6 +118,8 @@ public interface DartTokenTypesSets {
   );
 
   TokenSet BINARY_OPERATORS = TokenSet.create(
+    // '??
+    QUEST_QUEST,
     // '&&' '||'
     AND_AND, OR_OR,
     // '==' '!='

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -29,7 +29,6 @@ import com.intellij.openapi.fileEditor.FileEditorManagerAdapter;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Ref;
@@ -897,9 +896,9 @@ public class DartAnalysisServerService {
         final boolean ok = runInPooledThreadAndWait(new Runnable() {
           @Override
           public void run() {
-            server.analysis_updateOptions(new AnalysisOptions(true, true, true, false /*true*/, false, true, false));
+            server.analysis_updateOptions(new AnalysisOptions(true, true, true, true, false, true, false));
           }
-        }, "analysis_updateOptions(true, true, true, false, false, true, false)", SEND_REQUEST_TIMEOUT);
+        }, "analysis_updateOptions(true, true, true, true, false, true, false)", SEND_REQUEST_TIMEOUT);
 
         if (!ok) {
           stopServer();

--- a/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighter.java
+++ b/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighter.java
@@ -48,6 +48,7 @@ public class DartSyntaxHighlighter extends SyntaxHighlighterBase {
     ATTRIBUTES.put(COMMA, DartSyntaxHighlighterColors.COMMA);
     ATTRIBUTES.put(DOT, DartSyntaxHighlighterColors.DOT);
     ATTRIBUTES.put(DOT_DOT, DartSyntaxHighlighterColors.DOT);
+    ATTRIBUTES.put(QUEST_DOT, DartSyntaxHighlighterColors.DOT);
     ATTRIBUTES.put(SEMICOLON, DartSyntaxHighlighterColors.SEMICOLON);
 
     ATTRIBUTES.put(SINGLE_LINE_COMMENT, DartSyntaxHighlighterColors.LINE_COMMENT);

--- a/Dart/src/com/jetbrains/lang/dart/lexer/Dart.flex
+++ b/Dart/src/com/jetbrains/lang/dart/lexer/Dart.flex
@@ -247,7 +247,6 @@ HEX_NUMBER = 0 [Xx] {HEX_DIGIT}*
 <YYINITIAL, LONG_TEMPLATE_ENTRY> "&&"               { return AND_AND; }
 <YYINITIAL, LONG_TEMPLATE_ENTRY> "@"                { return AT; }
 <YYINITIAL, LONG_TEMPLATE_ENTRY> "#"                { return HASH; }
-<YYINITIAL, LONG_TEMPLATE_ENTRY> "?."               { return QUEST_DOT; }
 
 <YYINITIAL, LONG_TEMPLATE_ENTRY> {NUMERIC_LITERAL} { return NUMBER; }
 

--- a/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
@@ -458,8 +458,11 @@ public class DartResolveUtil {
     for (PsiElement sibling = UsefulPsiTreeUtil.getPrevSiblingSkipWhiteSpacesAndComments(node, true);
          sibling != null;
          sibling = UsefulPsiTreeUtil.getPrevSiblingSkipWhiteSpacesAndComments(sibling, true)) {
-      if (".".equals(sibling.getText())) continue;
-      if ("..".equals(sibling.getText())) continue;
+      String siblingText = sibling.getText();
+      // String.equals() is fast so use it instead of trying to optimize this.
+      if (".".equals(siblingText)) continue;
+      if ("..".equals(siblingText)) continue;
+      if ("?.".equals(siblingText)) continue;
       PsiElement candidate = sibling;
       if (candidate instanceof DartType) {
         candidate = ((DartType)sibling).getReferenceExpression();

--- a/Dart/testData/completion/references/NonNullRef.dart
+++ b/Dart/testData/completion/references/NonNullRef.dart
@@ -1,0 +1,13 @@
+class Reference{
+  Bar getBar(){
+    return new BarImpl();
+  }
+  main(){
+    getBar()?.te<caret>;
+  }
+}
+
+class Bar {
+  test1();
+  test2();
+}

--- a/Dart/testData/completion/references/NonNullRef.txt
+++ b/Dart/testData/completion/references/NonNullRef.txt
@@ -1,0 +1,3 @@
+BASIC 1 INCLUDES
+test1
+test2

--- a/Dart/testSrc/com/jetbrains/lang/dart/completion/reference/DartReferenceCompletionInLibraryRootTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/completion/reference/DartReferenceCompletionInLibraryRootTest.java
@@ -54,6 +54,10 @@ public class DartReferenceCompletionInLibraryRootTest extends DartCompletionTest
     doTest();
   }
 
+  public void testNonNullRef() throws Throwable {
+    doTest();
+  }
+
   public void testPackages1() throws Throwable {
     myFixture.addFileToProject("pubspec.yaml", "");
     myFixture.addFileToProject("packages/foo/foo.dart", "");


### PR DESCRIPTION
@alexander-doroshko I think this completes support for [DEP 0009]
(https://github.com/dart-lang/dart_enhancement_proposals/blob/master/Accepted/0009%20-%20Null-aware%20Operators/proposal.md)

* Address previous review comments.
* Enable null-aware operator parsing.
* Add syntax highlighting: ??= assignment, ?? operator, ?. message/dot.
* Clean up completion for elvis operator.