### PR TITLE
Also allow catalog.xml files in JARs, not only in SWCs.

### DIFF
--- a/flex/src/com/intellij/javascript/flex/mxml/schema/CodeContext.java
+++ b/flex/src/com/intellij/javascript/flex/mxml/schema/CodeContext.java
@@ -307,7 +307,7 @@ public class CodeContext {
 
   private static void handleFileDependency(Module module, Map<String, CodeContext> contextsOfModule, VirtualFile file) {
     if (file.getFileType() == FileTypes.ARCHIVE &&
-        ("swc".equalsIgnoreCase(file.getExtension()) || "ane".equalsIgnoreCase(file.getExtension()))) {
+        ("swc".equalsIgnoreCase(file.getExtension()) || "ane".equalsIgnoreCase(file.getExtension()) || "jar".equalsIgnoreCase(file.getExtension()))) {
       final VirtualFile local = file.getFileSystem() instanceof JarFileSystem
                                 ? file : JarFileSystem.getInstance().getJarRootForLocalFile(file);
       if (local == null) return;


### PR DESCRIPTION
Jangaroo uses the same catalog.xml format as Flash/Flex SWC, but packages its artifacts as JARs.
It should not do harm to look for catalog.xml entries in the root directory of JAR archives that are in the dependency list of a Flex module, too.