### PR TITLE
Tighten up format for simple if statements

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
@@ -303,7 +303,11 @@ public class DartSpacingProcessor {
       if (type1 == RPAREN && mySettings.BRACE_STYLE == CommonCodeStyleSettings.END_OF_LINE) {
         // Always have a single space following the closing paren of an if-condition.
         int nsp = mySettings.SPACE_BEFORE_IF_LBRACE ? 1 : 0;
-        return Spacing.createSpacing(nsp, nsp, 0, type2 == BLOCK ? false : mySettings.KEEP_LINE_BREAKS, 0);
+        int lf = 0;
+        if (type2 != BLOCK && mySettings.SPECIAL_ELSE_IF_TREATMENT) {
+          if (FormatterUtil.isFollowedBy(node2, ELSE, SEMICOLON)) lf = 1;
+        }
+        return Spacing.createSpacing(nsp, nsp, lf, type2 == BLOCK ? false : mySettings.KEEP_LINE_BREAKS, 0);
       }
       if (type1 == SEMICOLON && type2 == ELSE) {
         // If the then-part is on the line with the condition put the else-part on the next line.
@@ -555,8 +559,9 @@ public class DartSpacingProcessor {
         return Spacing.createSpacing(1, 1, mySettings.SPECIAL_ELSE_IF_TREATMENT ? 0 : 1, false, mySettings.KEEP_BLANK_LINES_IN_CODE);
       }
       if (type2 != LBRACE) {
-        // Keep single-statement else-part on same line.
-        return Spacing.createSpacing(1, 1, 0, type2 == BLOCK ? false : mySettings.KEEP_LINE_BREAKS, 0);
+        // Keep single-statement else-part on same line?
+        int lf = mySettings.SPECIAL_ELSE_IF_TREATMENT ? 1 : 0;
+        return Spacing.createSpacing(1, 1, lf, type2 == BLOCK ? false : mySettings.KEEP_LINE_BREAKS, 0);
       }
     }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartWrappingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartWrappingProcessor.java
@@ -184,8 +184,12 @@ public class DartWrappingProcessor {
     //
     // If
     //
-    if (elementType == IF_STATEMENT && childType == ELSE) {
-      return createWrap(mySettings.ELSE_ON_NEW_LINE);
+    if (elementType == IF_STATEMENT) {
+      if (childType == ELSE) {
+        return createWrap(mySettings.ELSE_ON_NEW_LINE);
+      } else if (childType != BLOCK && child == child.getTreeParent().getLastChildNode()) {
+        return createWrap(true);
+      }
     }
 
     //

--- a/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -98,7 +98,6 @@ public abstract class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("regression/0000/0042.unit:2");
     KNOWN_TO_FAIL.add("regression/0000/0044.stmt:10");
     KNOWN_TO_FAIL.add("regression/0000/0044.stmt:50");
-    KNOWN_TO_FAIL.add("regression/0000/0045.stmt:1  doesn't wrap after condition on single-line ifs"); // NEW 3/16
     KNOWN_TO_FAIL.add("regression/0000/0046.stmt:1");
     KNOWN_TO_FAIL.add("regression/0000/0050.stmt:1  (indent 2)");
     KNOWN_TO_FAIL.add("regression/0000/0055.unit:17  (indent 12)");
@@ -251,9 +250,6 @@ public abstract class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("regression/0400/0439.stmt:9  (indent 2)"); // NEW 3/26
     KNOWN_TO_FAIL.add("regression/0400/0441.unit:1"); // NEW 3/26
     KNOWN_TO_FAIL.add("regression/0400/0444.unit:1"); // NEW 3/26
-    KNOWN_TO_FAIL.add("regression/0400/0448.stmt:1  (indent 6)"); // NEW 3/26
-    KNOWN_TO_FAIL.add("regression/0400/0448.stmt:15  (indent 4)"); // NEW 3/26
-    KNOWN_TO_FAIL.add("regression/0400/0448.stmt:21  (indent 6)"); // NEW 3/26
     KNOWN_TO_FAIL.add("regression/0400/0454.unit:10"); // NEW 3/26
     KNOWN_TO_FAIL.add("regression/0400/0462.unit:1"); // NEW 3/26
     KNOWN_TO_FAIL.add("regression/0400/0462.unit:21"); // NEW 3/26
@@ -492,10 +488,7 @@ public abstract class DartStyleTest extends FormatterTestCase {
     KNOWN_TO_FAIL.add("whitespace/directives.unit:53  configuration"); // https://github.com/munificent/dep-interface-libraries
     KNOWN_TO_FAIL.add("whitespace/directives.unit:57  configuration"); // https://github.com/munificent/dep-interface-libraries
     KNOWN_TO_FAIL.add("whitespace/expressions.stmt:110  ?. operator");
-    KNOWN_TO_FAIL.add("whitespace/if.stmt:44  single-expression else body"); // NEW 3/16
     KNOWN_TO_FAIL.add("whitespace/if.stmt:67  long if without curlies"); // NEW 3/16
-    KNOWN_TO_FAIL.add("whitespace/if.stmt:72  long if else without curlies"); // NEW 3/16
-    KNOWN_TO_FAIL.add("whitespace/if.stmt:82  long if long else without curlies"); // NEW 3/16
   }
 
   protected String getFileExtension() {


### PR DESCRIPTION
@alexander-doroshko Some new tests exercise this pattern:
```
if (cond)
  print(1);
else
  print(2);
```
We were not handling it well.