### PR TITLE
Add folding for multi-line strings

### DIFF
--- a/Dart/testData/folding/MultilineStrings.dart
+++ b/Dart/testData/folding/MultilineStrings.dart
@@ -1,0 +1,18 @@
+var z = <fold text='"""..."""' expand='true'>"""
+something
+"""</fold>;
+
+var w = <fold text='r"""..."""' expand='true'>r"""
+something"""</fold>;
+
+class Patho <fold text='{...}' expand='true'>{
+  String stringify() <fold text='{...}' expand='true'>{
+    String stringer() <fold text='{...}' expand='true'>{
+      var str = <fold text='"""..."""' expand='true'>"""
+It may be weird to have a string here.
+"""</fold>;
+      return str;
+    }</fold>
+    return stringer();
+  }</fold>
+}</fold>

--- a/Dart/testSrc/com/jetbrains/lang/dart/folding/DartFoldingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/folding/DartFoldingTest.java
@@ -144,4 +144,8 @@ public class DartFoldingTest extends DartCodeInsightFixtureTestCase {
   public void testPartsByDefault() throws Exception {
     doTest();
   }
+
+  public void testMultilineStrings() throws Exception {
+    doTest();
+  }
 }


### PR DESCRIPTION
@alexander-doroshko Fixes https://youtrack.jetbrains.com/issue/WEB-16703

I could not find a way to make the test framework define folding regions for strings that use triple single quotes. I tested those by hand and they work.