### PR TITLE
Navigate to component names.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/AbstractDartComponentImpl.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/AbstractDartComponentImpl.java
@@ -204,4 +204,10 @@ abstract public class AbstractDartComponentImpl extends DartPsiCompositeElementI
       }
     };
   }
+
+  @Override
+  public int getTextOffset() {
+    final DartComponentName name = getComponentName();
+    return name != null ? name.getTextOffset() : super.getTextOffset();
+  }
 }


### PR DESCRIPTION
Like it is done for Java.
It's actually more convenient - when I navigate to a method I often want to search references to it or rename it. So, placing the caret on the name is convenient.