### PR TITLE
Put static DAS arguments before additional ones.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1180,16 +1180,16 @@ public class DartAnalysisServerService {
         vmArgsRaw = "";
       }
 
-      String serverArgsRaw;
-      try {
-        serverArgsRaw = Registry.stringValue("dart.server.additional.arguments");
-      }
-      catch (MissingResourceException e) {
-        serverArgsRaw = "";
-      }
+      String serverArgsRaw = "";
       serverArgsRaw += " --port=" + port;
       serverArgsRaw += " --useAnalysisHighlight2";
       serverArgsRaw += " --file-read-mode=normalize-eol-always";
+      try {
+        serverArgsRaw += " " + Registry.stringValue("dart.server.additional.arguments");
+      }
+      catch (MissingResourceException e) {
+        // NOP
+      }
 
       myServerSocket =
         new StdioServerSocket(runtimePath, StringUtil.split(vmArgsRaw, " "), analysisServerPath, StringUtil.split(serverArgsRaw, " "),


### PR DESCRIPTION
This would allow for example to specify "--port=4000" and always use it, instead of searching for a random port.