### PR TITLE
Remove throws Throwable from step template

### DIFF
--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/steps/JavaSnippet.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/steps/JavaSnippet.java
@@ -25,7 +25,7 @@ class JavaSnippet implements Snippet {
   }
 
   public String template() {
-    return "@{0}(\"{1}\")\npublic void {2}({3}) throws Throwable \'{\'\n    // {4}\n{5}    throw new PendingException();\n\'}\'\n";
+    return "@{0}(\"{1}\")\npublic void {2}({3}) \'{\'\n    // {4}\n{5}    throw new PendingException();\n\'}\'\n";
   }
 
   public String tableHint() {


### PR DESCRIPTION
Hi,
I've not been using Cucumber and its IntelliJ plugin for too long but every time I generate steps from my feature I find myself deleting on each method "throws Throwable". Is there a reason I should let it there ? Otherwise would you accept a real PR (not like this one ^^) to remove it or to enable the user to edit the templates (like junit test templates).
