### PR TITLE
Generate documentation using Analysis Server, when possible.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -3,14 +3,17 @@ package com.jetbrains.lang.dart.ide.documentation;
 import com.intellij.lang.documentation.DocumentationProvider;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartComponentType;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
 import com.jetbrains.lang.dart.psi.DartSetterDeclaration;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import org.dartlang.analysis.server.protocol.HoverInformation;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -20,6 +23,25 @@ import java.util.List;
 
 public class DartDocumentationProvider implements DocumentationProvider {
   private static final String BASE_DART_DOC_URL = "http://api.dartlang.org/docs/releases/latest/";
+
+  @Override
+  public String generateDoc(PsiElement element, PsiElement originalElement) {
+    final String serverDoc = generateDocServer(originalElement);
+    if (serverDoc != null) {
+      return serverDoc;
+    }
+    return DartDocUtil.generateDoc(element);
+  }
+
+  @Override
+  public PsiElement getDocumentationElementForLink(PsiManager psiManager, String link, PsiElement context) {
+    return null;
+  }
+
+  @Override
+  public PsiElement getDocumentationElementForLookupItem(PsiManager psiManager, Object object, PsiElement element) {
+    return null;
+  }
 
   @Override
   public String getQuickNavigateInfo(PsiElement element, PsiElement originalElement) {
@@ -44,22 +66,29 @@ public class DartDocumentationProvider implements DocumentationProvider {
   }
 
   @Nullable
-  private static String getLibRelatedUrlPart(@NotNull final PsiElement element) {
-    for (VirtualFile libFile : DartResolveUtil.findLibrary(element.getContainingFile())) {
-      final DartUrlResolver urlResolver = DartUrlResolver.getInstance(element.getProject(), libFile);
-
-      final String dartUrl = urlResolver.getDartUrlForFile(libFile);
-      // "dart:html" -> "dart_html"
-      if (dartUrl.startsWith(DartUrlResolver.DART_PREFIX)) {
-        return "dart_" + dartUrl.substring(DartUrlResolver.DART_PREFIX.length());
-      }
-      // "package:unittest" -> "unittest"
-      if (dartUrl.startsWith(DartUrlResolver.PACKAGE_PREFIX)) {
-        return dartUrl.substring(DartUrlResolver.PACKAGE_PREFIX.length());
-      }
+  public static String generateDocServer(HoverInformation hover) {
+    if (hover == null) {
+      return null;
     }
+    // prepare data
+    final String elementDescription = hover.getElementDescription();
+    final String containingLibraryName = hover.getContainingLibraryName();
+    final String containingClassDescription = hover.getContainingClassDescription();
+    final String staticType = hover.getStaticType();
+    final String propagatedType = hover.getPropagatedType();
+    final String docText = hover.getDartdoc();
+    return DartDocUtil
+      .generateDoc(elementDescription, false, docText, containingLibraryName, containingClassDescription, staticType, propagatedType);
+  }
 
-    return null;
+  @Nullable
+  public static HoverInformation getSingleHover(@NotNull final PsiFile psiFile, final int offset) {
+    final String filePath = psiFile.getVirtualFile().getPath();
+    final List<HoverInformation> hoverList = DartAnalysisServerService.getInstance().analysis_getHover(filePath, offset);
+    if (hoverList.isEmpty()) {
+      return null;
+    }
+    return hoverList.get(0);
   }
 
   @Nls
@@ -94,18 +123,38 @@ public class DartDocumentationProvider implements DocumentationProvider {
     return resultUrl.toString();
   }
 
-  @Override
-  public String generateDoc(PsiElement element, PsiElement originalElement) {
-    return DartDocUtil.generateDoc(element);
+  @Nullable
+  private static String generateDocServer(PsiElement element) {
+    final HoverInformation hover = getSingleHover(element);
+    return generateDocServer(hover);
   }
 
-  @Override
-  public PsiElement getDocumentationElementForLookupItem(PsiManager psiManager, Object object, PsiElement element) {
+  @Nullable
+  private static String getLibRelatedUrlPart(@NotNull final PsiElement element) {
+    for (VirtualFile libFile : DartResolveUtil.findLibrary(element.getContainingFile())) {
+      final DartUrlResolver urlResolver = DartUrlResolver.getInstance(element.getProject(), libFile);
+
+      final String dartUrl = urlResolver.getDartUrlForFile(libFile);
+      // "dart:html" -> "dart_html"
+      if (dartUrl.startsWith(DartUrlResolver.DART_PREFIX)) {
+        return "dart_" + dartUrl.substring(DartUrlResolver.DART_PREFIX.length());
+      }
+      // "package:unittest" -> "unittest"
+      if (dartUrl.startsWith(DartUrlResolver.PACKAGE_PREFIX)) {
+        return dartUrl.substring(DartUrlResolver.PACKAGE_PREFIX.length());
+      }
+    }
+
     return null;
   }
 
-  @Override
-  public PsiElement getDocumentationElementForLink(PsiManager psiManager, String link, PsiElement context) {
+  @Nullable
+  private static HoverInformation getSingleHover(final PsiElement element) {
+    if (element != null) {
+      final PsiFile psiFile = element.getContainingFile();
+      final int offset = element.getTextOffset();
+      return getSingleHover(psiFile, offset);
+    }
     return null;
   }
 }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.HoverInformation;
+
+public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    DartTestUtils.configureDartSdk(myModule, getTestRootDisposable(), true);
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  public void testAbstractClassSig() throws Exception {
+    doTest("<code><b>Signature:</b> abstract class Foo extends Bar<br></code>", "abstract class <caret>Foo extends Bar { }\nclass Bar { }");
+  }
+
+  public void testClassMultilineDoc1() throws Exception {
+    doTest("<code><b>Signature:</b> class A<br></code><br><pre><code>     doc1\n" +
+           "</code></pre>\n"                                                      +
+           "\n"                                                                   +
+           "<p>doc2\n"                                                            +
+           " doc3</p>\n"                                                          +
+           "\n"                                                                   +
+           "<p>   doc4</p>\n"                                                     +
+           "\n"                                                                   +
+           "<pre><code>    code\n"                                                +
+           "</code></pre>\n",
+
+           "/** 1 */\n"     +
+           "/**\n"          +
+           " *      doc1\n" +
+           " * doc2\n"      +
+           " *  doc3\n"     +
+           " *\n"           +
+           " *    doc4\n"   +
+           " * \n"          +
+           " *     code\n"  +
+           " */\n"          +
+           "// non-doc\n"   +
+           "class <caret>A{}");
+  }
+
+  public void testClassMultilineDoc2() throws Exception {
+    doTest("<code><b>Signature:</b> abstract class A<br></code><br><p>doc1\n" +
+           "doc2\n"                                                           +
+           " doc3\n"                                                          +
+           "doc4\n"                                                           +
+           "doc5\n"                                                           +
+           " doc6</p>\n",
+
+           "@deprecated\n"  +
+           "/**\n"          +
+           "*doc1\n"        +
+           "* doc2\n"       +
+           "*  doc3\n"      +
+           "     *doc4\n"   +
+           "     * doc5\n"  +
+           "     *  doc6\n" +
+           " */\n"          +
+           "abstract class <caret>A{}");
+  }
+
+  public void testClassSingleLineDocs1() throws Exception {
+    doTest("<code><b>Signature:</b> class A<br></code><br><p>  doc1\n" +
+           "/* not doc */\n"                                           +
+           "doc2</p>\n",
+
+           "// not doc \n"    +
+           "///   doc1  \n"   +
+           " /* not doc */\n" +
+           "   /// doc2   \n" +
+           " // not doc \n"   +
+           "class <caret>A{}");
+  }
+
+  public void testClassSingleLineDocs2() throws Exception {
+    doTest("<code><b>Signature:</b> class A<br></code><br><p>  doc1\n" +
+           "/* not doc */\n"                                           +
+           "doc2</p>\n",
+
+           "@deprecated"      +
+           "// not doc \n"    +
+           "///   doc1  \n"   +
+           " /* not doc */\n" +
+           "   /// doc2   \n" +
+           " // not doc \n"   +
+           "class <caret>A{}");
+  }
+
+  public void testConstructorSig() throws Exception {
+    doTest("<code><b>Signature:</b> Z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z(); }");
+  }
+
+  public void testEnumSig() throws Exception {
+    doTest("<code><b>Signature:</b> enum Foo<br></code>", "enum <caret>Foo { BAR }");
+  }
+
+  public void testFieldSig1() throws Exception {
+    doTest("<code><b>Signature:</b> int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
+           "class Z { int <caret>y = 42; }");
+  }
+
+  public void testFieldSig2() throws Exception {
+    doTest("<code><b>Signature:</b> int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
+           "class Z { int <caret>y; }");
+  }
+
+  public void testFunctionDoc1() throws Exception {
+    doTest("<code><b>Signature:</b> foo(int x) → void<br></code><br><p>A function on [x]s.</p>\n",
+           "/// A function on [x]s.\nvoid <caret>foo(int x) { }");
+  }
+
+  public void testFunctionDoc2() throws Exception {
+    doTest("<code><b>Signature:</b> foo(int x) → void<br></code><br><p>Good for:</p>\n" +
+           "\n" +
+           "<ul>\n" +
+           "<li>this</li>\n" +
+           "<li>that</li>\n" +
+           "</ul>\n", "/** Good for:\n\n" +
+                      " * * this\n" +
+                      " * * that\n" +
+                      "*/\n" +
+                      "\nvoid <caret>foo(int x) { }");
+  }
+
+  //public void testMetaClassSig2() throws Exception {
+  //  doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
+  //         "@Meta(\'foo\') class <caret>A {};\n" +
+  //         "class Meta {\n" +
+  //         "  final String name;\n" +
+  //         "  const Meta([this.name]);\n" +
+  //         "}");
+  //}
+
+  public void testFunctionSig1() throws Exception {
+    doTest("<code><b>Signature:</b> calc(int x) → int<br></code>", "int <caret>calc(int x) => x + 42;");
+  }
+
+  public void testFunctionSig10() throws Exception {
+    doTest("<code><b>Signature:</b> x({bool b}) → void<br></code>", "void <caret>x({bool b}){};");
+  }
+
+  public void testFunctionSig2() throws Exception {
+    doTest("<code><b>Signature:</b> foo([int x = 3]) → dynamic<br></code>", "<caret>foo([int x = 3]) { print(x); }");
+  }
+
+  public void testFunctionSig3() throws Exception {
+    doTest("<code><b>Signature:</b> foo([int x = 3]) → void<br></code>", "void <caret>foo([int x = 3]) { print(x); }");
+  }
+
+  public void testFunctionSig4() throws Exception {
+    doTest("<code><b>Signature:</b> foo(int x, {int y, int z}) → void<br></code>", "void <caret>foo(int x, {int y, int z}) { }");
+  }
+
+  public void testFunctionSig5() throws Exception {
+    doTest("<code><b>Signature:</b> x(List&lt;dynamic&gt; e) → dynamic<br></code>", "E <caret>x(List<E> e) { }");
+  }
+
+  public void testFunctionSig6() throws Exception {
+    doTest("<code><b>Signature:</b> calc(() → int x) → int<br></code>", "int <caret>calc(int x()) => null;");
+  }
+
+  public void testFunctionSig7() throws Exception {
+    doTest("<code><b>Signature:</b> foo(Map&lt;int, String&gt; p) → Map&lt;String, int&gt;<br></code>",
+           "Map<String, int> <caret>foo(Map<int, String> p) => null;");
+  }
+
+  public void testFunctionSig8() throws Exception {
+    doTest("<code><b>Signature:</b> x() → dynamic<br></code>", "<caret>x() => null;");
+  }
+
+  public void testFunctionSig9() throws Exception {
+    doTest("<code><b>Signature:</b> x({bool b: true}) → dynamic<br></code>", "<caret>x({bool b: true}){};");
+  }
+
+  public void testGetterSig() throws Exception {
+    doTest("<code><b>Signature:</b> get x → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int get <caret>x => 0; }");
+  }
+
+  public void testImplementsSig1() throws Exception {
+    doTest("<code><b>Signature:</b> abstract class Foo implements Bar<br></code>",
+           "abstract class <caret>Foo implements Bar<T> { }\nclass Bar { }");
+  }
+
+  public void testLibraryClassDoc() throws Exception {
+    doTest("<code><b>Signature:</b> class A<br><br><b>Containing library:</b> c.b.a<br></code>", "library c.b.a;\nclass <caret>A {}");
+  }
+
+  public void testMetaClassSig1() throws Exception {
+    doTest("<code><b>Signature:</b> class A<br></code>", " @deprecated class <caret>A {}");
+  }
+
+  public void testMethodMultilineDoc() throws Exception {
+    doTest("<code><b>Signature:</b> foo() → dynamic<br><br><b>Containing class:</b> A<br></code><br><pre><code>     doc1\n" +
+           "</code></pre>\n"                                                                                                +
+           "\n"                                                                                                             +
+           "<p>doc2\n"                                                                                                      +
+           " doc3</p>\n"                                                                                                    +
+           "\n"                                                                                                             +
+           "<p>   doc4</p>\n"                                                                                               +
+           "\n"                                                                                                             +
+           "<pre><code>    code\n"                                                                                          +
+           "</code></pre>\n",
+
+           "class A{\n"       +
+           "/** 1 */\n"       +
+           "/**\n"            +
+           " *      doc1\n"   +
+           " * doc2\n"        +
+           " *  doc3\n"       +
+           " *\n"             +
+           " *    doc4\n"     +
+           " * \n"            +
+           " *     code\n"    +
+           " */\n"            +
+           "// non-doc\n"     +
+           "<caret>foo(){}\n" +
+           "}");
+  }
+
+  public void testMethodSig1() throws Exception {
+    doTest("<code><b>Signature:</b> y() → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int <caret>y() => 42; }");
+  }
+
+  public void testMethodSingleLineDocs() throws Exception {
+    doTest("<code><b>Signature:</b> foo() → dynamic<br><br><b>Containing class:</b> A<br></code><br><p>  doc1\n" +
+           "/* not doc */\n" +
+           "doc2</p>\n", "class A{\n" +
+                         "// not doc \n" +
+                         "///   doc1  \n" +
+                         " /* not doc */\n" +
+                         "   /// doc2   \n" +
+                         " // not doc \n" +
+                         "<caret>foo(){}\n" +
+                         "}");
+  }
+
+  public void testMixinSig1() throws Exception {
+    doTest("<code><b>Signature:</b> class Foo2 extends Bar1 with Baz1, Baz2<br></code>",
+           "class Bar1 {} class Baz1{} class Baz2 {} class <caret>Foo2 = Bar1<E> with Baz1<K>, Baz2");
+  }
+
+  public void testMixinSig2() throws Exception {
+    doTest("<code><b>Signature:</b> class X extends Y with Z<br></code>", "class Y {} class Z {} class <caret>X extends Y with Z { }");
+  }
+
+  public void testNamedConstructorSig() throws Exception {
+    doTest("<code><b>Signature:</b> Z.z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z.z(); }");
+  }
+
+  public void testParamClassSig() throws Exception {
+    doTest("<code><b>Signature:</b> class Foo&lt;T&gt;<br></code>", "class <caret>Foo<T>{ }");
+  }
+
+  public void testParamClassSig2() throws Exception {
+    doTest("<code><b>Signature:</b> class Foo&lt;T, Z&gt;<br></code>", "class <caret>Foo<T,Z>{ }");
+  }
+
+  public void testParamClassSig3() throws Exception {
+    doTest("<code><b>Signature:</b> class Foo implements Bar<br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
+  }
+
+  public void testParamClassSig4() throws Exception {
+    doTest("<code><b>Signature:</b> class Foo implements Bar, Baz<br></code>",
+           "class <caret>Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
+  }
+
+  public void testParamClassSig5() throws Exception {
+    doTest("<code><b>Signature:</b> class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br></code>",
+           "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
+  }
+
+  public void testParamClassSig6() throws Exception {
+    doTest("<code><b>Signature:</b> List&lt;String&gt; ids<br><br><b>Static type:</b> List&lt;String&gt;<br></code>",
+           "class A { foo() { List<String> <caret>ids; }}");
+  }
+
+  public void testParamClassSig7() throws Exception {
+    doTest(
+      "<code><b>Signature:</b> List&lt;Map&lt;String, int&gt;&gt; ids<br><br><b>Static type:</b> List&lt;Map&lt;String, int&gt;&gt;<br></code>",
+      "class A { foo() { List<Map<String, int>> <caret>ids; }}");
+  }
+
+  public void testParamClassSig8() throws Exception {
+    doTest("<code><b>Signature:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; list<br><br>" +
+           "<b>Static type:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt;<br></code>",
+           "class A { foo() { List<List<Map<String, List<Object>>>> <caret>list; }}");
+  }
+
+  public void testSetterSig() throws Exception {
+    doTest("<code><b>Signature:</b> set x(int x) → void<br><br><b>Containing class:</b> Z<br></code>",
+           "class Z { void set <caret>x(int x) { } }");
+  }
+
+  public void testTopLevelVarDoc1() throws Exception {
+    doTest("<code><b>Signature:</b> dynamic x<br><br><b>Containing library:</b> a.b.c<br><br>" +
+           "<b>Static type:</b> dynamic<br><b>Propagated type:</b> String<br></code><br><p>docs1\n" +
+           "docs2</p>\n", "library a.b.c;\n" +
+                          "/// docs1\n" +
+                          "/// docs2\n" +
+                          "@deprecated var <caret>x = 'foo';");
+  }
+
+  public void testTopLevelVarDoc2() throws Exception {
+    doTest("<code><b>Signature:</b> int x<br><br><b>Containing library:</b> a.b.c<br><br><b>Static type:</b> int<br></code>",
+           "library a.b.c;\nint <caret>x = 3;\n");
+  }
+
+  public void testTypedefSig() throws Exception {
+    doTest("<code><b>Signature:</b> typedef F(int x) → int<br></code>", "typedef int <caret>F(int x);");
+  }
+
+  private void doTest(String expectedDoc, String fileContents) {
+    final int caretOffset = fileContents.indexOf("<caret>");
+    assertTrue(caretOffset != -1);
+    final String realContents = fileContents.substring(0, caretOffset) + fileContents.substring(caretOffset + "<caret>".length());
+    final PsiFile psiFile = myFixture.configureByText("test.dart", realContents);
+    //System.out.println(psiFile.getText());
+    myFixture.doHighlighting(); // warm up
+    //final DartComponent dartComponent = PsiTreeUtil.getParentOfType(psiFile.findElementAt(caretOffset), DartComponent.class);
+    //assertNotNull("target element not found at offset " + caretOffset, dartComponent);
+    final HoverInformation hover = DartDocumentationProvider.getSingleHover(psiFile, caretOffset);
+    assertNotNull(hover);
+    //System.out.println(hover);
+    final String doc = DartDocumentationProvider.generateDocServer(hover);
+    assertEquals(expectedDoc, doc);
+    //for (int i = 0; i < 10; i++) {
+    //  final HoverInformation hover = DartDocumentationProvider.getSingleHover(psiFile, caretOffset);
+    //  System.out.println(hover);
+    //  if (hover != null) {
+    //    final String doc = DartDocumentationProvider.generateDocServer(hover);
+    //    assertEquals(expectedDoc, doc);
+    //    System.out.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    //    break;
+    //  }
+    //  Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    //}
+  }
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
@@ -1,6 +1,5 @@
 package com.jetbrains.lang.dart.documentation;
 
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
@@ -22,58 +21,59 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testAbstractClassSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>abstract class <b>Foo</b><br/>extends Bar</code>",
+    doTest("<code><b>Signature:</b> abstract class <b>Foo</b> extends Bar<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>abstract class Foo extends Bar { }\nclass Bar { }");
   }
 
   public void testParamClassSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>Foo</b>&lt;T&gt;</code>",
+    doTest("<code><b>Signature:</b> class <b>Foo</b>&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo<T>{ }");
   }
 
   public void testParamClassSig2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>Foo</b>&lt;T, Z&gt;</code>",
+    doTest("<code><b>Signature:</b> class <b>Foo</b>&lt;T, Z&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>Foo</b><br/>implements Bar</code>",
+    doTest("<code><b>Signature:</b> class <b>Foo</b> implements Bar<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>Foo</b><br/>implements Bar, Baz</code>",
+    doTest("<code><b>Signature:</b> class <b>Foo</b> implements Bar, Baz<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
   }
 
   public void testParamClassSig5() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>Foo</b>&lt;A, B&gt;<br/>extends Bar&lt;A,B&gt;</code>",
+    doTest("<code><b>Signature:</b> class <b>Foo</b>&lt;A, B&gt; extends Bar&lt;A,B&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
   }
 
   public void testParamClassSig6() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>A<br/>List&lt;String&gt; <b>ids</b></code>",
+    doTest("<code><b>Signature:</b> List&lt;String&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
            "class A { foo() { List<String> <caret>ids; }}");
   }
 
   public void testParamClassSig7() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>A<br/>List&lt;Map&lt;String, int&gt;&gt; <b>ids</b></code>",
+    doTest("<code><b>Signature:</b> List&lt;Map&lt;String, int&gt;&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
            "class A { foo() { List<Map<String, int>> <caret>ids; }}");
   }
 
   public void testParamClassSig8() throws Exception {
     doTest(
-      "<code><small><b>test.dart</b></small></code><br/><br/><code>A<br/>List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; <b>list</b></code>",
+      "<code><b>Signature:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; <b>list</b><br><br>" +
+      "<b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
       "class A { foo() { List<List<Map<String, List<Object>>>> <caret>list; }}");
   }
 
   public void testMetaClassSig1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>@deprecated<br/>class <b>A</b></code>",
+    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
            " @deprecated class <caret>A {}");
   }
 
   public void testMetaClassSig2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>@Meta(&#39;foo&#39;)<br/>class <b>A</b></code>",
+    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
            "@Meta(\'foo\') class <caret>A {};\n" +
            "class Meta {\n" +
            "  final String name;\n" +
@@ -82,127 +82,126 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testLibraryClassDoc() throws Exception {
-    doTest("<code><small><b>c.b.a</b></small></code><br/><br/><code>class <b>A</b></code>",
+    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> c.b.a<br></code>",
            "library c.b.a;\nclass <caret>A {}");
   }
 
   public void testImplementsSig1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>abstract class <b>Foo</b><br/>implements Bar&lt;T&gt;</code>",
+    doTest("<code><b>Signature:</b> abstract class <b>Foo</b> implements Bar&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>abstract class Foo implements Bar<T> { }\nclass Bar { }");
   }
 
   public void testMixinSig1() throws Exception {
     doTest(
-      "<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>Foo2</b><br/>extends Bar1&lt;E&gt; with Baz1&lt;K&gt;, Baz2</code>",
+      "<code><b>Signature:</b> class <b>Foo2</b> extends Bar1&lt;E&gt; with Baz1&lt;K&gt;, Baz2<br><br>" +
+      "<b>Containing library:</b> test.dart<br></code>",
       "<caret>class Foo2 = Bar1<E> with Baz1<K>, Baz2");
   }
 
   public void testMixinSig2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>X</b><br/>extends Y with Z</code>",
+    doTest("<code><b>Signature:</b> class <b>X</b> extends Y with Z<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class X extends Y with Z { }");
   }
 
   public void testEnumSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>enum <b>Foo</b></code>",
+    doTest("<code><b>Signature:</b> enum <b>Foo</b><br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>enum Foo { BAR }");
   }
 
   public void testFunctionSig1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>calc</b>(int x) " + RIGHT_ARROW + " int</code>",
+    doTest("<code><b>Signature:</b> <b>calc</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>int calc(int x) => x + 42;");
   }
 
   public void testFunctionSig2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " dynamic</code>",
+    doTest("<code><b>Signature:</b> <b>foo</b>([int x = 3]) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig3() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " void</code>",
+    doTest("<code><b>Signature:</b> <b>foo</b>([int x = 3]) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>void foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig4() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>foo</b>(int x, {int y, int z}) " + RIGHT_ARROW + " void</code>",
+    doTest("<code><b>Signature:</b> <b>foo</b>(int x, {int y, int z}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>void foo(int x, {int y, int z}) { }");
   }
 
   public void testFunctionSig5() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>x</b>(List&lt;E&gt; e) " + RIGHT_ARROW + " E</code>",
+    doTest("<code><b>Signature:</b> <b>x</b>(List&lt;E&gt; e) " + RIGHT_ARROW + " E<br><br><b>Containing library:</b> test.dart<br></code>",
            "E <caret>x(List<E> e) { }");
   }
 
   public void testFunctionSig6() throws Exception {
     doTest(
-      "<code><small><b>test.dart</b></small></code><br/><br/><code><b>calc</b>(x() " + StringUtil.escapeXml(RIGHT_ARROW) + " int) "
-      + RIGHT_ARROW + " int</code>",
+      "<code><b>Signature:</b> <b>calc</b>(x() " + RIGHT_ARROW + " int) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
       "<caret>int calc(int x()) => null;");
   }
 
   public void testFunctionSig7() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>foo</b>(Map&lt;int, String&gt; p) " +
-           RIGHT_ARROW +
-           " Map&lt;String, int&gt;</code>",
+    doTest("<code><b>Signature:</b> <b>foo</b>(Map&lt;int, String&gt; p) " + RIGHT_ARROW + " Map&lt;String, int&gt;<br><br>" +
+           "<b>Containing library:</b> test.dart<br></code>",
            "Map<String, int> <caret>foo(Map<int, String> p) => null;");
   }
 
   public void testFunctionSig8() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>x</b>() " + RIGHT_ARROW + " dynamic</code>",
+    doTest("<code><b>Signature:</b> <b>x</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>x() => null;");
   }
 
   public void testFunctionSig9() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>x</b>({bool b: true}) " + RIGHT_ARROW + " dynamic</code>",
