### PR TITLE
Always allow "native" constructor in MXML.

### DIFF
--- a/flex/src/com/intellij/lang/javascript/inspections/actionscript/ActionScriptAnnotatingVisitor.java
+++ b/flex/src/com/intellij/lang/javascript/inspections/actionscript/ActionScriptAnnotatingVisitor.java
@@ -310,9 +310,13 @@ public class ActionScriptAnnotatingVisitor extends TypedJSAnnotatingVisitor {
       parent = JSResolveUtil.getClassReferenceForXmlFromContext(parent);
       final String name = node.getName();
 
+      final JSAttributeList attributeList = node.getAttributeList();
+      final boolean isNative = attributeList != null && attributeList.hasModifier(JSAttributeList.ModifierType.NATIVE);
+
       if (parent instanceof JSClass &&
           name != null &&
           name.equals(((JSClass)parent).getName()) &&
+          !isNative &&
           JavaScriptSupportLoader.isFlexMxmFile(parent.getContainingFile())) {
         final Annotation annotation = myHolder.createErrorAnnotation(
           nameIdentifier,


### PR DESCRIPTION
For Ext JS compatibility, Jangaroo needs to specify a constructor signature
in MXML classes. Standard MXML always generates an implicit no-arg
constructor,  thus IDEA marks any constructor in MXML script code as red.

This change allows to specify a constructor signature in MXML using the
`native` keyword (the constructor implementation is generated from the
declarative MXML part).
The `native` keyword does not appear in standard MXML, so no Flex
developer would try to use it anyway, and thus it does not affect normal
Flex development.