### PR TITLE
Don't apply potential edits during Rename refactoring.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartSortMembersAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartSortMembersAction.java
@@ -34,7 +34,6 @@ import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.assists.AssistUtils;
-import com.jetbrains.lang.dart.sdk.DartSdk;
 import icons.DartIcons;
 import org.dartlang.analysis.server.protocol.SourceEdit;
 import org.dartlang.analysis.server.protocol.SourceFileEdit;
@@ -64,9 +63,7 @@ public class DartSortMembersAction extends AbstractDartFileProcessingAction {
     return DartBundle.message("dart.sort.members.action.name.ellipsis"); // because with dialog
   }
 
-  protected void runOverEditor(@NotNull final Project project,
-                               @NotNull final Editor editor,
-                               @NotNull final PsiFile psiFile) {
+  protected void runOverEditor(@NotNull final Project project, @NotNull final Editor editor, @NotNull final PsiFile psiFile) {
     final Document document = editor.getDocument();
     if (!ReadonlyStatusHandler.ensureDocumentWritable(project, document)) return;
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartRenameHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartRenameHandler.java
@@ -46,6 +46,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Set;
 
 public class DartRenameHandler implements RenameHandler, TitledHandler {
   @Override
@@ -219,7 +220,8 @@ class DartRenameDialog extends RefactoringDialog {
       public void run() {
         final SourceChange change = myRefactoring.getChange();
         assert change != null;
-        AssistUtils.applySourceChange(myProject, change);
+        final Set<String> excludedIds = myRefactoring.getPotentialEdits();
+        AssistUtils.applySourceChange(myProject, change, excludedIds);
         close(DialogWrapper.OK_EXIT_CODE);
       }
     });

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoring.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoring.java
@@ -51,6 +51,7 @@ public abstract class ServerRefactoring {
   @Nullable private RefactoringStatus optionsStatus;
   @Nullable private RefactoringStatus finalStatus;
   @Nullable private SourceChange change;
+  @NotNull private final Set<String> potentialEdits = Sets.newHashSet();
 
   private int lastId = 0;
   @Nullable private ServerRefactoringListener listener;
@@ -91,7 +92,7 @@ public abstract class ServerRefactoring {
       return serverErrorStatus;
     }
     if (initialStatus != null) {
-      return  initialStatus;
+      return initialStatus;
     }
     return new RefactoringStatus();
   }
@@ -106,6 +107,11 @@ public abstract class ServerRefactoring {
    */
   @Nullable
   protected abstract RefactoringOptions getOptions();
+
+  @NotNull
+  public Set<String> getPotentialEdits() {
+    return potentialEdits;
+  }
 
   /**
    * Sets the received {@link RefactoringFeedback}.
@@ -135,7 +141,7 @@ public abstract class ServerRefactoring {
                                          List<RefactoringProblem> finalProblems,
                                          RefactoringFeedback feedback,
                                          SourceChange _change,
-                                         List<String> potentialEdits) {
+                                         List<String> _potentialEdits) {
           if (feedback != null) {
             setFeedback(feedback);
           }
@@ -143,6 +149,10 @@ public abstract class ServerRefactoring {
           optionsStatus = toRefactoringStatus(optionsProblems);
           finalStatus = toRefactoringStatus(finalProblems);
           change = _change;
+          potentialEdits.clear();
+          if (_potentialEdits != null) {
+            potentialEdits.addAll(_potentialEdits);
+          }
           latch.countDown();
           requestDone(id);
         }


### PR DESCRIPTION
Applying potential edits is unsafe.
We need a way to preview these changes and let users to check them on/off individually.