+    doTest("<code><b>Signature:</b> <b>x</b>({bool b: true}) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>x({bool b: true}){};");
   }
 
   public void testFunctionSig10() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>x</b>({bool b}) " + RIGHT_ARROW + " void</code>",
+    doTest("<code><b>Signature:</b> <b>x</b>({bool b}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
            "void <caret>x({bool b}){};");
   }
 
   public void testTypedefSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>typedef <b>a</b>(int x) " + RIGHT_ARROW + " int</code>",
+    doTest("<code><b>Signature:</b> typedef <b>a</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>typedef int a(int x);");
   }
 
   public void testFieldSig1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/>int <b>y</b></code>",
+    doTest("<code><b>Signature:</b> int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int y = 42; }");
   }
 
   public void testFieldSig2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/>int <b>y</b></code>",
+    doTest("<code><b>Signature:</b> int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int y; }");
   }
 
   public void testMethodSig1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/><b>y</b>() " + RIGHT_ARROW + " int</code>",
+    doTest("<code><b>Signature:</b> <b>y</b>() " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int y() => 42; }");
   }
 
   public void testNamedConstructorSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/><b>Z.</b><b>z</b>() " + RIGHT_ARROW + " Z</code>",
+    doTest("<code><b>Signature:</b> <b>Z.</b><b>z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>Z.z(); }");
   }
 
   public void testConstructorSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/><b>Z</b>() " + RIGHT_ARROW + " Z</code>",
