### PR TITLE
Use continuation indent before var init expression

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -190,7 +190,7 @@ public class DartIndentProcessor {
       }
     }
     if ((elementType == REFERENCE_EXPRESSION || BINARY_EXPRESSIONS.contains(elementType)) &&
-        FormatterUtil.isPrecededBy(node, ASSIGNMENT_OPERATOR)) {
+        (FormatterUtil.isPrecededBy(node, ASSIGNMENT_OPERATOR) || FormatterUtil.isPrecededBy(node, EQ))) {
       return Indent.getContinuationIndent();
     }
     if (elementType == VAR_DECLARATION_LIST_PART) {

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -614,4 +614,17 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "foo() {return comment.replaceAll(\n" +
                  "    <caret>'foo', 'bar');}");
   }
+
+  public void testEnterAfterEQ() {
+    doTypingTest('\n',
+                 "ms(toto)\n" +
+                 "  bool x =<caret> toto;\n" +
+                 "  return;\n" +
+                 "}",
+                 "ms(toto)\n" +
+                 "  bool x =\n" +
+                 "      <caret>toto;\n" +
+                 "  return;\n" +
+                 "}");
+  }
 }


### PR DESCRIPTION
@alexander-doroshko Typing newline after the equals sign in a var init should indent at continuation level.