### PR TITLE
Callbug

### DIFF
--- a/Dart/gen/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionImpl.java
+++ b/Dart/gen/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionImpl.java
@@ -11,7 +11,7 @@ import static com.jetbrains.lang.dart.DartTokenTypes.*;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 
-public class DartFunctionExpressionImpl extends DartExpressionImpl implements DartFunctionExpression {
+public class DartFunctionExpressionImpl extends DartFunctionExpressionBase implements DartFunctionExpression {
 
   public DartFunctionExpressionImpl(ASTNode node) {
     super(node);

--- a/Dart/src/com/jetbrains/lang/dart/Dart.bnf
+++ b/Dart/src/com/jetbrains/lang/dart/Dart.bnf
@@ -606,6 +606,7 @@ mapLiteralEntry ::= expression ':' expression {recoverWhile="map_literal_entry_r
 private map_literal_entry_recover ::= !(',' | '}')
 
 functionExpression ::= formalParameterList functionExpressionBody
+{mixin="com.jetbrains.lang.dart.psi.impl.DartFunctionExpressionBase"}
 functionSignature ::= metadata* functionDeclarationPrivate
 {mixin="com.jetbrains.lang.dart.psi.impl.AbstractDartComponentImpl" implements="com.jetbrains.lang.dart.psi.DartComponent"}
 private functionDeclarationPrivate ::= returnType componentName formalParameterList | componentName formalParameterList // todo remove, use functionSignature as in spec

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
@@ -1,21 +1,33 @@
 package com.jetbrains.lang.dart.psi.impl;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.lang.ASTNode;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.lang.dart.DartComponentType;
+import com.intellij.ui.RowIcon;
+import com.intellij.util.PlatformIcons;
 import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
 import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class DartFunctionExpressionBase extends DartExpressionImpl {
+abstract public class DartFunctionExpressionBase extends DartExpressionImpl {
 
   public DartFunctionExpressionBase(ASTNode node) {
     super(node);
+  }
+
+  @Override
+  public Icon getIcon(int flags) {
+    Icon icon = AllIcons.Nodes.Function;
+    RowIcon baseIcon = new RowIcon(2);
+    baseIcon.setIcon(icon, 0);
+    Icon visibility = PlatformIcons.PRIVATE_ICON;
+    baseIcon.setIcon(visibility, 1);
+    return baseIcon;
   }
 
   @Override
@@ -41,9 +53,7 @@ public class DartFunctionExpressionBase extends DartExpressionImpl {
         @Nullable
         @Override
         public Icon getIcon(boolean unused) {
-          DartComponentType type = DartComponentType.typeOf(DartFunctionExpressionBase.this);
-          assert type != null;
-          return type.getIcon();
+          return DartFunctionExpressionBase.this.getIcon(0);
         }
       };
     }

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
@@ -1,0 +1,52 @@
+package com.jetbrains.lang.dart.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.navigation.NavigationItem;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.DartComponentType;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class DartFunctionExpressionBase extends DartExpressionImpl {
+
+  public DartFunctionExpressionBase(ASTNode node) {
+    super(node);
+  }
+
+  @Override
+  public ItemPresentation getPresentation() {
+    final PsiElement parent = PsiTreeUtil.getParentOfType(this, DartFunctionExpressionBase.class, DartMethodDeclaration.class,
+                                                          DartFunctionDeclarationWithBodyOrNative.class);
+    if (parent != null) {
+      return new ItemPresentation() {
+        @Nullable
+        @Override
+        public String getPresentableText() {
+          ItemPresentation container = ((NavigationItem)parent).getPresentation();
+          return container == null ? null : "() in " + container.getPresentableText();
+        }
+
+        @Nullable
+        @Override
+        public String getLocationString() {
+          ItemPresentation container = ((NavigationItem)parent).getPresentation();
+          return container == null ? null : container.getLocationString();
+        }
+
+        @Nullable
+        @Override
+        public Icon getIcon(boolean unused) {
+          DartComponentType type = DartComponentType.typeOf(DartFunctionExpressionBase.this);
+          assert type != null;
+          return type.getIcon();
+        }
+      };
+    }
+    return null;
+  }
+}

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/C.dart
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/C.dart
@@ -1,0 +1,11 @@
+foo() {
+  bar((q) {
+    bar((r) {
+      baz();
+    });
+    baz();
+  });
+  baz();
+}
+bar(a) {}
+void baz() {}

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/LocalFnInFunction_verification.xml
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/LocalFnInFunction_verification.xml
@@ -1,0 +1,5 @@
+<node text="baz() → void (C.dart)" base="true">
+  <node text="() in () in foo() (C.dart)"/>
+  <node text="() in foo() (C.dart)"/>
+  <node text="foo() (C.dart)"/>
+</node>

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/C.dart
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/C.dart
@@ -1,0 +1,14 @@
+class C {
+  int m() => 3;
+  foo() {
+    bar((q) {
+      bar((r) {
+        baz();
+      });
+      baz();
+    });
+    baz();
+  }
+}
+bar(a) {}
+void baz() {}

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/LocalFnInMethod_verification.xml
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/LocalFnInMethod_verification.xml
@@ -1,0 +1,5 @@
+<node text="baz() → void (C.dart)" base="true">
+  <node text="() in () in foo() (C.dart)"/>
+  <node text="() in foo() (C.dart)"/>
+  <node text="C.foo() (C.dart)"/>
+</node>

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
@@ -181,6 +181,14 @@ public class DartCallHierarchyTest extends HierarchyViewTestBase {
     doCallHierarchyTest("A", "a", false, "A.dart", "B.dart", "C.dart");
   }
 
+  public void testLocalFnInMethod() throws Exception {
+    doCallHierarchyTest(null, "baz", true, "C.dart");
+  }
+
+  public void testLocalFnInFunction() throws Exception {
+    doCallHierarchyTest(null, "baz", true, "C.dart");
+  }
+
   private static class ExitVisitor extends Error {
   }
 }


### PR DESCRIPTION
@alexander-doroshko This fixes the bug in call hierarchy where nothing was displayed for calls represented by unnamed functions. It defines getPresentation() for functions, which requires a small change to the grammar.