### PR TITLE
Hook up dartfmt for experimenting

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -59,6 +59,8 @@
     <lang.implementationTextSelectioner language="Dart"
                                         implementationClass="com.jetbrains.lang.dart.ide.DartImplementationTextSelectioner"/>
     <lang.formatter language="Dart" implementationClass="com.jetbrains.lang.dart.ide.formatter.DartFormattingModelBuilder"/>
+    <preFormatProcessor implementation="com.jetbrains.lang.dart.ide.formatter.DartPreFormatProcessor"/>
+    <!-- postFormatProcessor implementation="com.jetbrains.lang.dart.ide.formatter.DartPostFormatProcessor"/ -->
     <lang.psiStructureViewFactory language="Dart" implementationClass="com.jetbrains.lang.dart.ide.structure.DartStructureViewFactory"/>
     <lang.structureViewExtension implementation="com.jetbrains.lang.dart.ide.structure.DartStructureViewExtension"/>
     <psi.referenceContributor language="HTML" implementation="com.jetbrains.lang.dart.psi.DartPackagePathReferenceContributor"
@@ -85,7 +87,7 @@
     <codeInsight.lineMarkerProvider language="Dart"
                                     implementationClass="com.jetbrains.lang.dart.ide.marker.DartMethodOverrideMarkerProvider"/>
     <!--<codeInsight.lineMarkerProvider language="Dart"-->
-                                    <!--implementationClass="com.jetbrains.lang.dart.ide.marker.DartServerOverrideMarkerProvider"/>-->
+    <!--implementationClass="com.jetbrains.lang.dart.ide.marker.DartServerOverrideMarkerProvider"/>-->
 
     <codeInsight.gotoSuper language="Dart" implementationClass="com.jetbrains.lang.dart.ide.actions.DartGotoSuperHandler"/>
 
@@ -145,9 +147,9 @@
     <!--<completion.contributor language="Dart" implementationClass="com.jetbrains.lang.dart.ide.completion.DartKeywordCompletionContributor"/>-->
     <!--<completion.contributor language="Dart" implementationClass="com.jetbrains.lang.dart.ide.completion.DartArgumentNameContributor"/>-->
     <!--<completion.contributor language="Dart"-->
-                            <!--implementationClass="com.jetbrains.lang.dart.ide.completion.DartClassNameCompletionContributor"/>-->
+    <!--implementationClass="com.jetbrains.lang.dart.ide.completion.DartClassNameCompletionContributor"/>-->
     <!--<completion.contributor language="Dart"-->
-                            <!--implementationClass="com.jetbrains.lang.dart.ide.completion.DartReferenceCompletionContributor"/>-->
+    <!--implementationClass="com.jetbrains.lang.dart.ide.completion.DartReferenceCompletionContributor"/>-->
 
     <resolveScopeProvider implementation="com.jetbrains.lang.dart.resolve.DartResolveScopeProvider"/>
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartFormattingModelBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartFormattingModelBuilder.java
@@ -1,8 +1,9 @@
 package com.jetbrains.lang.dart.ide.formatter;
 
