### PR TITLE
Invocation completion improvements - parenthesis, identifier.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -259,19 +259,15 @@ public class DartAnalysisServerService {
       ProgressManager.checkCanceled();
 
       synchronized (myCompletionInfos) {
-        // todo in case of several AnalysisServerListenerAdapter.computedCompletion() invocations for one completion (only the last
-        // invocation has isLast==true) it looks like each next List<CompletionSuggestion> also contains all items that were already
-        // given in previous invocations. If it is by design we should optimize cycle and handle only the last in queue.
-
         CompletionInfo completionInfo;
         while ((completionInfo = myCompletionInfos.poll()) != null) {
           if (!completionInfo.myCompletionId.equals(completionId)) continue;
+          if (!completionInfo.isLast) continue;
 
           for (final CompletionSuggestion completion : completionInfo.myCompletions) {
             consumer.consume(completion);
           }
-
-          if (completionInfo.isLast) return;
+          return;
         }
 
         try {


### PR DESCRIPTION
Fixes for https://github.com/JetBrains/intellij-plugins/pull/228 review comments.

1. Use ParenthesesInsertHandler to reuse the same logic as Java uses.

2. Check whether suggestion's kind is INVOCATION, for import directives IDENTIFIER is returned, so we know when we should not insert arguments.

3. The same INVOCATION / IDENTIFIER works also for using functions as arguments, but we need to wait for isLast suggestions notification.