### PR TITLE
Optimize DartServerOverrideMarkerProvider - extract name offset.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/marker/DartServerOverrideMarkerProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/marker/DartServerOverrideMarkerProvider.java
@@ -112,10 +112,11 @@ public class DartServerOverrideMarkerProvider implements LineMarkerProvider {
 
     final List<DartServerData.DartOverrideMember> overrideMembers = DartAnalysisServerService.getInstance().getOverrideMembers(virtualFile);
     final Project project = componentName.getProject();
+    final int nameOffset = componentName.getTextRange().getStartOffset();
     DartComponent superclassComponent = null;
     List<DartComponent> interfaceComponents = Lists.newArrayList();
     for (DartServerData.DartOverrideMember overrideMember : overrideMembers) {
-      if (overrideMember.getOffset() == componentName.getTextRange().getStartOffset()) {
+      if (overrideMember.getOffset() == nameOffset) {
         superclassComponent = findDartComponent(project, overrideMember.getSuperclassMember());
         if (overrideMember.getInterfaceMembers() != null) {
           for (OverriddenMember overriddenMember : overrideMember.getInterfaceMembers()) {


### PR DESCRIPTION
We don't need to ask it again and again, and it was a hotspot.

Before:
![image](https://cloud.githubusercontent.com/assets/384794/11151394/b4b5ceb0-89e1-11e5-948a-1a565ed60524.png)

After:
![image](https://cloud.githubusercontent.com/assets/384794/11151403/d0ba6d28-89e1-11e5-8c87-88bc6d492028.png)

These are not ideally comparable, but give some idea that it was using significant percent of the time.