### PR TITLE
Dart '==() and hashCode' generator change

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/BaseDartGenerateAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/BaseDartGenerateAction.java
@@ -8,7 +8,9 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.DartComponentType;
 import com.jetbrains.lang.dart.psi.DartClass;
+import com.jetbrains.lang.dart.psi.DartComponent;
 import com.jetbrains.lang.dart.psi.DartGetterDeclaration;
 import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
@@ -79,6 +81,15 @@ public abstract class BaseDartGenerateAction extends AnAction {
     }
     for (DartGetterDeclaration getterDecaration : getterDeclarations) {
       if (getterName.equals(getterDecaration.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected static boolean hasNonStaticField(@NotNull final DartClass dartClass) {
+    for (DartComponent component : DartResolveUtil.getNamedSubComponents(dartClass)) {
+      if (DartComponentType.typeOf(component) == DartComponentType.FIELD && !component.isStatic()) {
         return true;
       }
     }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateEqualsAndHashcodeAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateEqualsAndHashcodeAction.java
@@ -33,6 +33,6 @@ public class DartGenerateEqualsAndHashcodeAction extends BaseDartGenerateAction 
     if (dartClass == null) {
       return false;
     }
-    return !doesClassContainMethod(dartClass, EQUALS_OP) && !doesClassContainGetter(dartClass, HASHCODE);
+    return hasNonStaticField(dartClass) && !doesClassContainMethod(dartClass, EQUALS_OP) && !doesClassContainGetter(dartClass, HASHCODE);
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateEqualsAndHashcodeHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateEqualsAndHashcodeHandler.java
@@ -16,7 +16,6 @@
 package com.jetbrains.lang.dart.ide.generation;
 
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartComponentType;
@@ -24,7 +23,6 @@ import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartComponent;
 
 import java.util.List;
-import java.util.Map;
 
 public class DartGenerateEqualsAndHashcodeHandler extends BaseDartGenerateHandler {
   @Override
@@ -39,11 +37,11 @@ public class DartGenerateEqualsAndHashcodeHandler extends BaseDartGenerateHandle
 
   @Override
   protected void collectCandidates(DartClass dartClass, List<DartComponent> candidates) {
-  candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass).values(), new Condition<DartComponent>() {
-        @Override
-        public boolean value(DartComponent component) {
-          return DartComponentType.typeOf(component) == DartComponentType.FIELD;
-        }
-      }));
+    candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass).values(), new Condition<DartComponent>() {
+      @Override
+      public boolean value(DartComponent component) {
+        return DartComponentType.typeOf(component) == DartComponentType.FIELD && !component.isStatic();
+      }
+    }));
   }
 }

--- a/Dart/testData/generate/EqualsAndHashCode1.dart
+++ b/Dart/testData/generate/EqualsAndHashCode1.dart
@@ -1,5 +1,6 @@
 class EqualsAndHashCode1 {
   String str;
   var v;
-  int i;<caret>
+  int i;
+  static var s;<caret>
 }

--- a/Dart/testData/generate/EqualsAndHashCode1.txt
+++ b/Dart/testData/generate/EqualsAndHashCode1.txt
@@ -2,6 +2,7 @@ class EqualsAndHashCode1 {
   String str;
   var v;
   int i;
+  static var s;
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
Disable the Dart ==() and hashCode generator if there is not a non-static field in the containing class