### PR TITLE
Fix a broken test and update tests to ignore selection.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
@@ -571,6 +571,11 @@ public class DartSpacingProcessor {
         return addLineBreak();
       }
       if (type2 == ARGUMENT_LIST) {
+        if (type1 == MULTI_LINE_COMMENT && isEmbeddedComment(type1, child1)) {
+          if (!hasNewlineInText(node1)) {
+            return addSingleSpaceIf(true);
+          }
+        }
         return addLineBreak();
       }
     }
@@ -1083,6 +1088,11 @@ public class DartSpacingProcessor {
       child = FormatterUtil.getPreviousNonWhitespaceSibling(child);
       return child != null && child.getElementType() == LBRACE;
     }
+  }
+
+  private static boolean hasNewlineInText(ASTNode node) {
+    String comment = node.getText();
+    return comment.indexOf('\n') > 0;
   }
 
   private static boolean isBlankLineAfterComment(ASTNode node) {

--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleStrictTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleStrictTest.java
@@ -32,20 +32,6 @@ public class DartStyleStrictTest extends DartStyleTest {
     KNOWN_TO_FAIL_STRICT.add("regression/0100/0177.stmt:1");
     KNOWN_TO_FAIL_STRICT.add("regression/0200/0201.stmt:1");
 
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:22  includes added whitespace");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:30  in beginning of multi-line string literal");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:36  in middle of multi-line string literal");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:46  in end of multi-line string literal");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:52  in string interpolation");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:56  in moved comment");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:66  after comments");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.stmt:70  between adjacent comments");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.unit:13  trailing comment");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.unit:23  in zero split whitespace");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.unit:34  in soft space split whitespace");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.unit:43  in hard split whitespace");
-    KNOWN_TO_FAIL_STRICT.add("selections/selections.unit:54  across lines that get split separately");
-
     KNOWN_TO_FAIL_STRICT.add("splitting/maps.stmt:35  empty literal does not force outer split");
     KNOWN_TO_FAIL_STRICT.add("splitting/expressions.stmt:13  adjacent string lines all split together;");
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -1,6 +1,5 @@
 package com.jetbrains.lang.dart.dart_style;
 
-import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.psi.formatter.FormatterTestCase;
@@ -214,8 +213,6 @@ public abstract class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("regression/other/dart2js.unit:1  (indent 4) preemption follows constraints");
     KNOWN_TO_FAIL.add("regression/other/pub.stmt:1  (indent 6)");
     KNOWN_TO_FAIL.add("regression/other/pub.stmt:22  (indent 4) was slow");
-
-    KNOWN_TO_FAIL.add("selections/selections.stmt:26  inside comment");
 
     KNOWN_TO_FAIL.add("splitting/arguments.stmt:105  if split before first positional, split before first named too");
     KNOWN_TO_FAIL.add("splitting/arguments.stmt:112  if split before other positional, split before first named too");
@@ -1359,8 +1356,6 @@ public abstract class DartStyleTest extends FormatterTestCase {
 
         SourceCode inputCode = extractSourceSelection(input, expectedOutput, isCompilationUnit);
         SourceCode expected = extractSelection(expectedOutput, isCompilationUnit);
-
-        myTextRange = new TextRange(inputCode.selectionStart, inputCode.selectionEnd());
 
         try {
           doTextTest(inputCode.text, expected.text);


### PR DESCRIPTION
@denofevil @alexander-doroshko  The Dart formatter always formats everything. The purpose of the selection is to ensure that the (single, I think) selection is preserved after formatting. I updated the tests accordingly. Also, added a little code to fix a test case that used to work before I started trying to improve other things.