### PR TITLE
Improve Dart string wrapping

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -44,6 +44,8 @@
     <lang.parserDefinition language="Dart" implementationClass="com.jetbrains.lang.dart.DartParserDefinition"/>
 
     <enterHandlerDelegate implementation="com.jetbrains.lang.dart.ide.editor.DartEnterInDocLineCommentHandler"/>
+    <enterHandlerDelegate implementation="com.jetbrains.lang.dart.ide.editor.DartEnterInStringHandler" order="first"/>
+    <lang.lineWrapStrategy language="Dart" implementationClass="com.jetbrains.lang.dart.ide.editor.DartLineWrapPositionStrategy"/>
 
     <languageInjector implementation="com.jetbrains.lang.dart.psi.DartLanguageInjector"/>
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/editor/DartEnterInStringHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/editor/DartEnterInStringHandler.java
@@ -1,0 +1,56 @@
+package com.jetbrains.lang.dart.ide.editor;
+
+import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegateAdapter;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
+import com.intellij.openapi.util.Ref;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import com.jetbrains.lang.dart.DartTokenTypes;
+import org.jetbrains.annotations.NotNull;
+
+public class DartEnterInStringHandler extends EnterHandlerDelegateAdapter {
+
+  @Override
+  public Result preprocessEnter(@NotNull final PsiFile file,
+                                @NotNull final Editor editor,
+                                @NotNull final Ref<Integer> caretOffsetRef,
+                                @NotNull final Ref<Integer> caretAdvanceRef,
+                                @NotNull final DataContext dataContext,
+                                final EditorActionHandler originalHandler) {
+    int caretOffset = caretOffsetRef.get().intValue();
+    int caretAdvance = caretAdvanceRef.get().intValue();
+    PsiElement psiAtOffset = file.findElementAt(caretOffset);
+    if (psiAtOffset == null || psiAtOffset.getTextOffset() > caretOffset) {
+      return Result.Continue;
+    }
+    Document document = editor.getDocument();
+    ASTNode token = psiAtOffset.getNode();
+    IElementType type = token.getElementType();
+    if (type == DartTokenTypes.REGULAR_STRING_PART) {
+      token = token.getTreeNext();
+      type = token.getElementType();
+      // At this point we might have type == TokenType.ERROR_ELEMENT if the string is unterminated.
+      // We're ignoring that case since we don't have a rich enough set of signals to deduce where or
+      // even if an additional quote should be added. Since strings are by default terminated it should be rare.
+    }
+    if (type == DartTokenTypes.CLOSING_QUOTE) {
+      // The final effect is to insert matching close-quote, newline, indent, matching open-quote.
+      char literalStart = token.getText().charAt(0);
+      StringBuilder quotes = new StringBuilder();
+      quotes.append(literalStart);
+      quotes.append(literalStart);
+      document.insertString(caretOffset, quotes.toString());
+      caretOffset++;
+      caretAdvance++;
+      caretOffsetRef.set(caretOffset);
+      caretAdvanceRef.set(caretAdvance);
+      return Result.Default;
+    }
+    return Result.Continue;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/editor/DartLineWrapPositionStrategy.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/editor/DartLineWrapPositionStrategy.java
@@ -1,0 +1,49 @@
+package com.jetbrains.lang.dart.ide.editor;
+
+import com.intellij.openapi.editor.DefaultLineWrapPositionStrategy;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DartLineWrapPositionStrategy extends DefaultLineWrapPositionStrategy {
+
+  public DartLineWrapPositionStrategy() {
+    super();
+    addRule(new Rule('\\', WrapCondition.BEFORE)); // Wrap before escape sequences in strings
+  }
+
+  @Override
+  public int calculateWrapPosition(@NotNull Document document,
+                                   @Nullable Project project,
+                                   int startOffset,
+                                   int endOffset,
+                                   int maxPreferredOffset,
+                                   boolean allowToBeyondMaxPreferredOffset,
+                                   boolean virtual) {
+    int pos =
+      super.calculateWrapPosition(document, project, startOffset, endOffset, maxPreferredOffset, allowToBeyondMaxPreferredOffset, virtual);
+    if (pos < 0) {
+      return pos;
+    }
+    char ch = document.getCharsSequence().charAt(pos);
+    if (ch == '\'' || ch == '"') {
+      return maxPreferredOffset;
+    }
+    return pos;
+  }
+
+  @Override
+  protected boolean canUseOffset(@NotNull Document document, int offset, boolean virtual) {
+    CharSequence chars = document.getCharsSequence();
+    char charAtOffset = chars.charAt(offset);
+
+    if (charAtOffset == '.') {
+      // Do not split the cascade token, but allow wrapping in front of it.
+      if (offset > 0 && chars.charAt(offset - 1) == '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
@@ -129,7 +129,10 @@ public class DartBlock extends AbstractBlock implements BlockWithParent {
     }
 
     if (myParent instanceof DartBlock && ((DartBlock)myParent).isIncomplete()) {
-      return new ChildAttributes(Indent.getContinuationIndent(), null);
+      ASTNode child = myNode.getFirstChildNode();
+      if (child == null || !(child.getElementType() == OPEN_QUOTE && child.getText().length() == 3)) {
+        return new ChildAttributes(Indent.getContinuationIndent(), null);
+      }
     }
     return new ChildAttributes(previousBlock.getIndent(), previousBlock.getAlignment());
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -226,7 +226,9 @@ public class DartIndentProcessor {
     }
 
     if (elementType == OPEN_QUOTE && parentType == STRING_LITERAL_EXPRESSION && superParentType == VAR_INIT) {
-      return Indent.getContinuationIndent();
+      if (node.getText().length() < 3) {
+        return Indent.getContinuationIndent();
+      }
     }
 
     return Indent.getNoneIndent();

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -225,6 +225,10 @@ public class DartIndentProcessor {
       return Indent.getContinuationIndent();
     }
 
+    if (elementType == OPEN_QUOTE && parentType == STRING_LITERAL_EXPRESSION && superParentType == VAR_INIT) {
+      return Indent.getContinuationIndent();
+    }
+
     return Indent.getNoneIndent();
   }
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -2,8 +2,11 @@ package com.jetbrains.lang.dart.typing;
 
 import com.intellij.openapi.actionSystem.IdeActions;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.DartLanguage;
 import org.jetbrains.annotations.NotNull;
 
 public class DartTypingTest extends DartCodeInsightFixtureTestCase {
@@ -435,5 +438,58 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "    <caret>\n" +
                  "  }\n" +
                  "");
+  }
+
+  public void testEnterBetweenEmptyStringQuotes() {
+    // Checks single quotes.
+    doTypingTest('\n',
+                 "var x = '<caret>'",
+                 "var x = ''\n" +
+                 "    '<caret>'");
+  }
+
+  public void testEnterBetweenStringQuotes() {
+    // Checks single quotes.
+    doTypingTest('\n',
+                 "var x = 'content<caret>'",
+                 "var x = 'content'\n" +
+                 "    '<caret>'");
+  }
+
+  public void testEnterMidString() {
+    doTypingTest('\n',
+                 "var x = 'content<caret>and stuff'",
+                 "var x = 'content'\n" +
+                 "    '<caret>and stuff'");
+  }
+
+  public void testAutoWrapString() {
+    CommonCodeStyleSettings settings = CodeStyleSettingsManager.getSettings(getProject()).getCommonSettings(DartLanguage.INSTANCE);
+    settings.WRAP_ON_TYPING = CommonCodeStyleSettings.WrapOnTyping.WRAP.intValue;
+    settings.RIGHT_MARGIN = 42;
+    doTypingTest('3',
+                 "var x = '12345678901234567890123456789012<caret>'",
+                 "var x = '123456789012345678901234567890'\n" +
+                 "    '123<caret>'");
+  }
+
+  public void testAutoWrapCascade() {
+    CommonCodeStyleSettings settings = CodeStyleSettingsManager.getSettings(getProject()).getCommonSettings(DartLanguage.INSTANCE);
+    settings.WRAP_ON_TYPING = CommonCodeStyleSettings.WrapOnTyping.WRAP.intValue;
+    settings.RIGHT_MARGIN = 42;
+    doTypingTest('3',
+                 "var x = a123456789012345..b890123456789012<caret>",
+                 "var x = a123456789012345\n" +
+                 "  ..b8901234567890123");
+  }
+
+  public void testAutoWrapStringEscape() {
+    CommonCodeStyleSettings settings = CodeStyleSettingsManager.getSettings(getProject()).getCommonSettings(DartLanguage.INSTANCE);
+    settings.WRAP_ON_TYPING = CommonCodeStyleSettings.WrapOnTyping.WRAP.intValue;
+    settings.RIGHT_MARGIN = 42;
+    doTypingTest('3',
+                 "var x = '123456789012345\\t890123456789012<caret>'",
+                 "var x = '123456789012345'\n" +
+                 "    '\\t8901234567890123'");
   }
 }

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -492,4 +492,11 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "var x = '123456789012345'\n" +
                  "    '\\t8901234567890123'");
   }
+
+  public void testAutoIndentMultilineString() {
+    doTypingTest('\n',
+                 "var q = '''<caret>",
+                 "var q = '''\n" +
+                 "<caret>");
+  }
 }


### PR DESCRIPTION
@alexander-doroshko Typing <return> in the middle of a string will insert proper syntax to make two concatenating strings (similar to java).

Fixes https://youtrack.jetbrains.com/issue/WEB-12608

This may have a merge conflict in DartIndentProcessor with another formatter-related pull request that has not yet been merged. I'm not sure how clever git is; there actually is no conflict.