### PR TITLE
Made check for "addEventListener" method precise.

### DIFF
--- a/flex/flex-tests/testData/flex_highlighting/StarlingEvent.as
+++ b/flex/flex-tests/testData/flex_highlighting/StarlingEvent.as
@@ -9,6 +9,8 @@ import starling.events.Event;
 import starling.events.ResizeEvent;
 import starling.events.TouchEvent;
 
+import com.acme.MyEventDispatcher;
+
 [Event(type="starling.events.Event")]
 [Event(type="starling.events.TouchEvent")]
 [Event(type="starling.events.<error descr="Expected class flash.events.Event, starling.events.Event or descendant">NotEvent</error>")]
@@ -96,6 +98,8 @@ public class StarlingEvent extends Sprite{
         quad.addEventListener(TouchEvent.TOUCH, function(e:TouchEvent):void{});
         quad.addEventListener(TouchEvent.TOUCH, function(e:starling.events.Event):void{});
         quad.addEventListener(TouchEvent.TOUCH, function(e:starling.events.Event, b:Boolean=true, ...rest):void{});
+
+        new MyEventDispatcher().addEventListener("foo", function(one:String, two:int, three:Boolean):void {});
     }
 }
 }
@@ -107,10 +111,20 @@ package <error>starling.events</error>{
     }
     public class <error><error>ResizeEvent</error></error> extends Event {}
     public class <error><error>NotEvent</error></error> {}
+    public class <error><error>EventDispatcher</error></error> {
+        public function addEventListener(type:String, listener:Function):void{}
+    }
 }
 
 package <error>starling.display</error>{
-    public class <error>Quad</error>{
+    import starling.events.EventDispatcher;
+    public class <error>Quad</error> extends starling.events.EventDispatcher {
+        override public function addEventListener(type:String, listener:Function):void{}
+    }
+}
+
+package <error>com.acme</error>{
+    public class <error>MyEventDispatcher</error> {
         public function addEventListener(type:String, listener:Function):void{}
     }
 }

--- a/flex/src/com/intellij/javascript/flex/mxml/FlexCommonTypeNames.java
+++ b/flex/src/com/intellij/javascript/flex/mxml/FlexCommonTypeNames.java
@@ -18,5 +18,7 @@ public interface FlexCommonTypeNames {
   String IVISUAL_ELEMENT = "mx.core.IVisualElement";
 
   String FLASH_EVENT_FQN = "flash.events.Event";
+  String FLASH_IEVENT_DISPATCHER_FQN = "flash.events.IEventDispatcher";
   String STARLING_EVENT_FQN = "starling.events.Event";
+  String STARLING_EVENT_DISPATCHER_FQN = "starling.events.EventDispatcher";
 }

--- a/flex/src/com/intellij/lang/javascript/inspections/actionscript/ActionScriptTypeChecker.java
+++ b/flex/src/com/intellij/lang/javascript/inspections/actionscript/ActionScriptTypeChecker.java
@@ -75,7 +75,7 @@ public class ActionScriptTypeChecker extends JSTypeChecker<Annotation> {
     if (annotationAndExprType == null &&
         type != null && FUNCTION_CLASS_NAME.equals(type.getResolvedTypeText()) &&
         p instanceof JSParameter &&
-        "addEventListener".equals(((JSFunction)p.getParent().getParent()).getName()) &&
+        isAddEventListenerMethod((JSFunction)p.getParent().getParent()) &&
         (( expr instanceof JSReferenceExpression &&
            (_fun = ((JSReferenceExpression)expr).resolve()) instanceof JSFunction
          ) ||
@@ -159,6 +159,20 @@ public class ActionScriptTypeChecker extends JSTypeChecker<Annotation> {
         }
       }
     }
+  }
+
+  private static boolean isAddEventListenerMethod(final JSFunction method) {
+    if ("addEventListener".equals(method.getName())) {
+      PsiElement methodParent = method.getParent();
+      if (methodParent instanceof JSClass) {
+        JSClass declaringClass = (JSClass)methodParent;
+        if (JSResolveUtil.isAssignableType(FlexCommonTypeNames.FLASH_IEVENT_DISPATCHER_FQN, declaringClass.getQualifiedName(), method)
+          || ActionScriptClassResolver.isParentClass(declaringClass, FlexCommonTypeNames.STARLING_EVENT_DISPATCHER_FQN, false)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   @Nullable


### PR DESCRIPTION
`ActionScriptTypeChecker` complains if a method `addEventListener` is called with a callback that does not have a single parameter of type `flash.events.Event` or `starling.events.Event`.
However, the check used to simply compare the method name, not whether it actually refers to `flash.events.IEventDispatcher#addEventListener()` or `starling.events.EventDispatcher#addEventListener()`. Thus, if a method in another framework is named "addEventLister", but does not require the same contract, you get false negatives.

This fix checks whether the object on which `addEventListener()` is invoked is of a type that implements Flash's `IEventDispatcher` interface or extends Starling's `EventDispatcher` class.

The test file `StarlingEvent.as` has been extended to mock Starling's `EventDispatcher` class and to test the case that when another framework defines its own event dispatcher (here: made-up `com.acme.MyEventDispatcher`), no warning appears.