### PR TITLE
Enable test nav for multiple-file runs

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestEventsConverter.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestEventsConverter.java
@@ -28,14 +28,16 @@ import java.util.regex.Pattern;
 public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter {
 
   private static final String TYPE_START = "start";
-  private static final String TYPE_TEST_START = "testStart";
+  private static final String TYPE_SUITE = "suite";
   private static final String TYPE_ERROR = "error";
   private static final String TYPE_GROUP = "group";
   private static final String TYPE_PRINT = "print";
-  private static final String TYPE_TEST_DONE = "testDone";
   private static final String TYPE_DONE = "done";
+  private static final String TYPE_TEST_START = "testStart";
+  private static final String TYPE_TEST_DONE = "testDone";
 
   private static final String DEF_GROUP = "group";
+  private static final String DEF_SUITE = "suite";
   private static final String DEF_TEST = "test";
   private static final String DEF_METADATA = "metadata";
 
@@ -43,6 +45,7 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
   private static final String JSON_NAME = "name";
   private static final String JSON_ID = "id";
   private static final String JSON_TEST_ID = "testID";
+  private static final String JSON_SUITE_ID = "suiteID";
   private static final String JSON_PARENT_ID = "parentID";
   private static final String JSON_GROUP_IDS = "groupIDs";
   private static final String JSON_RESULT = "result";
@@ -52,6 +55,8 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
   private static final String JSON_ERROR_MESSAGE = "error";
   private static final String JSON_STACK_TRACE = "stackTrace";
   private static final String JSON_IS_FAILURE = "isFailure";
+  private static final String JSON_PATH = "path";
+  private static final String JSON_PLATFORM = "platform";
 
   private static final String RESULT_SUCCESS = "success";
   private static final String RESULT_FAILURE = "failure";
@@ -75,11 +80,13 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
   private ServiceMessageVisitor myCurrentVisitor;
   private Map<Integer, Test> myTestData;
   private Map<Integer, Group> myGroupData;
+  private Map<Integer, Suite> mySuiteData;
 
   public DartTestEventsConverter(@NotNull final String testFrameworkName, @NotNull final TestConsoleProperties consoleProperties) {
     super(testFrameworkName, consoleProperties);
     myTestData = new HashMap<Integer, Test>();
     myGroupData = new HashMap<Integer, Group>();
+    mySuiteData = new HashMap<Integer, Suite>();
   }
 
   protected boolean processServiceMessages(final String text, final Key outputType, final ServiceMessageVisitor visitor)
@@ -122,6 +129,9 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
     }
     else if (TYPE_GROUP.equals(type)) {
       return handleGroup(obj);
+    }
+    else if (TYPE_SUITE.equals(type)) {
+      return handleSuite(obj);
     }
     else if (TYPE_START.equals(type)) {
       return handleStart(obj);
@@ -188,6 +198,14 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
     return result;
   }
 
