### PR TITLE
Indentmetas

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -121,6 +121,9 @@ public class DartIndentProcessor {
       }
       return Indent.getNormalIndent();
     }
+    if (elementType == LPAREN && superParentType == METADATA) {
+      return Indent.getContinuationIndent();
+    }
     if (parentType == ARGUMENT_LIST) {
       // TODO In order to handle some dart_style examples we need to set indent for each arg.
       // The formatter does not appear to honor indent on individual argument expressions

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -623,7 +623,7 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  ")");
   }
 
-  public void testEnterInBeforeMetadataNamedArg() {
+  public void testEnterBeforeMetadataNamedArg() {
     doTypingTest('\n',
                  "@Component(<caret>selector: 'something')",
                  "@Component(\n" +

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -614,4 +614,19 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "foo() {return comment.replaceAll(\n" +
                  "    <caret>'foo', 'bar');}");
   }
+
+  public void testEnterInEmptyMetadataArgList() {
+    doTypingTest('\n',
+                 "@Component(<caret>)",
+                 "@Component(\n" +
+                 "    <caret>\n" +
+                 ")");
+  }
+
+  public void testEnterInBeforeMetadataNamedArg() {
+    doTypingTest('\n',
+                 "@Component(<caret>selector: 'something')",
+                 "@Component(\n" +
+                 "    <caret>selector: 'something')");
+  }
 }


### PR DESCRIPTION
@alexander-doroshko Typing a newline in an angular component arg list should cause the named arg to be indented at continuation level.

There is still a problem. Trying to add an arg by typing a comma then newline (before r-paren) does not indent properly. The indent processor never sees any of the arguments, probably because of the syntax error. I don't know what to do about that yet.