### PR TITLE
Index all top-level component symbols.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/index/DartIndexUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/index/DartIndexUtil.java
@@ -54,6 +54,8 @@ public class DartIndexUtil {
           continue;
         }
 
+        result.addSymbol(name);
+
         PsiElement parent = componentName.getParent();
         final DartComponentType type = DartComponentType.typeOf(parent);
         if (type != null) {


### PR DESCRIPTION
This allows using Navigate | Symbol... for top-level functions, top-level variables and typedefs.
I discussed this locally in the office and we thought that classes also should be in the list of symbols.
It seems that in Java classes are included too.