### PR TITLE
Dart Generator refactoring and cleanup of API

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/BaseDartGenerateAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/BaseDartGenerateAction.java
@@ -9,9 +9,12 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.psi.DartClass;
-import com.jetbrains.lang.dart.psi.DartComponent;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
+import com.jetbrains.lang.dart.util.DartResolveUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static com.intellij.psi.util.PsiTreeUtil.getChildrenOfType;
 
 public abstract class BaseDartGenerateAction extends AnAction {
 
@@ -49,16 +52,20 @@ public abstract class BaseDartGenerateAction extends AnAction {
     return dartClass != null;
   }
 
-  protected static boolean doesClassContainMember(@NotNull final DartClass dartClass, @NotNull final String memberName) {
-    if (memberName.isEmpty()) {
+  protected static boolean doesClassContainMethod(@NotNull final DartClass dartClass, @NotNull final String methodName) {
+    if (methodName.isEmpty()) {
       return false;
     }
-    final DartComponent dartComponent = dartClass.findMemberByName(memberName);
-    if (dartComponent == null) {
-      return true;
+    final DartMethodDeclaration[] methodDeclarations = getChildrenOfType(DartResolveUtil.getBody(dartClass), DartMethodDeclaration.class);
+    if (methodDeclarations == null) {
+      return false;
     }
-    final DartClass containingClass = PsiTreeUtil.getParentOfType(dartComponent, DartClass.class);
-    return containingClass != dartClass;
+    for (DartMethodDeclaration methodDecaration : methodDeclarations) {
+      if (methodName.equals(methodDecaration.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateAccessorHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateAccessorHandler.java
@@ -1,17 +1,14 @@
 package com.jetbrains.lang.dart.ide.generation;
 
-import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.Condition;
+import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartComponentType;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 
 import java.util.List;
-import java.util.Map;
 
-/**
- * @author: Fedor.Korotkov
- */
 public abstract class DartGenerateAccessorHandler extends BaseDartGenerateHandler {
 
   private final CreateGetterSetterFix.Strategy myStrategy;
@@ -25,25 +22,17 @@ public abstract class DartGenerateAccessorHandler extends BaseDartGenerateHandle
     return new CreateGetterSetterFix(dartClass, myStrategy);
   }
 
-  @Override
-  protected void collectCandidates(DartClass dartClass, List<DartComponent> candidates) {
-    final List<DartComponent> subComponents = DartResolveUtil.getNamedSubComponents(dartClass);
-
-    for (DartComponent dartComponent : subComponents) {
-      if (DartComponentType.typeOf(dartComponent) != DartComponentType.FIELD) continue;
-      if (dartComponent.isStatic()) continue;
-
-      if (!myStrategy.accept(dartComponent.getName(), subComponents)) continue;
-
-      candidates.add(dartComponent);
-    }
-  }
 
   @Override
-  protected void collectCandidates(Map<Pair<String, Boolean>, DartComponent> classMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superClassesMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superInterfacesMembersMap,
-                                   List<DartComponent> candidates) {
-    // ignore
+  protected void collectCandidates(final DartClass dartClass, List<DartComponent> candidates) {
+    candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass).values(), new Condition<DartComponent>() {
+      @Override
+      public boolean value(DartComponent component) {
+        return DartComponentType.typeOf(component) == DartComponentType.FIELD &&
+               !component.isStatic() &&
+               myStrategy.accept(component.getName(), DartResolveUtil.getNamedSubComponents(dartClass));
+      }
+    }));
   }
+
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorAction.java
@@ -1,8 +1,5 @@
 package com.jetbrains.lang.dart.ide.generation;
 
-/**
- * @author: Fedor.Korotkov
- */
 public class DartGenerateConstructorAction extends BaseDartGenerateAction {
   @Override
   protected BaseDartGenerateHandler getGenerateHandler() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorHandler.java
@@ -1,7 +1,6 @@
 package com.jetbrains.lang.dart.ide.generation;
 
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartComponentType;
@@ -9,11 +8,7 @@ import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
 
 import java.util.List;
-import java.util.Map;
 
-/**
- * Created by fedorkorotkov.
- */
 public class DartGenerateConstructorHandler extends BaseDartGenerateHandler {
   @Override
   protected String getTitle() {
@@ -26,15 +21,13 @@ public class DartGenerateConstructorHandler extends BaseDartGenerateHandler {
   }
 
   @Override
-  protected void collectCandidates(Map<Pair<String, Boolean>, DartComponent> classMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superClassesMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superInterfacesMembersMap,
-                                   List<DartComponent> candidates) {
-    candidates.addAll(ContainerUtil.findAll(classMembersMap.values(), new Condition<DartComponent>() {
+  protected void collectCandidates(DartClass dartClass, List<DartComponent> candidates) {
+    candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass).values(), new Condition<DartComponent>() {
       @Override
       public boolean value(DartComponent component) {
         return DartComponentType.typeOf(component) == DartComponentType.FIELD;
       }
     }));
   }
+
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateGetterAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateGetterAction.java
@@ -2,9 +2,6 @@ package com.jetbrains.lang.dart.ide.generation;
 
 import com.jetbrains.lang.dart.DartBundle;
 
-/**
- * @author: Fedor.Korotkov
- */
 public class DartGenerateGetterAction extends BaseDartGenerateAction {
   @Override
   protected BaseDartGenerateHandler getGenerateHandler() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateGetterSetterAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateGetterSetterAction.java
@@ -2,9 +2,6 @@ package com.jetbrains.lang.dart.ide.generation;
 
 import com.jetbrains.lang.dart.DartBundle;
 
-/**
- * @author: Fedor.Korotkov
- */
 public class DartGenerateGetterSetterAction extends BaseDartGenerateAction {
   @Override
   protected BaseDartGenerateHandler getGenerateHandler() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateNamedConstructorHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateNamedConstructorHandler.java
@@ -16,7 +16,6 @@
 package com.jetbrains.lang.dart.ide.generation;
 
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartComponentType;
@@ -24,7 +23,6 @@ import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
 
 import java.util.List;
-import java.util.Map;
 
 public class DartGenerateNamedConstructorHandler extends BaseDartGenerateHandler {
   @Override
@@ -38,15 +36,13 @@ public class DartGenerateNamedConstructorHandler extends BaseDartGenerateHandler
   }
 
   @Override
-  protected void collectCandidates(Map<Pair<String, Boolean>, DartComponent> classMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superClassesMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superInterfacesMembersMap,
-                                   List<DartComponent> candidates) {
-    candidates.addAll(ContainerUtil.findAll(classMembersMap.values(), new Condition<DartComponent>() {
+  protected void collectCandidates(DartClass dartClass, List<DartComponent> candidates) {
+    candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass).values(), new Condition<DartComponent>() {
       @Override
       public boolean value(DartComponent component) {
         return DartComponentType.typeOf(component) == DartComponentType.FIELD;
       }
     }));
   }
+
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateSetterAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateSetterAction.java
@@ -2,9 +2,6 @@ package com.jetbrains.lang.dart.ide.generation;
 
 import com.jetbrains.lang.dart.DartBundle;
 
-/**
- * @author: Fedor.Korotkov
- */
 public class DartGenerateSetterAction extends BaseDartGenerateAction {
   @Override
   protected BaseDartGenerateHandler getGenerateHandler() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateToStringAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateToStringAction.java
@@ -32,7 +32,7 @@ public class DartGenerateToStringAction extends BaseDartGenerateAction {
     if (dartClass == null) {
       return false;
     }
-    return doesClassContainMember(dartClass, TO_STRING);
+    return !doesClassContainMethod(dartClass, TO_STRING);
   }
 
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateToStringHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateToStringHandler.java
@@ -16,15 +16,14 @@
 package com.jetbrains.lang.dart.ide.generation;
 
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartComponentType;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Map;
 
 public class DartGenerateToStringHandler extends BaseDartGenerateHandler {
   @Override
@@ -37,12 +36,10 @@ public class DartGenerateToStringHandler extends BaseDartGenerateHandler {
     return new CreateToStringFix(dartClass);
   }
 
+
   @Override
-  protected void collectCandidates(Map<Pair<String, Boolean>, DartComponent> classMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superClassesMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superInterfacesMembersMap,
-                                   List<DartComponent> candidates) {
-    candidates.addAll(ContainerUtil.findAll(classMembersMap.values(), new Condition<DartComponent>() {
+  protected void collectCandidates(@NotNull final DartClass dartClass, @NotNull final List<DartComponent> candidates) {
+    candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass).values(), new Condition<DartComponent>() {
       @Override
       public boolean value(DartComponent component) {
         return DartComponentType.typeOf(component) == DartComponentType.FIELD;

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartImplementMethodHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartImplementMethodHandler.java
@@ -16,19 +16,19 @@ public class DartImplementMethodHandler extends BaseDartGenerateHandler {
   }
 
   @Override
-  protected void collectCandidates(Map<Pair<String, Boolean>, DartComponent> classMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superClassesMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superInterfacesMembersMap,
-                                   List<DartComponent> candidates) {
-    Map<Pair<String, Boolean>, DartComponent> result = new THashMap<Pair<String, Boolean>, DartComponent>(superInterfacesMembersMap);
-    result.keySet().removeAll(superClassesMembersMap.keySet());
-    for (Map.Entry<Pair<String, Boolean>, DartComponent> entry : superClassesMembersMap.entrySet()) {
+  protected void collectCandidates(DartClass dartClass, List<DartComponent> candidates) {
+    Map<Pair<String, Boolean>, DartComponent> result =
+      new THashMap<Pair<String, Boolean>, DartComponent>(computeSuperInterfacesMembersMap(dartClass));
+    Map<Pair<String, Boolean>, DartComponent> superClassesMemberMap =
+      new THashMap<Pair<String, Boolean>, DartComponent>(computeSuperClassesMemberMap(dartClass));
+    result.keySet().removeAll(superClassesMemberMap.keySet());
+    for (Map.Entry<Pair<String, Boolean>, DartComponent> entry : superClassesMemberMap.entrySet()) {
       final DartComponent component = entry.getValue();
       if (component.isAbstract() && !result.containsKey(entry.getKey())) {
         result.put(entry.getKey(), entry.getValue());
       }
     }
-    result.keySet().removeAll(classMembersMap.keySet());
+    result.keySet().removeAll(computeClassMembersMap(dartClass).keySet());
     candidates.addAll(result.values());
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartOverrideMethodHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartOverrideMethodHandler.java
@@ -1,7 +1,10 @@
 package com.jetbrains.lang.dart.ide.generation;
 
+import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Pair;
+import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.DartComponentType;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
 import gnu.trove.THashMap;
@@ -16,13 +19,16 @@ public class DartOverrideMethodHandler extends BaseDartGenerateHandler {
   }
 
   @Override
-  protected void collectCandidates(Map<Pair<String, Boolean>, DartComponent> classMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superClassesMembersMap,
-                                   Map<Pair<String, Boolean>, DartComponent> superInterfacesMembersMap,
-                                   List<DartComponent> candidates) {
-    Map<Pair<String, Boolean>, DartComponent> result = new THashMap<Pair<String, Boolean>, DartComponent>(superClassesMembersMap);
-    result.keySet().removeAll(classMembersMap.keySet());
-    candidates.addAll(result.values());
+  protected void collectCandidates(DartClass dartClass, List<DartComponent> candidates) {
+    Map<Pair<String, Boolean>, DartComponent> result =
+      new THashMap<Pair<String, Boolean>, DartComponent>(computeSuperClassesMemberMap(dartClass));
+    result.keySet().removeAll(computeClassMembersMap(dartClass).keySet());
+    candidates.addAll(ContainerUtil.findAll(result.values(), new Condition<DartComponent>() {
+      @Override
+      public boolean value(DartComponent component) {
+        return component.isPublic() && DartComponentType.typeOf(component) != DartComponentType.FIELD;
+      }
+    }));
   }
 
   @Override

--- a/Dart/testData/generate/Override5.dart
+++ b/Dart/testData/generate/Override5.dart
@@ -1,0 +1,14 @@
+class A {
+  publicMethodInA() {}
+  _privateMethodInA() {}
+}
+
+class B extends A {
+  var someField;
+  publicMethodInB() {}
+  _privateMethodInB() {}
+}
+
+class C extends B {
+  <caret>
+}

--- a/Dart/testData/generate/Override5.txt
+++ b/Dart/testData/generate/Override5.txt
@@ -1,0 +1,24 @@
+class A {
+  publicMethodInA() {}
+  _privateMethodInA() {}
+}
+
+class B extends A {
+  var someField;
+  publicMethodInB() {}
+  _privateMethodInB() {}
+}
+
+class C extends B {
+
+  @override
+  publicMethodInA() {
+    
+  }
+
+  @override
+  publicMethodInB() {
+    
+  }
+
+}

--- a/Dart/testData/generate/Override5.txt~
+++ b/Dart/testData/generate/Override5.txt~
@@ -1,0 +1,24 @@
+class A {
+  publicMethodInA() {}
+  _privateMethodInA() {}
+}
+
+class B extends A {
+  var someField;
+  publicMethodInB() {}
+  _privateMethodInB() {}
+}
+
+class C extends B {
+
+  @override
+  publicMethodInA() {
+
+  }
+
+  @override
+  publicMethodInB() {
+
+  }
+
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/generate/DartGenerateActionTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/generate/DartGenerateActionTest.java
@@ -100,6 +100,10 @@ public class DartGenerateActionTest extends DartGenerateActionTestBase {
     doOverrideTest();
   }
 
+  public void testOverride5() throws Throwable {
+    doOverrideTest();
+  }
+
   public void testOverrideMixin1() throws Throwable {
     doOverrideTest();
   }


### PR DESCRIPTION
- Dart Generator refactoring and cleanup of API in superclasses BaseDartGenerateHandler and BaseDartGenerateAction
- WEB-19915 bug fix: Override method in Dart generator recommends members that are not overridable