### PR TITLE
Fix output of print during test run

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestJsonReader.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestJsonReader.java
@@ -134,12 +134,11 @@ public class DartTestJsonReader {
   }
 
   private void processPrint(JsonObject obj) {
-    myProcessor.signalTestMessage(testName(obj), message(obj));
+    myProcessor.signalTestMessage(testName(obj), myTestId, message(obj));
   }
 
   private void processEnter(JsonObject obj) {
     myProcessor.signalTestFrameworkAttached();
-    ;
   }
 
   private void processExit(JsonObject obj) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestSignaller.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestSignaller.java
@@ -29,5 +29,5 @@ public interface DartTestSignaller {
 
   void signalTestSkipped(@NotNull String testName, @NotNull String reason, @Nullable String stackTrace);
 
-  void signalTestMessage(@NotNull String testName, @NotNull String message);
+  void signalTestMessage(@NotNull String testName, int testId, @NotNull String message);
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestToGeneralTestEventsConverter.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestToGeneralTestEventsConverter.java
@@ -110,6 +110,14 @@ class DartTestToGeneralTestEventsConverter extends OutputToGeneralTestEventsConv
     }
   }
 
+  private void fireOnTestsCountInSuite(final int count) {
+    // local variable is used to prevent concurrent modification
+    final GeneralTestEventsProcessor processor = getProcessor();
+    if (processor != null) {
+      processor.onTestsCountInSuite(count);
+    }
+  }
+
   private void fireOnTestStarted(@NotNull TestStartedEvent testStartedEvent) {
     // local variable is used to prevent concurrent modification
     final GeneralTestEventsProcessor processor = getProcessor();
@@ -174,6 +182,11 @@ class DartTestToGeneralTestEventsConverter extends OutputToGeneralTestEventsConv
     fireOnTestFrameworkAttached();
   }
 
+  // TODO Find the number of tests to be run and tell the test view so it can track progress correctly.
+  public void signalTestCount(int count) {
+    fireOnTestsCountInSuite(count);
+  }
+
   public void signalTestStarted(@NotNull String testName,
                                 int testId,
                                 int parentId,
@@ -205,7 +218,12 @@ class DartTestToGeneralTestEventsConverter extends OutputToGeneralTestEventsConv
     fireOnTestIgnored(new TestIgnoredEvent(testName, reason, stackTrace));
   }
 
-  public void signalTestMessage(@NotNull String testName, @NotNull String message) {
-    fireOnTestOutput(new TestOutputEvent(testName, message, false));
+  public void signalTestMessage(@NotNull String testName, final int testId, @NotNull String message) {
+    fireOnTestOutput(new TestOutputEvent(testName, message, false) {
+      int id = testId;
+      public int getId() {
+        return id;
+      }
+    });
   }
 }

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/test/DartTestJsonReaderTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/test/DartTestJsonReaderTest.java
@@ -128,7 +128,7 @@ public class DartTestJsonReaderTest extends TestCase {
     }
 
     @Override
-    public void signalTestMessage(@NotNull String testName, @NotNull String message) {
+    public void signalTestMessage(@NotNull String testName, int id, @NotNull String message) {
       signals.add("print " + testName + " " + message);
     }
   }


### PR DESCRIPTION
@alexander-doroshko Fix the node id generated by print events from the test runner. Also adds preliminary support for recording the number of test, in hope that someday the test runner will tell us that.