+    doTest("<code><b>Signature:</b> <b>Z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>Z(); }");
   }
 
   public void testGetterSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/>get <b>x</b>() " + RIGHT_ARROW + " int</code>",
+    doTest("<code><b>Signature:</b> get <b>x</b> " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int get x => 0; }");
   }
 
   public void testSetterSig() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>Z<br/>set <b>x</b>(int x) " + RIGHT_ARROW + " void</code>",
+    doTest("<code><b>Signature:</b> set <b>x</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>void set x(int x) { } }");
   }
 
   public void testTopLevelVarDoc1() throws Exception {
-    doTest("<code><small><b>a.b.c</b></small></code><br/><br/><code>@deprecated<br/>var <b>x</b></code><br/><br/><p>docs1\ndocs2</p>\n",
+    doTest("<code><b>Signature:</b> var <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code><br><p>docs1\ndocs2</p>\n",
            "library a.b.c;\n" +
            "/// docs1\n" +
            "/// docs2\n" +
@@ -210,20 +209,19 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testTopLevelVarDoc2() throws Exception {
-    doTest("<code><small><b>a.b.c</b></small></code><br/><br/><code>int <b>x</b></code>",
+    doTest("<code><b>Signature:</b> int <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code>",
            "library a.b.c;\n<caret>int x = 3;\n");
   }
 
   public void testFunctionDoc1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>foo</b>(int x) " + RIGHT_ARROW +
-           " void</code><br/><br/><p>A function on [x]s.</p>\n",
+    doTest("<code><b>Signature:</b> <b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br>" +
+           "<b>Containing library:</b> test.dart<br></code><br><p>A function on [x]s.</p>\n",
            "/// A function on [x]s.\n<caret>void foo(int x) { }");
   }
 
-
   public void testFunctionDoc2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code><b>foo</b>(int x) " + RIGHT_ARROW + " void</code>" +
-           "<br/><br/><p> Good for:</p>\n\n" +
+    doTest("<code><b>Signature:</b> <b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>" +
+           "<br><p> Good for:</p>\n\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
            "<li>that</li>\n" +
@@ -236,7 +234,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>A</b></code><br/><br/><p>     doc1\n" +
+    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>     doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
            "\n" +
@@ -260,7 +258,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>@deprecated<br/>abstract class <b>A</b></code><br/><br/><p>doc1\n" +
+    doTest("<code><b>Signature:</b> abstract class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>doc1\n" +
            "doc2\n" +
            " doc3\n" +
            "doc4\n" +
@@ -280,7 +278,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs1() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>class <b>A</b></code><br/><br/><p>doc1\n" +
+    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>doc1\n" +
            "doc2</p>\n",
 
            "// not doc \n" +
@@ -292,7 +290,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs2() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>@deprecated<br/>class <b>A</b></code><br/><br/><p>doc1\n" +
+    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>doc1\n" +
            "doc2</p>\n",
 
            "@deprecated" +
@@ -305,8 +303,8 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testMethodMultilineDoc() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>A<br/><b>foo</b>() " + RIGHT_ARROW + " dynamic</code>" +
-           "<br/><br/><p>     doc1\n" +
+    doTest("<code><b>Signature:</b> <b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
+           "<b>Containing class:</b> A<br></code><br><p>     doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
            "\n" +
@@ -332,8 +330,8 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testMethodSingleLineDocs() throws Exception {
-    doTest("<code><small><b>test.dart</b></small></code><br/><br/><code>A<br/><b>foo</b>() " + RIGHT_ARROW + " dynamic</code>" +
-           "<br/><br/><p>doc1\n" +
+    doTest("<code><b>Signature:</b> <b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
+           "<b>Containing class:</b> A<br></code><br><p>doc1\n" +
            "doc2</p>\n",
 
            "class A{\n" +

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
@@ -27,7 +27,7 @@ public class DartDocumentationProviderTest extends DartCodeInsightFixtureTestCas
   }
 
   public void testFieldRef() throws Exception {
-    doTestQuickNavigateInfo("A<br/>int <b>x</b>", "class A { int <caret>x; foo() => x; }");
+    doTestQuickNavigateInfo("int <b>x</b>", "class A { int <caret>x; foo() => x; }");
   }
 
   public void _testTypeRef() throws Exception {


### PR DESCRIPTION
This may be a solution for [WEB-15936](https://youtrack.jetbrains.com/issue/WEB-15936).

When DAS.getHover() is used, we can show the exact type information about the given element  both static and propagated. Note that even the static type is not always the same as the declared type because of the type promotion process or "strong mode".