### PR TITLE
Allow "native" constructor in MXML.

### DIFF
--- a/flex/flex-tests/testData/flex_highlighting/NativeConstructorAllowedInMxml.mxml
+++ b/flex/flex-tests/testData/flex_highlighting/NativeConstructorAllowedInMxml.mxml
@@ -1,0 +1,5 @@
+<mx:Application xmlns:mx="http://www.adobe.com/2006/mxml">
+    <mx:Script>
+      public native function NativeConstructorAllowedInMxml(config:Object = null);
+    </mx:Script>
+</mx:Application>

--- a/flex/flex-tests/testSrc/com/intellij/lang/javascript/FlexHighlightingTest.java
+++ b/flex/flex-tests/testSrc/com/intellij/lang/javascript/FlexHighlightingTest.java
@@ -734,6 +734,11 @@ public class FlexHighlightingTest extends ActionScriptDaemonAnalyzerTestCase {
     doTestFor(true, getTestName(false) + ".mxml", getTestName(false) + "_2.as");
   }
 
+  @JSTestOptions({JSTestOption.WithFlexSdk})
+  public void testNativeConstructorAllowedInMxml() throws Exception {
+    doTestFor(true, getTestName(false) + ".mxml", getTestName(false) + "_2.as");
+  }
+
   @JSTestOptions(
     {JSTestOption.WithJsSupportLoader, JSTestOption.WithFlexFacet/*, WithoutSourceRoot*/})
   public void testEmbedWithAbsLocation() throws Exception {

--- a/flex/src/com/intellij/lang/javascript/inspections/actionscript/ActionScriptAnnotatingVisitor.java
+++ b/flex/src/com/intellij/lang/javascript/inspections/actionscript/ActionScriptAnnotatingVisitor.java
@@ -403,6 +403,7 @@ public class ActionScriptAnnotatingVisitor extends TypedJSAnnotatingVisitor {
       if (parent instanceof JSClass &&
           name != null &&
           name.equals(((JSClass)parent).getName()) &&
+          !isNative(node) &&
           JavaScriptSupportLoader.isFlexMxmFile(parent.getContainingFile())) {
         final Annotation annotation = myHolder.createErrorAnnotation(
           nameIdentifier,
@@ -563,6 +564,11 @@ public class ActionScriptAnnotatingVisitor extends TypedJSAnnotatingVisitor {
         }
       }
     }
+  }
+
+  private static boolean isNative(final JSFunction function) {
+    final JSAttributeList attributeList = function.getAttributeList();
+    return attributeList != null && attributeList.hasModifier(JSAttributeList.ModifierType.NATIVE);
   }
 
   private void reportStaticMethodProblem(JSAttributeList attributeList, String key) {


### PR DESCRIPTION
For Ext JS compatibility, Jangaroo needs to specify a constructor signature in MXML classes. Standard MXML always generates an implicit no-arg constructor,  thus IDEA marks any constructor in MXML script code as red.

This change allows to specify a constructor signature in MXML using the `native` keyword (the constructor implementation is generated from the declarative MXML part).
The `native` keyword does not appear in standard MXML, so no Flex developer would try to use it anyway, and thus it does not affect normal Flex development.

Test `FlexHighlightingTest#testConstructorNotAllowedInMxml()` is still green.
Added new test `FlexHighlightingTest#testNativeConstructorAllowedInMxml()` to assure that `native` constructors can now indeed be used in MXML.