-import com.intellij.formatting.FormattingModel;
-import com.intellij.formatting.FormattingModelBuilder;
+import com.intellij.formatting.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -12,6 +13,9 @@ import com.jetbrains.lang.dart.psi.DartFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DartFormattingModelBuilder implements FormattingModelBuilder {
   @NotNull
   @Override
@@ -19,13 +23,58 @@ public class DartFormattingModelBuilder implements FormattingModelBuilder {
     // element can be DartFile, DartEmbeddedContent, DartExpressionCodeFragment
     final PsiFile psiFile = element.getContainingFile();
     final ASTNode rootNode = psiFile instanceof DartFile ? psiFile.getNode() : element.getNode();
-    final DartBlock rootBlock = new DartBlock(rootNode, null, null, settings);
-    return new DocumentBasedFormattingModel(rootBlock, element.getProject(), settings, psiFile.getFileType(), psiFile);
+    final DartBlock rootBlock;
+    Object wasFormatted = rootNode.getUserData(DartPreFormatProcessor.FORMAT_MARK);
+    if (wasFormatted == DartPreFormatProcessor.FORMAT_MARKER) {
+      rootNode.putUserData(DartPreFormatProcessor.FORMAT_MARK, null);
+      rootBlock = new NonFormattingDartBlock(rootNode, null, null, settings);
+    } else {
+      rootBlock = new DartBlock(rootNode, null, null, settings);
+    }
+    return new DartFormattingModel(rootBlock, element.getProject(), settings, psiFile.getFileType(), psiFile);
   }
 
   @Nullable
   @Override
   public TextRange getRangeAffectingIndent(PsiFile file, int offset, ASTNode elementAtOffset) {
     return null;
+  }
+
+  private static class DartFormattingModel extends DocumentBasedFormattingModel {
+    private DartFormattingModel(DartBlock rootBlock, Project project, CodeStyleSettings settings, FileType fileType, PsiFile psiFile) {
+      super(rootBlock, project, settings, fileType, psiFile);
+    }
+  }
+
+  private static class NonFormattingDartBlock extends DartBlock {
+    NonFormattingDartBlock(ASTNode node, Wrap wrap, Alignment alignment, CodeStyleSettings settings) {
+      super(node, wrap, alignment, settings);
+    }
+
+    @Override
+    public Indent getIndent() {
+      return null;
+    }
+
+    @Override
+    public Spacing getSpacing(Block child1, @NotNull Block child2) {
+      return null;
+    }
+
+    @Override
+    protected List<Block> buildChildren() {
+      return new ArrayList<Block>();
+    }
+
+    @NotNull
+    @Override
+    public ChildAttributes getChildAttributes(final int newIndex) {
+      return new ChildAttributes(Indent.getNoneIndent(), null);
+    }
+
+    @Override
+    public boolean isLeaf() {
+      return true;
+    }
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartPostFormatProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartPostFormatProcessor.java
@@ -1,0 +1,138 @@
+package com.jetbrains.lang.dart.ide.formatter;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.RangeMarker;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
+import com.intellij.psi.impl.source.codeStyle.PostFormatProcessor;
+import com.jetbrains.lang.dart.DartLanguage;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import org.dartlang.analysis.server.protocol.SourceEdit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DartPostFormatProcessor implements PostFormatProcessor {
+
+  @NotNull
+  @Override
+  public PsiElement processElement(@NotNull PsiElement psiElement, @NotNull CodeStyleSettings settings) {
+    if (!psiElement.getLanguage().is(DartLanguage.INSTANCE)) return psiElement;
+    if (!psiElement.isValid()) return psiElement;
+    PsiFile file = psiElement.getContainingFile();
+    if (file == null || !file.isWritable()) return psiElement;
+
+    Project project = psiElement.getProject();
+    final FileViewProvider viewProvider = file.getViewProvider();
+    final Document document = viewProvider.getDocument();
+    if (document == null) return psiElement;
+
+    PsiDocumentManager documentManager = PsiDocumentManager.getInstance(project);
+    documentManager.commitDocument(document);
+
+    //final FileDocumentManager fileDocMgr = FileDocumentManager.getInstance();
+    //fileDocMgr.saveDocument(document);
+
+    FileEditorManager fileManager = FileEditorManager.getInstance(project);
+    Editor editor = null;
+    int selectionStart = 0, selectionLength = 0;
+    if (fileManager != null) {
+      TextEditor textEditor = (TextEditor)fileManager.getSelectedEditor(file.getVirtualFile());
+      if (textEditor != null) {
+        editor = textEditor.getEditor();
+        selectionStart = editor.getSelectionModel().getSelectionStart();
+        selectionLength = editor.getSelectionModel().getSelectionEnd() - selectionStart;
+      }
+    }
+
+    final String path = FileUtil.toSystemDependentName(file.getVirtualFile().getPath());
+    final int lineLength = settings.getCommonSettings(DartLanguage.INSTANCE).RIGHT_MARGIN;
+    final DartAnalysisServerService das = DartAnalysisServerService.getInstance();
+    das.updateFilesContent();
+
+    final DartAnalysisServerService.FormatResult formatResult = das.edit_format(path, selectionStart, selectionLength, lineLength);
+    if (formatResult == null) return psiElement;
+    final List<SourceEdit> edits = formatResult.getEdits();
+    if (edits == null || edits.size() != 1) return psiElement;
+
+    final int selectionOffset = formatResult.getOffset();
+    final int selectionEnd = formatResult.getLength() + selectionOffset;
+    final String code = edits.get(0).getReplacement();
+    if (code == null) return psiElement;
+    document.replaceString(0, document.getTextLength(), code);
+    documentManager.commitDocument(document);
+
+    if (editor != null) {
+      editor.getCaretModel().moveToOffset(selectionOffset); // TODO Is this needed?
+      editor.getSelectionModel().setSelection(selectionOffset, selectionEnd);
+    }
+    return psiElement;
+  }
+
+  @NotNull
+  @Override
+  public TextRange processText(@NotNull PsiFile file, @NotNull TextRange range, @NotNull CodeStyleSettings settings) {
+    if (!file.getLanguage().is(DartLanguage.INSTANCE)) return range;
+    if (!file.isWritable()) return range;
+
+    Project project = file.getProject();
+
+    final FileViewProvider viewProvider = file.getViewProvider();
+    final Document document = viewProvider.getDocument();
+    if (document == null) return range;
+
+    PsiDocumentManager documentManager = PsiDocumentManager.getInstance(project);
+    documentManager.doPostponedOperationsAndUnblockDocument(document);
+    documentManager.commitDocument(document);
+
+    //final FileDocumentManager fileDocMgr = FileDocumentManager.getInstance();
+    //fileDocMgr.saveDocument(document);
+
+    FileEditorManager fileManager = FileEditorManager.getInstance(project);
+    Editor editor = null;
+    int selectionStart = 0, selectionLength = 0;
+    if (fileManager != null) {
+      TextEditor textEditor = (TextEditor)fileManager.getSelectedEditor(file.getVirtualFile());
+      if (textEditor != null) {
+        editor = textEditor.getEditor();
+        selectionStart = editor.getSelectionModel().getSelectionStart();
+        selectionLength = editor.getSelectionModel().getSelectionEnd() - selectionStart;
+      }
+    }
+
+    final String path = FileUtil.toSystemDependentName(file.getVirtualFile().getPath());
+    final int lineLength = CodeStyleSettingsManager.getSettings(project).getCommonSettings(DartLanguage.INSTANCE).RIGHT_MARGIN;
+    final DartAnalysisServerService das = DartAnalysisServerService.getInstance();
+    das.updateFilesContent();
+
+    final DartAnalysisServerService.FormatResult formatResult = das.edit_format(path, selectionStart, selectionLength, lineLength);
+    if (formatResult == null) return range;
+
+    final List<SourceEdit> edits = formatResult.getEdits();
+    if (edits == null || edits.size() != 1) return range;
+    final int selectionOffset = formatResult.getOffset();
+    final int selectionEnd = formatResult.getLength() + selectionOffset;
+    final String code = edits.get(0).getReplacement();
+    if (code == null) return range;
+
+    final RangeMarker marker = document.createRangeMarker(range.getStartOffset(), range.getEndOffset(), true);
+    document.replaceString(0, document.getTextLength(), code);
+    documentManager.commitDocument(document);
+
+    if (editor != null) {
+      editor.getCaretModel().moveToOffset(selectionOffset); // TODO Is this needed?
+      editor.getSelectionModel().setSelection(selectionOffset, selectionEnd);
+    }
+    return TextRange.create(marker.getStartOffset(), marker.getEndOffset());
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartPreFormatProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartPreFormatProcessor.java
@@ -1,0 +1,97 @@
+package com.jetbrains.lang.dart.ide.formatter;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.RangeMarker;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
+import com.intellij.psi.impl.source.codeStyle.PreFormatProcessor;
+import com.jetbrains.lang.dart.DartLanguage;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import org.dartlang.analysis.server.protocol.SourceEdit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DartPreFormatProcessor implements PreFormatProcessor {
+  public static Key<Boolean> FORMAT_MARK = new Key<Boolean>("FORMAT_MARK");
+  public static Boolean FORMAT_MARKER = Boolean.TRUE;
+
+  @NotNull
+  @Override
+  public TextRange process(@NotNull ASTNode element, @NotNull TextRange range) {
+    // TODO return range if not in a paste operation
+    final PsiElement psiElement = element.getPsi();
+    if (psiElement == null) return range;
+
+    if (!psiElement.getLanguage().is(DartLanguage.INSTANCE)) return range;
+
+    if (!psiElement.isValid()) return range;
+    PsiFile file = psiElement.getContainingFile();
+    if (file == null || !file.isWritable()) return range;
+
+    Project project = psiElement.getProject();
+
+    final FileViewProvider viewProvider = file.getViewProvider();
+    final Document document = viewProvider.getDocument();
+    if (document == null) return range;
+
+    PsiDocumentManager documentManager = PsiDocumentManager.getInstance(project);
+    documentManager.doPostponedOperationsAndUnblockDocument(document);
+    documentManager.commitDocument(document);
+
+    //final FileDocumentManager fileDocMgr = FileDocumentManager.getInstance();
+    //fileDocMgr.saveDocument(document);
+
+    FileEditorManager fileManager = FileEditorManager.getInstance(project);
+    Editor editor = null;
+    int selectionStart = 0, selectionLength = 0;
+    if (fileManager != null) {
+      TextEditor textEditor = (TextEditor)fileManager.getSelectedEditor(file.getVirtualFile());
+      if (textEditor != null) {
+        editor = textEditor.getEditor();
+        selectionStart = editor.getSelectionModel().getSelectionStart();
+        selectionLength = editor.getSelectionModel().getSelectionEnd() - selectionStart;
+      }
+    }
+
+    final String path = FileUtil.toSystemDependentName(file.getVirtualFile().getPath());
+    final int lineLength = CodeStyleSettingsManager.getSettings(project).getCommonSettings(DartLanguage.INSTANCE).RIGHT_MARGIN;
+    final DartAnalysisServerService das = DartAnalysisServerService.getInstance();
+    das.updateFilesContent();
+
+    final DartAnalysisServerService.FormatResult formatResult = das.edit_format(path, selectionStart, selectionLength, lineLength);
+    if (formatResult == null) return range;
+
+    final List<SourceEdit> edits = formatResult.getEdits();
+    if (edits == null || edits.size() != 1) return range;
+    final int selectionOffset = formatResult.getOffset();
+    final int selectionEnd = formatResult.getLength() + selectionOffset;
+    final String code = edits.get(0).getReplacement();
+    if (code == null) return range;
+
+    final RangeMarker marker = document.createRangeMarker(range.getStartOffset(), range.getEndOffset(), true);
+    document.replaceString(0, document.getTextLength(), code);
+
+    element.putUserData(FORMAT_MARK, FORMAT_MARKER);
+    // Without this commit, an error is thrown by some tests.
+    // With it, some files get garbled. TODO Remove this comment.
+    documentManager.commitDocument(document);
+
+    if (editor != null) {
+      editor.getCaretModel().moveToOffset(selectionOffset); // TODO Is this needed?
+      editor.getSelectionModel().setSelection(selectionOffset, selectionEnd);
+    }
+    return TextRange.create(marker.getStartOffset(), marker.getEndOffset());
+  }
+}


### PR DESCRIPTION
@alexander-doroshko Here's another attempt at using dartfmt as the incremental formatter. Unfortunately, my git-fu is weak and I ruined the previous branch so I decided to start over. There are still some useful comments in the old PR so I have not deleted it yet.

This passes the same tests that pass without it. (I reported two new failures earlier.) Notably, as you mentioned, the test that previously mangled the code now works. So does one that should have failed (DartServerQuickFixTest.testCreateClass()), so I wonder if this formatter is even being called by the tests. (I just checked with the debugger. The breakpoint in DartPreFormatProcessor was not hit so I guess that test no longer uses the formatter.)

You can ignore DartPostFormatProcessor. I have not tested it, but I haven't deleted it since this is still work-in-progress.

I tried the Extract Method refactoring in the runtime IDE and it did hit the breakpoint, so at least that works. The performance is horrible. It took about 7 seconds to extract the method when *Bar* is selected in this code.
```dart
library foo;

part 'eee.dart';

main() {
  Iterable b = new Bar().doSomething(2+2==4, 1+1, 2*2.0, "", [1], {1:2}, #*, null);
}
```