### PR TITLE
Enable manipulation of console output of Karma test runs

### DIFF
--- a/js-karma/src/com/intellij/javascript/karma/execution/KarmaExecutionSession.java
+++ b/js-karma/src/com/intellij/javascript/karma/execution/KarmaExecutionSession.java
@@ -160,7 +160,7 @@ public class KarmaExecutionSession {
     public KarmaConsoleProperties(KarmaRunConfiguration configuration, Executor executor, KarmaTestProxyFilterProvider filterProvider) {
       super(configuration, FRAMEWORK_NAME, executor);
       myFilterProvider = filterProvider;
-      setUsePredefinedMessageFilter(false);
+      setUsePredefinedMessageFilter(true);
       setIfUndefined(TestConsoleProperties.HIDE_PASSED_TESTS, false);
       setIfUndefined(TestConsoleProperties.HIDE_IGNORED_TEST, true);
       setIfUndefined(TestConsoleProperties.SCROLL_TO_SOURCE, true);


### PR DESCRIPTION
I would like to enhance the output of jasmine js framework when executed by karma by implementing com.intellij.execution.filters.Filter. My filter is neglected because the KarmeExecutionSession sets usePredefinedMessageFilter to false.

Setting this property to `true` would enable plugins to enrich the console output of karma test runs.

For example to add diffing via com.intellij.diff.DiffManager when expected objects are not equal to current objects.
