### PR TITLE
Expand 'Goto super' tests - include grandsuper and sub classes.

### DIFF
--- a/Dart/testData/analysisServer/gotoSuper/SuperClass.after.dart
+++ b/Dart/testData/analysisServer/gotoSuper/SuperClass.after.dart
@@ -1,4 +1,8 @@
-class <caret>A {}
-class B extends A {
-  mmm() {}
+class A {
+}
+class <caret>B extends A {
+}
+class C extends B {
+}
+class D extends C {
 }

--- a/Dart/testData/analysisServer/gotoSuper/SuperClass.dart
+++ b/Dart/testData/analysisServer/gotoSuper/SuperClass.dart
@@ -1,4 +1,8 @@
-class A {}
-class B extends A {<caret>
-  mmm() {}
+class A {
+}
+class B extends A {
+}
+class C extends B {<caret>
+}
+class D extends C {
 }

--- a/Dart/testData/analysisServer/gotoSuper/SuperClassMethod.after.dart
+++ b/Dart/testData/analysisServer/gotoSuper/SuperClassMethod.after.dart
@@ -1,6 +1,12 @@
 class A {
-  <caret>mmm() {}
+  mmm() {}
 }
 class B extends A {
+  <caret>mmm() {}
+}
+class C extends B {
+  mmm() {}
+}
+class D extends C {
   mmm() {}
 }

--- a/Dart/testData/analysisServer/gotoSuper/SuperClassMethod.dart
+++ b/Dart/testData/analysisServer/gotoSuper/SuperClassMethod.dart
@@ -2,5 +2,11 @@ class A {
   mmm() {}
 }
 class B extends A {
+  mmm() {}
+}
+class C extends B {
   mm<caret>m() {}
+}
+class D extends C {
+  mmm() {}
 }


### PR DESCRIPTION
Please note, that the test DartServerGotoSuperHandlerTest.testSuperClassMethod now fails.
The reason is that it is enable by default, but in plugin.xml DartServerGotoSuperHandler is not.

And there is a bug in non-server version in case of grand-super.