### PR TITLE
Terminate tests when Rerun is clicked

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunner.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunner.java
@@ -1,12 +1,16 @@
 package com.jetbrains.lang.dart.ide.runner.test;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.ExecutionManager;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.testframework.AbstractTestProxy;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.execution.ui.RunContentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
@@ -30,6 +34,11 @@ public class DartTestRerunner implements RunProfileState {
   @Nullable
   @Override
   public ExecutionResult execute(Executor executor, @NotNull ProgramRunner runner) throws ExecutionException {
+    RunContentManager contentManager = ExecutionManager.getInstance(environment.getProject()).getContentManager();
+    for (RunContentDescriptor descriptor : contentManager.getAllDescriptors()) {
+      ProcessHandler handler = descriptor.getProcessHandler();
+      if (handler != null) handler.destroyProcess();
+    }
     DartTestRunningState state = new DartTestRunningState(environment);
     DartTestRunnerParameters params = state.getParameters();
     params.setScope(DartTestRunnerParameters.Scope.MULTIPLE_NAMES);

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
@@ -62,14 +62,15 @@ public class DartTestRunningState extends DartCommandLineRunningState {
     if (ActionManager.getInstance().getAction("RerunFailedTests") != null) {
       DartConsoleProperties properties = (DartConsoleProperties)((SMTRunnerConsoleView)consoleView).getProperties();
       AbstractRerunFailedTestsAction rerunFailedTestsAction = properties.createRerunFailedTestsAction(consoleView);
-      assert rerunFailedTestsAction != null;
-      rerunFailedTestsAction.setModelProvider(new Getter<TestFrameworkRunningModel>() {
-        @Override
-        public TestFrameworkRunningModel get() {
-          return ((SMTRunnerConsoleView)consoleView).getResultsViewer();
-        }
-      });
-      executionResult.setRestartActions(rerunFailedTestsAction, new ToggleAutoTestAction());
+      if (rerunFailedTestsAction != null) {
+        rerunFailedTestsAction.setModelProvider(new Getter<TestFrameworkRunningModel>() {
+          @Override
+          public TestFrameworkRunningModel get() {
+            return ((SMTRunnerConsoleView)consoleView).getResultsViewer();
+          }
+        });
+        executionResult.setRestartActions(rerunFailedTestsAction, new ToggleAutoTestAction());
+      }
     }
     else {
       executionResult.setRestartActions(new ToggleAutoTestAction());


### PR DESCRIPTION
@alexander-doroshko This is in response to:
https://youtrack.jetbrains.com/issue/WEB-21067

I believe junit stops tests that are running when the Rerun button is clicked, so that's what this code does.

Manual testing is required, unfortunately.