### PR TITLE
WEB-17605. Use selection offset / length from CompletionSuggestion.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -88,6 +88,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
       lookup = lookup.bold();
     }
 
+    boolean shouldSetSelection = true;
     if (element != null) {
       // @deprecated
       if (element.isDeprecated()) {
@@ -118,6 +119,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
       }
       // Prepare for typing arguments, if any.
       if (CompletionSuggestionKind.INVOCATION.equals(suggestion.getKind())) {
+        shouldSetSelection = false;
         final List<String> parameterNames = suggestion.getParameterNames();
         if (parameterNames != null) {
           lookup = lookup.withInsertHandler(new InsertHandler<LookupElement>() {
@@ -138,6 +140,21 @@ public class DartServerCompletionContributor extends CompletionContributor {
         }
       }
     }
+
+    // Use selection offset / length.
+    if (shouldSetSelection) {
+      lookup = lookup.withInsertHandler(new InsertHandler<LookupElement>() {
+        @Override
+        public void handleInsert(InsertionContext context, LookupElement item) {
+          final Editor editor = context.getEditor();
+          final int startOffset = context.getStartOffset() + suggestion.getSelectionOffset();
+          final int endOffset = startOffset + suggestion.getSelectionLength();
+          editor.getCaretModel().moveToOffset(startOffset);
+          editor.getSelectionModel().setSelection(startOffset, endOffset);
+        }
+      });
+    }
+
     return lookup;
   }
 


### PR DESCRIPTION
It seems to me that ideally we should remove these "for ()", "import as " completions and replace them with Live Templates. We need to provide contexts thought in order to not suggest using "import" inside method bodies :-)