### PR TITLE
Add Rerun Failed Tests button to test results viewer

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/base/DartRunConfiguration.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/base/DartRunConfiguration.java
@@ -1,0 +1,11 @@
+package com.jetbrains.lang.dart.ide.runner.base;
+
+import com.intellij.execution.configurations.RunConfiguration;
+import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunnerParameters;
+import org.jetbrains.annotations.NotNull;
+
+public interface DartRunConfiguration extends RunConfiguration {
+
+  @NotNull
+  DartCommandLineRunnerParameters getRunnerParameters();
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/base/DartRunConfigurationBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/base/DartRunConfigurationBase.java
@@ -22,7 +22,8 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class DartRunConfigurationBase extends LocatableConfigurationBase implements RefactoringListenerProvider {
+public abstract class DartRunConfigurationBase extends LocatableConfigurationBase
+  implements RefactoringListenerProvider, DartRunConfiguration {
 
   protected DartRunConfigurationBase(final Project project, final ConfigurationFactory factory, final String name) {
     super(project, factory, name);

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -30,7 +30,7 @@ import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.coverage.DartCoverageProgramRunner;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
-import com.jetbrains.lang.dart.ide.runner.base.DartRunConfigurationBase;
+import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.client.DartiumUtil;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunnerParameters;
 import com.jetbrains.lang.dart.pubServer.PubServerManager;
@@ -50,7 +50,7 @@ public class DartCommandLineRunningState extends CommandLineState {
 
   public DartCommandLineRunningState(final @NotNull ExecutionEnvironment env) throws ExecutionException {
     super(env);
-    myRunnerParameters = ((DartRunConfigurationBase)env.getRunProfile()).getRunnerParameters().clone();
+    myRunnerParameters = ((DartRunConfiguration)env.getRunProfile()).getRunnerParameters().clone();
 
     final Project project = env.getProject();
     try {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunner.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunner.java
@@ -1,0 +1,64 @@
+package com.jetbrains.lang.dart.ide.runner.test;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.ExecutionResult;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.ProgramRunner;
+import com.intellij.execution.testframework.AbstractTestProxy;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class DartTestRerunner implements RunProfileState {
+  private final ExecutionEnvironment environment;
+  private final List<AbstractTestProxy> failedTests;
+
+  DartTestRerunner(@NotNull ExecutionEnvironment env, @NotNull List<AbstractTestProxy> tests) {
+    environment = env;
+    failedTests = tests;
+  }
+
+  ExecutionEnvironment getEnvironment() {
+    return environment;
+  }
+
+  @Nullable
+  @Override
+  public ExecutionResult execute(Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
+    DartTestRunningState state = new DartTestRunningState(environment);
+    DartTestRunnerParameters params = state.getParameters();
+    params.setScope(DartTestRunnerParameters.Scope.MULTIPLE_NAMES);
+    params.setTestName(computeTestNameRegexp());
+    return state.execute(executor, runner);
+  }
+
+  @NotNull
+  Module[] getModulesToCompile() {
+    return new Module[0];
+  }
+
+  private String computeTestNameRegexp() {
+    StringBuilder buf = new StringBuilder();
+    boolean needsSeparator = false;
+    for (AbstractTestProxy test : failedTests) {
+      if (test.isPassed()) {
+        continue;
+      }
+      if (test.isLeaf()) {
+        if (needsSeparator) {
+          buf.append('|');
+        }
+        else {
+          needsSeparator = true;
+        }
+        buf.append(StringUtil.escapeToRegexp(test.getName()));
+      }
+    }
+    return buf.toString();
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunnerAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunnerAction.java
@@ -1,0 +1,53 @@
+package com.jetbrains.lang.dart.ide.runner.test;
+
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.RunConfigurationBase;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.testframework.TestConsoleProperties;
+import com.intellij.execution.testframework.actions.AbstractRerunFailedTestsAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.ui.ComponentContainer;
+import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
+import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunnerParameters;
+import org.jetbrains.annotations.NotNull;
+
+class DartTestRerunnerAction extends AbstractRerunFailedTestsAction {
+
+  public DartTestRerunnerAction(@NotNull ComponentContainer componentContainer, @NotNull TestConsoleProperties consoleProperties) {
+    super(componentContainer);
+  }
+
+  @Override
+  protected MyRunProfile getRunProfile(@NotNull ExecutionEnvironment environment) {
+    final RunConfigurationBase configuration = (RunConfigurationBase)myConsoleProperties.getConfiguration();
+    final DartTestRerunner runner = new DartTestRerunner(environment, getFailedTests(configuration.getProject()));
+    return new RerunProfile(configuration, runner);
+  }
+
+  private static class RerunProfile extends MyRunProfile implements DartRunConfiguration {
+    private final DartTestRerunner runner;
+
+    private RerunProfile(RunConfigurationBase configuration, DartTestRerunner runner) {
+      super(configuration);
+      this.runner = runner;
+    }
+
+    @NotNull
+    @Override
+    public DartCommandLineRunnerParameters getRunnerParameters() {
+      return ((DartRunConfiguration)runner.getEnvironment().getRunProfile()).getRunnerParameters();
+    }
+
+    @Override
+    @NotNull
+    public Module[] getModules() {
+      return runner.getModulesToCompile();
+    }
+
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) {
+      return runner;
+    }
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunnerParameters.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunnerParameters.java
@@ -69,7 +69,8 @@ public class DartTestRunnerParameters extends DartCommandLineRunnerParameters im
       GROUP("Test group"),
     @Deprecated // GROUP_OR_TEST_BY_NAME used instead
       METHOD("Test name"),
-    GROUP_OR_TEST_BY_NAME("Group or test by name");
+    GROUP_OR_TEST_BY_NAME("Group or test by name"),
+    MULTIPLE_NAMES("Multiple names"); // Used by test re-runner action; not visible in UI
 
     private final String myPresentableName;
 


### PR DESCRIPTION
@alexander-doroshko Testing is manual. I suggest checking a test suite that has no failures to ensure the button is visible but not active. Then a suite that has one failure, run it, fix the problem, rerun to get same view as first test. Then a suite with multiple failures. For the final one I re-ran it a couple times, fixed a problem, re-ran it and observed the fixed test disappeared from the view. Then re-introduce the problem, re-run failed tests, and see nothing happened (since the modified test was not in the list of failed tests after being fixed).

I needed to do a little refactoring in the framework, but it was mostly conceptual rather than structural.