### PR TITLE
New DAS client. Pass raw VM/DAS arguments.

### DIFF
--- a/Dart/thirdPartySrc/analyisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analyisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -361,7 +361,7 @@ public interface AnalysisServer {
    *
    * If directives of the Dart file cannot be organized, for example because it has scan or parse
    * errors, or by other reasons, ORGANIZE_DIRECTIVES_ERROR will be generated. The message will
-   * provide datails about the reason.
+   * provide details about the reason.
    *
    * @param file The Dart file to organize directives in.
    */


### PR DESCRIPTION
We need to allow our internal clients to pass VM arguments, for example to start DAS with Observatory.
It seems that instead of having a bunch of options it's easier to give users just one really big hammer.

Ideally it would be nice to have the Registry value `dart.server.vm.arguments` just as we have `dart.server.additional.arguments` now.