+  private boolean handleSuite(JsonObject obj) throws ParseException {
+    Suite suite = getSuite(obj.getAsJsonObject(DEF_SUITE));
+    if (!suite.hasPath()) {
+      mySuiteData.remove(suite.getId());
+    }
+    return true;
+  }
+
   private boolean handleError(JsonObject obj) throws ParseException {
     String message = getErrorMessage(obj);
     if (message.startsWith(FAILED_TO_LOAD)) {
@@ -247,6 +265,7 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
   private boolean handleStart(JsonObject obj) {
     myTestData.clear();
     myGroupData.clear();
+    mySuiteData.clear();
     // This apparently is a no-op: myProcessor.signalTestFrameworkAttached();
     return true;
   }
@@ -272,6 +291,7 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
     }
     myTestData.clear();
     myGroupData.clear();
+    mySuiteData.clear();
   }
 
   private boolean processGroupDone(Group group) throws ParseException {
@@ -310,9 +330,16 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
 
   private void addLocationHint(ServiceMessageBuilder messageBuilder, Item item) {
     String location = "unknown";
-    if (myLocation != null) {
+    String loc;
+    if (item.hasSuite()) {
+      loc = FILE_URL_PREFIX + item.getSuite().getPath();
+    }
+    else {
+      loc = myLocation;
+    }
+    if (loc != null) {
       String nameList = GSON.toJson(item.nameList(), DartTestLocationProvider.STRING_LIST_TYPE);
-      location = myLocation + "," + nameList;
+      location = loc + "," + nameList;
     }
     messageBuilder.addAttribute("locationHint", location);
   }
@@ -348,18 +375,27 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
   }
 
   @NotNull
+  private Suite getSuite(JsonObject obj) throws ParseException {
+    return getItem(obj, mySuiteData);
+  }
+
+  @NotNull
   private <T extends Item> T getItem(JsonObject obj, Map<Integer, T> items) throws ParseException {
     if (obj == null) throw new ParseException("Unexpected null json object", 0);
     T item;
     JsonElement id = obj.get(JSON_ID);
     if (id != null) {
       if (items == myTestData) {
-        @SuppressWarnings("unchecked") T type = (T)Test.from(obj, myGroupData);
+        @SuppressWarnings("unchecked") T type = (T)Test.from(obj, myGroupData, mySuiteData);
         item = type;
       }
-      else {
-        @SuppressWarnings("unchecked") T group = (T)Group.from(obj, myGroupData);
+      else if (items == myGroupData) {
+        @SuppressWarnings("unchecked") T group = (T)Group.from(obj, myGroupData, mySuiteData);
         item = group;
+      }
+      else {
+        @SuppressWarnings("unchecked") T suite = (T)Suite.from(obj);
+        item = suite;
       }
       items.put(id.getAsInt(), item);
     }
@@ -414,6 +450,7 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
     private final int myId;
     private final String myName;
     private final Group myParent;
+    private final Suite mySuite;
     private final Metadata myMetadata;
 
     static int extractId(JsonObject obj) {
@@ -432,10 +469,21 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
       return Metadata.from(obj.get(DEF_METADATA));
     }
 
-    Item(int id, String name, Group parent, Metadata metadata) {
+    static Suite lookupSuite(JsonObject obj, Map<Integer, Suite> suites) {
+      JsonElement suiteObj = obj.get(JSON_SUITE_ID);
+      Suite suite = null;
+      if (suiteObj != null && suiteObj.isJsonPrimitive()) {
+        int parentId = suiteObj.getAsInt();
+        suite = suites.get(parentId);
+      }
+      return suite;
+    }
+
+    Item(int id, String name, Group parent, Suite suite, Metadata metadata) {
       myId = id;
       myName = name;
       myParent = parent;
+      mySuite = suite;
       myMetadata = metadata;
     }
 
@@ -455,6 +503,14 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
         }
       }
       return myName;
+    }
+
+    boolean hasSuite() {
+      return mySuite != null && mySuite.hasPath();
+    }
+
+    Suite getSuite() {
+      return mySuite;
     }
 
     Group getParent() {
@@ -503,33 +559,75 @@ public class DartTestEventsConverter extends OutputToGeneralTestEventsConverter 
   private static class Test extends Item {
     private boolean isRunning = true;
 
-    static Test from(JsonObject obj, Map<Integer, Group> groups) {
+    static Test from(JsonObject obj, Map<Integer, Group> groups, Map<Integer, Suite> suites) {
       int[] groupIds = GSON.fromJson(obj.get(JSON_GROUP_IDS), int[].class);
       Group parent = null;
       if (groupIds != null && groupIds.length > 0) {
         parent = groups.get(groupIds[groupIds.length - 1]);
       }
-      return new Test(extractId(obj), extractName(obj), parent, extractMetadata(obj));
+      Suite suite = lookupSuite(obj, suites);
+      return new Test(extractId(obj), extractName(obj), parent, suite, extractMetadata(obj));
     }
 
-    Test(int id, String name, Group parent, Metadata metadata) {
-      super(id, name, parent, metadata);
+    Test(int id, String name, Group parent, Suite suite, Metadata metadata) {
+      super(id, name, parent, suite, metadata);
     }
   }
 
   private static class Group extends Item {
-    static Group from(JsonObject obj, Map<Integer, Group> groups) {
+    static Group from(JsonObject obj, Map<Integer, Group> groups, Map<Integer, Suite> suites) {
       JsonElement parentObj = obj.get(JSON_PARENT_ID);
       Group parent = null;
       if (parentObj != null && parentObj.isJsonPrimitive()) {
         int parentId = parentObj.getAsInt();
         parent = groups.get(parentId);
       }
-      return new Group(extractId(obj), extractName(obj), parent, extractMetadata(obj));
+      Suite suite = lookupSuite(obj, suites);
+      return new Group(extractId(obj), extractName(obj), parent, suite, extractMetadata(obj));
     }
 
-    Group(int id, String name, Group parent, Metadata metadata) {
-      super(id, name, parent, metadata);
+    Group(int id, String name, Group parent, Suite suite, Metadata metadata) {
+      super(id, name, parent, suite, metadata);
+    }
+  }
+
+  private static class Suite extends Item {
+    static Metadata NoMetadata = new Metadata();
+    static String NONE = "<none>";
+
+    static Suite from(JsonObject obj) {
+      return new Suite(extractId(obj), extractPath(obj), extractPlatform(obj));
+    }
+
+    static String extractPath(JsonObject obj) {
+      JsonElement elem = obj.get(JSON_PATH);
+      if (elem == null || elem.isJsonNull()) return NONE;
+      return elem.getAsString();
+    }
+
+    static String extractPlatform(JsonObject obj) {
+      JsonElement elem = obj.get(JSON_PLATFORM);
+      if (elem == null || elem.isJsonNull()) return NONE;
+      return elem.getAsString();
+    }
+
+    private final String myPlatform;
+
+    Suite(int id, String path, String platform) {
+      super(id, path, null, null, NoMetadata);
+      myPlatform = platform;
+    }
+
+    String getPath() {
+      return getName();
+    }
+
+    String getPlatform() {
+      return myPlatform;
+    }
+
+    boolean hasPath() {
+      return getPath() != NONE;
     }
   }
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/test/DartTestEventsConverterTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/test/DartTestEventsConverterTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class DartTestEventsConverterTest extends BaseSMTRunnerTestCase {
 
   // Do not reformat this list.
-  private static final String[] SampleEvents = {
+  private static final String[] Sample1Events = {
     // @formatter:off
     "/usr/local/opt/dart/libexec/bin/dart --ignore-unrecognized-flags --checked --enable-vm-service:51706 --trace_service_pause_events file:///usr/local/opt/dart/libexec/bin/snapshots/pub.dart.snapshot run test:test -r json test/formatter_test.dart -n \"line endings\"\n",
     "Observatory listening on http://127.0.0.1:51706\n",
@@ -68,7 +68,7 @@ public class DartTestEventsConverterTest extends BaseSMTRunnerTestCase {
   };
 
   // Do not reformat this list.
-  private static final String[] SampleSignals = {
+  private static final String[] Sample1Signals = {
     // @formatter:off
     "start uses given line ending",
     "finish uses given line ending",
@@ -94,7 +94,87 @@ public class DartTestEventsConverterTest extends BaseSMTRunnerTestCase {
     // @formatter:on
   };
 
-  private static final int[] SampleParents = {0, 0, 0, 2, 2, 2, 2, 2, 7, 7, 2, 2};
+  private static final int[] Sample1Parents = {0, 0, 0, 2, 2, 2, 2, 2, 7, 7, 2, 2};
+
+  // Do not reformat this list.
+  private static final String[] Sample2Events = {
+    // @formatter:off
+    "/usr/local/opt/dart/libexec/bin/dart --ignore-unrecognized-flags --checked --trace_service_pause_events file:///usr/local/opt/dart/libexec/bin/snapshots/pub.dart.snapshot run test:test -r json /Users/messick/src/quiver-dart/test/\n",
+    "{\"protocolVersion\":\"0.1.0\",\"runnerVersion\":\"0.12.9-dev (from ../test-master)\",\"type\":\"start\",\"time\":0}\n",
+    "{\"suite\":{\"id\":0,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/collect_test.dart\"},\"type\":\"suite\",\"time\":0}\n",
+    "{\"test\":{\"id\":1,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/collect_test.dart\",\"suiteID\":0,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":0}\n",
+    "{\"suite\":{\"id\":2,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/concat_test.dart\"},\"type\":\"suite\",\"time\":1}\n",
+    "{\"test\":{\"id\":3,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/concat_test.dart\",\"suiteID\":2,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":1}\n",
+    "{\"suite\":{\"id\":4,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/countdown_timer_test.dart\"},\"type\":\"suite\",\"time\":1}\n",
+    "{\"test\":{\"id\":5,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/countdown_timer_test.dart\",\"suiteID\":4,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":2}\n",
+    "{\"suite\":{\"id\":6,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/create_timer_test.dart\"},\"type\":\"suite\",\"time\":2}\n",
+    "{\"test\":{\"id\":7,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/create_timer_test.dart\",\"suiteID\":6,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":2}\n",
+    "{\"suite\":{\"id\":8,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/enumerate_test.dart\"},\"type\":\"suite\",\"time\":2}\n",
+    "{\"test\":{\"id\":9,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/enumerate_test.dart\",\"suiteID\":8,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":2}\n",
+    "{\"suite\":{\"id\":10,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/future_group_test.dart\"},\"type\":\"suite\",\"time\":3}\n",
+    "{\"test\":{\"id\":11,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/future_group_test.dart\",\"suiteID\":10,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":3}\n",
+    "{\"suite\":{\"id\":12,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/future_stream_test.dart\"},\"type\":\"suite\",\"time\":3}\n",
+    "{\"test\":{\"id\":13,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/future_stream_test.dart\",\"suiteID\":12,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":4}\n",
+    "{\"suite\":{\"id\":14,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/iteration_test.dart\"},\"type\":\"suite\",\"time\":4}\n",
+    "{\"test\":{\"id\":15,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/iteration_test.dart\",\"suiteID\":14,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":4}\n",
+    "{\"testID\":5,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":723}\n",
+    "{\"group\":{\"id\":16,\"suiteID\":4,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":730}\n",
+    "{\"group\":{\"id\":17,\"suiteID\":4,\"parentID\":16,\"name\":\"CountdownTimer\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":730}\n",
+    "{\"test\":{\"id\":18,\"name\":\"CountdownTimer should countdown\",\"suiteID\":4,\"groupIDs\":[16,17],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":732}\n",
+    "{\"testID\":1,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":733}\n",
+    "{\"group\":{\"id\":19,\"suiteID\":0,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":733}\n",
+    "{\"group\":{\"id\":20,\"suiteID\":0,\"parentID\":19,\"name\":\"collect\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":734}\n",
+    "{\"test\":{\"id\":21,\"name\":\"collect should produce no events for no futures\",\"suiteID\":0,\"groupIDs\":[19,20],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":734}\n",
+    "{\"testID\":7,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":734}\n",
+    "{\"group\":{\"id\":22,\"suiteID\":6,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":734}\n",
+    "{\"group\":{\"id\":23,\"suiteID\":6,\"parentID\":22,\"name\":\"createTimer\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":734}\n",
+    "{\"test\":{\"id\":24,\"name\":\"createTimer should be assignable to CreateTimer\",\"suiteID\":6,\"groupIDs\":[22,23],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":735}\n",
+    "{\"testID\":11,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":735}\n",
+    "{\"group\":{\"id\":25,\"suiteID\":10,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":735}\n",
+    "{\"group\":{\"id\":26,\"suiteID\":10,\"parentID\":25,\"name\":\"FutureGroup\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":735}\n",
+    "{\"test\":{\"id\":27,\"name\":\"FutureGroup should complete when all added futures are complete\",\"suiteID\":10,\"groupIDs\":[25,26],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":735}\n",
+    "{\"testID\":9,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":737}\n",
+    "{\"testID\":3,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":748}\n",
+    "{\"testID\":15,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":751}\n",
+    "{\"testID\":13,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":755}\n",
+    "{\"testID\":24,\"result\":\"success\",\"hidden\":false,\"type\":\"testDone\",\"time\":773}\n",
+    "{\"group\":{\"id\":28,\"suiteID\":6,\"parentID\":22,\"name\":\"createTimerPeriodic\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":774}\n",
+    "{\"test\":{\"id\":29,\"name\":\"createTimerPeriodic should be assignable to CreateTimerPeriodic\",\"suiteID\":6,\"groupIDs\":[22,28],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":774}\n",
+    "{\"testID\":21,\"result\":\"success\",\"hidden\":false,\"type\":\"testDone\",\"time\":776}\n",
+    "{\"test\":{\"id\":30,\"name\":\"collect should produce events for future completions in input order\",\"suiteID\":0,\"groupIDs\":[19,20],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":777}\n",
+    "{\"testID\":29,\"result\":\"success\",\"hidden\":false,\"type\":\"testDone\",\"time\":794}\n",
+    "{\"suite\":{\"id\":31,\"platform\":\"vm\",\"path\":\"/Users/messick/src/quiver-dart/test/async/metronome_test.dart\"},\"type\":\"suite\",\"time\":798}\n",
+    "{\"test\":{\"id\":32,\"name\":\"loading /Users/messick/src/quiver-dart/test/async/metronome_test.dart\",\"suiteID\":31,\"groupIDs\":[],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":798}\n",
+    "{\"group\":{\"id\":33,\"suiteID\":8,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":798}\n",
+    "{\"group\":{\"id\":34,\"suiteID\":8,\"parentID\":33,\"name\":\"enumerate\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":798}\n",
+    "{\"test\":{\"id\":35,\"name\":\"enumerate should add indices to its argument\",\"suiteID\":8,\"groupIDs\":[33,34],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":799}\n",
+    "{\"testID\":27,\"result\":\"success\",\"hidden\":false,\"type\":\"testDone\",\"time\":799}\n",
+    "{\"test\":{\"id\":36,\"name\":\"FutureGroup should throw if adding a future after the group is completed\",\"suiteID\":10,\"groupIDs\":[25,26],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":801}\n",
+    "{\"testID\":36,\"result\":\"success\",\"hidden\":false,\"type\":\"testDone\",\"time\":805}\n",
+    "{\"success\":true,\"type\":\"done\",\"time\":4877}\n",
+    "\n",
+    "Process finished with exit code 1\n",
+    // @formatter:on
+  };
+
+  // Do not reformat this list.
+  private static final String[] Sample2Signals = {
+    // @formatter:off
+    "start should countdown",
+    "start should produce no events for no futures",
+    "start should be assignable to CreateTimer",
+    "start should complete when all added futures are complete",
+    "finish should be assignable to CreateTimer",
+    "start should be assignable to CreateTimerPeriodic",
+    "finish should produce no events for no futures",
+    "start should produce events for future completions in input order",
+    "finish should be assignable to CreateTimerPeriodic",
+    "start should add indices to its argument",
+    "finish should complete when all added futures are complete",
+    "start should throw if adding a future after the group is completed",
+    "finish should throw if adding a future after the group is completed",
+    // @formatter:on
+  };
 
   private SMTRunnerConsoleView myConsole;
   private DartTestEventsConverter myEventsConverter;
@@ -105,8 +185,12 @@ public class DartTestEventsConverterTest extends BaseSMTRunnerTestCase {
   private MockPrinter myMockResettablePrinter;
   private Map<Integer, DefaultMutableTreeNode> myNodes;
 
-  public void testSample() throws Exception {
-    runTest(SampleEvents, SampleSignals, SampleParents);
+  public void testSample1() throws Exception {
+    runTest(Sample1Events, Sample1Signals, Sample1Parents);
+  }
+
+  public void testSample2() throws Exception {
+    runTest(Sample2Events, Sample2Signals, new int[]{});
   }
 
   public void testLoadFailure() throws Exception {


### PR DESCRIPTION
@alexander-doroshko This allows double-click nav from test name to test source in the test results view. It also works for groups. The only real problem is for legacy projects that have a single file used to drive all tests, as was needed in package:unittest. The suites are not generated for those runs. Using the new standard "run all tests in a directory" form, the navigation works as expected, and that should make a lot of users happy.