### PR TITLE
Fold multi-line strings

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/editor/DartEnterInStringHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/editor/DartEnterInStringHandler.java
@@ -39,8 +39,13 @@ public class DartEnterInStringHandler extends EnterHandlerDelegateAdapter {
       breakString("r" + quote, String.valueOf(quote), caretOffsetRef, caretAdvanceRef, document);
       return Result.Default;
     }
-    while ((token = token.getTreeParent()) != null) {
+    if ((token = token.getTreeParent()) != null) {
       type = token.getElementType();
+      if (type == DartTokenTypes.SHORT_TEMPLATE_ENTRY || type == DartTokenTypes.LONG_TEMPLATE_ENTRY) {
+        token = token.getTreeParent();
+        if (token == null) return Result.Continue;
+        type = token.getElementType();
+      }
       if (type == DartTokenTypes.STRING_LITERAL_EXPRESSION) {
         token = token.getFirstChildNode();
         if (token == null) return Result.Continue; // Can't happen with current grammar.

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -239,6 +239,9 @@ public class DartIndentProcessor {
       return Indent.getContinuationIndent();
     }
 
+    if (parentType == LONG_TEMPLATE_ENTRY && EXPRESSIONS.contains(elementType)) {
+      return Indent.getContinuationIndent();
+    }
     return Indent.getNoneIndent();
   }
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -555,4 +555,13 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "var a = r'''some\n" +
                  "<caret>content''';");
   }
+
+  public void testEnterBeforeEmbeddedInterpolation() {
+    // We are not going to address the whole issue of
+    // "how do I format an entire functional program written in an interpolation expression"
+    doTypingTest('\n',
+                 "var b = \"see ${'${<caret>a}'} and more\";",
+                 "var b = \"see ${'${\n" +
+                 "    a}'} and more\";");
+  }
 }


### PR DESCRIPTION
@alexander-doroshko Inspired by your optimization question for string splitting, I found and fixed a bug that occurred in complex interpolations. The new test shows the problem. Without this code it inserts single quotes around the additional whitespace, which is syntactically wrong. This case is not handled by dartfmt but I checked with Bob to make sure using continuation indent does not violate any unwritten rules.