### PR TITLE
Do not indent before syntax error

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
@@ -3,6 +3,7 @@ package com.jetbrains.lang.dart.ide.formatter;
 import com.intellij.formatting.*;
 import com.intellij.formatting.templateLanguages.BlockWithParent;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.TokenType;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.formatter.FormatterUtil;
 import com.intellij.psi.formatter.common.AbstractBlock;
@@ -128,6 +129,9 @@ public class DartBlock extends AbstractBlock implements BlockWithParent {
       return new ChildAttributes(Indent.getNoneIndent(), null);
     }
 
+    if (!previousBlock.isIncomplete() && newIndex < getSubDartBlocks().size() && previousType != TokenType.ERROR_ELEMENT) {
+      return new ChildAttributes(previousBlock.getIndent(), previousBlock.getAlignment());
+    }
     if (myParent instanceof DartBlock && ((DartBlock)myParent).isIncomplete()) {
       ASTNode child = myNode.getFirstChildNode();
       if (child == null || !(child.getElementType() == OPEN_QUOTE && child.getText().length() == 3)) {

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -410,6 +410,19 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "}");
   }
 
+  public void testEnterBeforeIncompleteStatement() {
+    doTypingTest('\n',
+                 "void _advanceParagraph(_currentParagraph, _currentIndentation, _currentListId) {\n" +
+                 "  _currentIndentation = null;<caret>\n" +
+                 "  _currentListId = _currentParagraph is bool ?\n" +
+                 "}",
+                 "void _advanceParagraph(_currentParagraph, _currentIndentation, _currentListId) {\n" +
+                 "  _currentIndentation = null;\n" +
+                 "  <caret>\n" +
+                 "  _currentListId = _currentParagraph is bool ?\n" +
+                 "}");
+  }
+
   public void testEnterAfterCompleteStatement() {
     doTypingTest('\n',
                  "class T {\n" +


### PR DESCRIPTION
@alexander-doroshko It seems difficult to know when indenting is before or after a syntax error.This helps clarify that indenting a continuation line should happen when newline is typed before the semicolon, not when it is after a complete statement.