### PR TITLE
Emit <base /> tag when rendering markdown

### DIFF
--- a/markdown/src/org/intellij/plugins/markdown/ui/preview/MarkdownPreviewFileEditor.java
+++ b/markdown/src/org/intellij/plugins/markdown/ui/preview/MarkdownPreviewFileEditor.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.*;
 import java.beans.PropertyChangeListener;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class MarkdownPreviewFileEditor extends UserDataHolderBase implements FileEditor {
   private final static long PARSING_CALL_TIMEOUT_MS = 50L;
@@ -247,11 +249,18 @@ public class MarkdownPreviewFileEditor extends UserDataHolderBase implements Fil
 
     String text = myDocument.getText();
     final ASTNode parsedTree = new MarkdownParser(MarkdownParserManager.FLAVOUR).buildMarkdownTreeFromString(text);
+    URI baseURI = null;
+    try {
+      baseURI = new URI(myFile.getParent().getPresentableUrl() + "/");
+    } catch (URISyntaxException e) {
+      baseURI = null;
+    }
     final String html = new HtmlGenerator(text,
                                           parsedTree,
                                           MarkdownParserManager.FLAVOUR,
                                           LinkMap.Builder.buildLinkMap(parsedTree, text),
-                                          true)
+                                          true,
+                                          baseURI)
       .generateHtml();
 
     // EA-75860: The lines to the top may be processed slowly; Since we're in pooled thread, we can be disposed already.
@@ -266,8 +275,7 @@ public class MarkdownPreviewFileEditor extends UserDataHolderBase implements Fil
       myLastHtmlOrRefreshRequest = new Runnable() {
         @Override
         public void run() {
-          String directory = myFile.getParent().getPresentableUrl() + "/";
-          final String currentHtml = "<html><head><base href=\"" + directory + "\" /></head>" + html + "</html>";
+          final String currentHtml = "<html><head></head>" + html + "</html>";
           if (!currentHtml.equals(myLastRenderedHtml)) {
             myLastRenderedHtml = currentHtml;
             getPanelGuaranteed().setHtml(myLastRenderedHtml);

--- a/markdown/src/org/intellij/plugins/markdown/ui/preview/MarkdownPreviewFileEditor.java
+++ b/markdown/src/org/intellij/plugins/markdown/ui/preview/MarkdownPreviewFileEditor.java
@@ -266,7 +266,8 @@ public class MarkdownPreviewFileEditor extends UserDataHolderBase implements Fil
       myLastHtmlOrRefreshRequest = new Runnable() {
         @Override
         public void run() {
-          final String currentHtml = "<html><head></head>" + html + "</html>";
+          String directory = myFile.getParent().getPresentableUrl() + "/";
+          final String currentHtml = "<html><head><base href=\"" + directory + "\" /></head>" + html + "</html>";
           if (!currentHtml.equals(myLastRenderedHtml)) {
             myLastRenderedHtml = currentHtml;
             getPanelGuaranteed().setHtml(myLastRenderedHtml);


### PR DESCRIPTION
The Markdown JavaFx previewer does not render images when the images are relative to the directory containing the .md file.  This patch should cause the renderer to emit a properly formed <base /> tag, allowing relative images to be referenced properly.

I'm unfortunately not able to build the plugins to test this.