### PR TITLE
Fix WEB-21189

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartSpacingProcessor.java
@@ -114,9 +114,12 @@ public class DartSpacingProcessor {
     if (AT == type1) return Spacing.createSpacing(0, 0, 0, false, 0);
 
     if (METADATA == type1) {
-      if (parentType == TYPE_PARAMETERS || COMMENTS.contains(type2)) {
+      if (parentType == TYPE_PARAMETERS) {
         // Metadata on type parameters must be inlined.
         return Spacing.createSpacing(1, 1, 0, false, 0);
+      }
+      if (COMMENTS.contains(type2)) {
+        return Spacing.createSpacing(1, 1, 0, true, 0);
       }
       if (parentType == DART_FILE) {
         // Metadata on top-level declarations must be on its own line.

--- a/Dart/testData/formatter/Metadata.dart
+++ b/Dart/testData/formatter/Metadata.dart
@@ -19,3 +19,10 @@
    var a4;
    fun(@Foo13  param){}
  }
+
+@annotation
+// comment
+var a;
+
+@annotation // comment
+var a;

--- a/Dart/testData/formatter/Metadata_after.dart
+++ b/Dart/testData/formatter/Metadata_after.dart
@@ -24,3 +24,10 @@ class Baz {
 
   fun(@Foo13 param) {}
 }
+
+@annotation
+// comment
+var a;
+
+@annotation // comment
+var a;


### PR DESCRIPTION
@alexander-doroshko
https://youtrack.jetbrains.com/issue/WEB-21189

We have to be a little careful because the style guide (or at least its tests) encourages comments inline with metadata, but I agree that the formatter should not remove the newline between them.