### PR TITLE
Ignore new events. Plumb in support for counting files.

### DIFF
--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/test/DartTestEventsConverterTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/test/DartTestEventsConverterTest.java
@@ -121,6 +121,7 @@ public class DartTestEventsConverterTest extends BaseSMTRunnerTestCase {
     "{\"group\":{\"id\":16,\"suiteID\":4,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":730}\n",
     "{\"group\":{\"id\":17,\"suiteID\":4,\"parentID\":16,\"name\":\"CountdownTimer\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":730}\n",
     "{\"test\":{\"id\":18,\"name\":\"CountdownTimer should countdown\",\"suiteID\":4,\"groupIDs\":[16,17],\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"testStart\",\"time\":732}\n",
+    "{\"count\":11,\"type\":\"allSuites\",\"time\":732}",
     "{\"testID\":1,\"result\":\"success\",\"hidden\":true,\"type\":\"testDone\",\"time\":733}\n",
     "{\"group\":{\"id\":19,\"suiteID\":0,\"parentID\":null,\"name\":null,\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":733}\n",
     "{\"group\":{\"id\":20,\"suiteID\":0,\"parentID\":19,\"name\":\"collect\",\"metadata\":{\"skip\":false,\"skipReason\":null}},\"type\":\"group\",\"time\":734}\n",


### PR DESCRIPTION
@alexander-doroshko New event types will no longer cause noisy notifications. I also added parsing support for counting files, in the hope that some day it will be useful. As it is today, the file count is useless. We do not know how many tests are in a file, and we don't know when all the tests in a file have run, so we still cannot update the progress bar. We also don't know how many tests are in a group, and we don't know when a file has completed, so we still cannot update the group status in the results view, either. I didn't make any changes to the progress bar since I think the current two-state display is better than what we could get if we used the file count.