### PR TITLE
Work

### DIFF
--- a/Dart/gen/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionImpl.java
+++ b/Dart/gen/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionImpl.java
@@ -11,7 +11,7 @@ import static com.jetbrains.lang.dart.DartTokenTypes.*;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 
-public class DartFunctionExpressionImpl extends DartExpressionImpl implements DartFunctionExpression {
+public class DartFunctionExpressionImpl extends DartFunctionExpressionBase implements DartFunctionExpression {
 
   public DartFunctionExpressionImpl(ASTNode node) {
     super(node);

--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -103,6 +103,9 @@
     <codeInsight.implementMethod language="Dart"
                                  implementationClass="com.jetbrains.lang.dart.ide.generation.DartImplementMethodHandler"/>
 
+    <statementUpDownMover implementation="com.jetbrains.lang.dart.ide.moveCode.DartStatementMover" id="statement" order="before component" />
+    <statementUpDownMover implementation="com.jetbrains.lang.dart.ide.moveCode.DartComponentMover" id="component" order="before xml" />
+
     <fileBasedIndex implementation="com.jetbrains.lang.dart.ide.index.DartImportAndExportIndex"/>
     <fileBasedIndex implementation="com.jetbrains.lang.dart.ide.index.DartPartUriIndex"/>
     <!--<fileBasedIndex implementation="com.jetbrains.lang.dart.ide.index.DartSourceIndex"/>-->

--- a/Dart/src/com/jetbrains/lang/dart/Dart.bnf
+++ b/Dart/src/com/jetbrains/lang/dart/Dart.bnf
@@ -606,6 +606,7 @@ mapLiteralEntry ::= expression ':' expression {recoverWhile="map_literal_entry_r
 private map_literal_entry_recover ::= !(',' | '}')
 
 functionExpression ::= formalParameterList functionExpressionBody
+{mixin="com.jetbrains.lang.dart.psi.impl.DartFunctionExpressionBase"}
 functionSignature ::= metadata* functionDeclarationPrivate
 {mixin="com.jetbrains.lang.dart.psi.impl.AbstractDartComponentImpl" implements="com.jetbrains.lang.dart.psi.DartComponent"}
 private functionDeclarationPrivate ::= returnType componentName formalParameterList | componentName formalParameterList // todo remove, use functionSignature as in spec

--- a/Dart/src/com/jetbrains/lang/dart/ide/moveCode/DartComponentMover.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/moveCode/DartComponentMover.java
@@ -1,0 +1,121 @@
+package com.jetbrains.lang.dart.ide.moveCode;
+
+import com.intellij.codeInsight.editorActions.moveUpDown.LineMover;
+import com.intellij.codeInsight.editorActions.moveUpDown.LineRange;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import com.jetbrains.lang.dart.psi.DartFile;
+import com.jetbrains.lang.dart.psi.DartLibraryStatement;
+import com.jetbrains.lang.dart.psi.DartUriBasedDirective;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Move top-level functions, entire class declarations, and class member declarations above or below the neighboring component.
+ * Movement may not cross semantic boundaries. Use a proper refactoring tool for that to ensure error detection.
+ */
+public class DartComponentMover extends LineMover {
+
+  @Override
+  public boolean checkAvailable(@NotNull Editor editor, @NotNull PsiFile file, @NotNull MoveInfo info, boolean down) {
+    if (!(file instanceof DartFile)) return false;
+    if (!super.checkAvailable(editor, file, info, down)) return false;
+    info.indentTarget = false;
+    Pair<PsiElement, PsiElement> psiRange = getElementRange(editor, file, info.toMove);
+    if (psiRange == null) return false;
+    final PsiElement firstMember = getDeclarationParent(psiRange.getFirst());
+    PsiElement endElement = psiRange.getSecond();
+    final PsiElement lastMember = getDeclarationParent(endElement);
+    if (firstMember == null || lastMember == null) return false;
+
+    LineRange range;
+    if (firstMember == lastMember) {
+      range = memberRange(firstMember, editor, info.toMove);
+      if (range == null) return false;
+      range.firstElement = range.lastElement = firstMember;
+    }
+    else {
+      final PsiElement parent = PsiTreeUtil.findCommonParent(firstMember, lastMember);
+      if (parent == null) return false;
+
+      final Pair<PsiElement, PsiElement> combinedRange = getElementRange(parent, firstMember, lastMember);
+      if (combinedRange == null) return false;
+      final LineRange lineRange1 = memberRange(combinedRange.getFirst(), editor, info.toMove);
+      if (lineRange1 == null) return false;
+      final LineRange lineRange2 = memberRange(combinedRange.getSecond(), editor, info.toMove);
+      if (lineRange2 == null) return false;
+      range = new LineRange(lineRange1.startLine, lineRange2.endLine);
+      range.firstElement = combinedRange.getFirst();
+      range.lastElement = combinedRange.getSecond();
+    }
+    Document document = editor.getDocument();
+    PsiElement ref;
+    PsiElement sibling = down ? (ref = range.lastElement.getNextSibling()) : (ref = range.firstElement).getPrevSibling();
+    sibling = firstNonWhiteElement(sibling, down);
+    ref = firstNonWhiteElement(ref, !down);
+    info.toMove = range;
+    if (sibling != null) {
+      if (crossesHeaderBoundary(ref, sibling)) {
+        info.prohibitMove();
+        return true;
+      }
+      info.toMove2 = new LineRange(sibling, sibling, document);
+    }
+    return true;
+  }
+
+  private static PsiElement getDeclarationParent(PsiElement element) {
+    if (isComment(element)) return element;
+    PsiElement parent = getHeaderParent(element);
+    if (parent != null) return parent;
+    return PsiTreeUtil.getParentOfType(element, DartComponent.class, false);
+  }
+
+  private static LineRange memberRange(@NotNull PsiElement member, Editor editor, LineRange lineRange) {
+    TextRange textRange = member.getTextRange();
+    if (editor.getDocument().getTextLength() < textRange.getEndOffset()) return null;
+    LogicalPosition startPosition = editor.offsetToLogicalPosition(textRange.getStartOffset());
+    LogicalPosition endPosition = editor.offsetToLogicalPosition(textRange.getEndOffset());
+    int endLine = endPosition.line + 1;
+    if (!isInsideDeclaration(member, startPosition.line, endLine, lineRange, editor)) return null;
+    return new LineRange(startPosition.line, endLine);
+  }
+
+  private static boolean isInsideDeclaration(@NotNull PsiElement member, int startLine, int endLine, LineRange lineRange, Editor editor) {
+    // Easy case: selection is on first or last line of component.
+    if (startLine == lineRange.startLine || startLine == lineRange.endLine || endLine == lineRange.startLine ||
+        endLine == lineRange.endLine) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean crossesHeaderBoundary(PsiElement base, PsiElement sibling) {
+    // We may want to be more flexible and allow header statements to move up past top-level declarations.
+    if (isComment(base) || isComment(sibling)) return false;
+    PsiElement baseType = getHeaderParent(base);
+    PsiElement sibType = getHeaderParent(sibling);
+    if (baseType == null && sibType == null) return false;
+    if (baseType == null || sibType == null) return true;
+    // Having two library statements is not legal but could happen while editing.
+    if (baseType instanceof DartLibraryStatement && sibType instanceof DartLibraryStatement) return false;
+    // Having mixed library and import is also possible but not allowed in this context.
+    if (baseType instanceof DartLibraryStatement || sibType instanceof DartLibraryStatement) return true;
+    return false; // both uri-based -- allow moving part & import
+  }
+
+  private static PsiElement getHeaderParent(PsiElement element) {
+    return PsiTreeUtil.getNonStrictParentOfType(element, DartUriBasedDirective.class, DartLibraryStatement.class);
+  }
+
+  private static boolean isComment(PsiElement element) {
+    return null != PsiTreeUtil.getNonStrictParentOfType(element, PsiComment.class);
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/moveCode/DartStatementMover.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/moveCode/DartStatementMover.java
@@ -1,0 +1,380 @@
+package com.jetbrains.lang.dart.ide.moveCode;
+
+import com.intellij.codeInsight.editorActions.moveUpDown.LineMover;
+import com.intellij.codeInsight.editorActions.moveUpDown.LineRange;
+import com.intellij.codeInsight.editorActions.moveUpDown.StatementUpDownMover;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.search.PsiElementProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.DartLanguage;
+import com.jetbrains.lang.dart.psi.*;
+import com.jetbrains.lang.dart.util.DartPsiImplUtil;
+import com.jetbrains.lang.dart.util.DartRefactoringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Move executable statements within a method or function. Statements cannot be moved outside a component.
+ * TODO: What about moving statements from a local function to the surrounding method?
+ */
+public class DartStatementMover extends LineMover {
+  private PsiElement statementToSurroundWithCodeBlock;
+
+  @Override
+  public boolean checkAvailable(@NotNull Editor editor, @NotNull PsiFile file, @NotNull MoveInfo info, boolean down) {
+    if (!(file instanceof DartFile)) return false;
+    if (!super.checkAvailable(editor, file, info, down)) return false;
+    LineRange range = expandLineRangeToCoverPsiElements(info.toMove, editor, file);
+    if (range == null) return false;
+    info.toMove = range;
+    final int startOffset = editor.logicalPositionToOffset(new LogicalPosition(range.startLine, 0));
+    final int endOffset = editor.logicalPositionToOffset(new LogicalPosition(range.endLine, 0));
+    final PsiElement[] statements = DartRefactoringUtil.findStatementsInRange(file, startOffset, endOffset);
+    if (statements.length == 0) return false;
+    range.firstElement = statements[0];
+    range.lastElement = statements[statements.length - 1];
+    info.indentTarget = false;
+    if (!checkMovingInsideOutside(file, editor, info, down)) {
+      info.toMove2 = null;
+    }
+    return true;
+  }
+
+  private static LineRange expandLineRangeToCoverPsiElements(final LineRange range, Editor editor, final PsiFile file) {
+    Pair<PsiElement, PsiElement> psiRange = getElementRange(editor, file, range);
+    if (psiRange == null) return null;
+    if (psiRange.getFirst() instanceof DartStatements) {
+      PsiElement first = psiRange.getFirst();
+      PsiElement last = psiRange.getSecond();
+      if (first != null && last != null) {
+        PsiElement statement = first.getFirstChild();
+        if (statement != null) {
+          psiRange = Pair.create(statement, psiRange.getSecond());
+        }
+      }
+    }
+    final PsiElement parent = PsiTreeUtil.findCommonParent(psiRange.getFirst(), psiRange.getSecond());
+    Pair<PsiElement, PsiElement> elementRange = getElementRange(parent, psiRange.getFirst(), psiRange.getSecond());
+    if (elementRange == null) return null;
+    int endOffset = elementRange.getSecond().getTextRange().getEndOffset();
+    Document document = editor.getDocument();
+    if (endOffset > document.getTextLength()) {
+      return null;
+    }
+    int endLine;
+    if (endOffset == document.getTextLength()) {
+      endLine = document.getLineCount();
+    }
+    else {
+      endLine = editor.offsetToLogicalPosition(endOffset).line + 1;
+      endLine = Math.min(endLine, document.getLineCount());
+    }
+    int startLine = Math.min(range.startLine, editor.offsetToLogicalPosition(elementRange.getFirst().getTextOffset()).line);
+    endLine = Math.max(endLine, range.endLine);
+    return new LineRange(startLine, endLine);
+  }
+
+  private boolean checkMovingInsideOutside(PsiFile file, final Editor editor, @NotNull final MoveInfo info, final boolean down) {
+    final int offset = editor.getCaretModel().getOffset();
+    PsiElement elementAtOffset = file.getViewProvider().findElementAt(offset, DartLanguage.INSTANCE);
+    if (elementAtOffset == null) return false;
+
+    PsiElement guard = elementAtOffset;
+    guard = PsiTreeUtil.getParentOfType(guard, DartMethodDeclaration.class,
+                                        DartFunctionDeclarationWithBodyOrNative.class, DartClass.class, PsiComment.class);
+
+    PsiElement brace = soloRightBraceBeingMoved(file, editor);
+    if (brace != null) {
+      int line = editor.getDocument().getLineNumber(offset);
+      final LineRange toMove = new LineRange(line, line + 1);
+      toMove.firstElement = toMove.lastElement = brace;
+      info.toMove = toMove;
+    }
+
+    // Cannot move in/outside method/class/function/comment.
+    if (!calcInsertOffset(file, editor, info.toMove, info, down)) return false;
+    int insertOffset = down
+                       ? getLineStartSafeOffset(editor.getDocument(), info.toMove2.endLine)
+                       : editor.getDocument().getLineStartOffset(info.toMove2.startLine);
+    PsiElement elementAtInsertOffset = file.getViewProvider().findElementAt(insertOffset, DartLanguage.INSTANCE);
+    PsiElement newGuard = PsiTreeUtil
+      .getParentOfType(elementAtInsertOffset, DartMethodDeclaration.class, DartFunctionDeclarationWithBodyOrNative.class, DartClass.class,
+                       PsiComment.class);
+
+    if (brace != null && PsiTreeUtil.getParentOfType(brace, DartBlock.class, false) !=
+                         PsiTreeUtil.getParentOfType(elementAtInsertOffset, DartBlock.class, false)) {
+      info.indentSource = true;
+    }
+    if (newGuard == guard && isInside(insertOffset, newGuard) == isInside(offset, guard)) return true;
+
+    return false;
+  }
+
+  private static PsiElement soloRightBraceBeingMoved(final PsiFile file, final Editor editor) {
+    // Return the right brace on the line with the cursor, or null if the line is not a single brace.
+    LineRange range = getLineRangeFromSelection(editor);
+    if (range.endLine - range.startLine != 1) {
+      return null;
+    }
+    Document document = editor.getDocument();
+    int offset = editor.getCaretModel().getOffset();
+    int line = document.getLineNumber(offset);
+    int lineStartOffset = document.getLineStartOffset(line);
+    String lineText = document.getText().substring(lineStartOffset, document.getLineEndOffset(line));
+    if (!lineText.trim().equals("}")) {
+      return null;
+    }
+    return file.findElementAt(lineStartOffset + lineText.indexOf('}'));
+  }
+
+  private boolean calcInsertOffset(@NotNull PsiFile file,
+                                   @NotNull Editor editor,
+                                   @NotNull LineRange range,
+                                   @NotNull final MoveInfo info,
+                                   final boolean down) {
+    int destLine = getDestLineForAnon(editor, range, down);
+
+    int startLine = down ? range.endLine : range.startLine - 1;
+    if (destLine < 0 || startLine < 0) return false;
+    while (true) {
+      final int offset = editor.logicalPositionToOffset(new LogicalPosition(destLine, 0));
+      PsiElement element = firstNonWhiteElement(offset, file, true);
+      if (element instanceof DartStatements) element = element.getFirstChild();
+
+      while (element != null && !(element instanceof PsiFile)) {
+        TextRange elementTextRange = element.getTextRange();
+        if (elementTextRange.isEmpty() || !elementTextRange.grown(-1).shiftRight(1).contains(offset)) {
+          PsiElement elementToSurround = null;
+          boolean found = false;
+          if ((isStatement(element) || element instanceof PsiComment)
+              && statementCanBePlacedAlong(element)) {
+            found = true;
+            if (!(element.getParent() instanceof DartBlock)) {
+              elementToSurround = element;
+            }
+          }
+          else if (DartPsiImplUtil.isRightBrace(element)
+                   && element.getParent() instanceof DartBlock && !isStatement(element.getParent().getParent())) {
+            // Before code block closing brace.
+            found = true;
+          }
+          if (found) {
+            statementToSurroundWithCodeBlock = elementToSurround;
+            info.toMove = range;
+            int endLine = destLine;
+            if (startLine > endLine) {
+              int tmp = endLine;
+              endLine = startLine;
+              startLine = tmp;
+            }
+
+            info.toMove2 = new LineRange(startLine, down ? endLine : endLine + 1);
+            return true;
+          }
+        }
+        element = element.getParent();
+      }
+      destLine += down ? 1 : -1;
+      if (destLine == 0 || destLine >= editor.getDocument().getLineCount()) {
+        return false;
+      }
+    }
+  }
+
+  private static int getDestLineForAnon(Editor editor, LineRange range, boolean down) {
+    int destLine = down ? range.endLine + 1 : range.startLine - 1;
+    if (!isStatement(range.firstElement)) {
+      return destLine;
+    }
+    PsiElement sibling =
+      StatementUpDownMover.firstNonWhiteElement(down ? range.lastElement.getNextSibling() : range.firstElement.getPrevSibling(), down);
+    final DartFunctionExpression fn = findChildOfType(sibling, DartFunctionExpression.class, DartPsiCompositeElement.class);
+    if (fn != null && sibling != null && PsiTreeUtil.getParentOfType(fn, DartPsiCompositeElement.class) == sibling) {
+      destLine =
+        editor.getDocument().getLineNumber(down ? sibling.getTextRange().getEndOffset() + 1 : sibling.getTextRange().getStartOffset());
+    }
+    return destLine;
+  }
+
+  @Nullable
+  private static <T extends PsiElement> T findChildOfType(@Nullable final PsiElement element,
+                                                          @NotNull final Class<T> aClass,
+                                                          @Nullable final Class<? extends PsiElement> stopAt) {
+    final PsiElementProcessor.FindElement<PsiElement> processor;
+    processor = new PsiElementProcessor.FindElement<PsiElement>() {
+      @Override
+      public boolean execute(@NotNull PsiElement each) {
+        if (element == each) return true; // strict
+        if (aClass.isInstance(each)) {
+          return setFound(each);
+        }
+        return stopAt == null || !stopAt.isInstance(each);
+      }
+    };
+
+    PsiTreeUtil.processElements(element, processor);
+    //noinspection unchecked
+    return (T)processor.getFoundElement();
+  }
+
+  private static boolean isInside(final int offset, final PsiElement guard) {
+    if (guard == null) return false;
+    TextRange inside = guard.getTextRange();
+    if (guard instanceof DartMethodDeclaration) {
+      DartFunctionBody body = ((DartMethodDeclaration)guard).getFunctionBody();
+      if (body != null) {
+        inside = body.getTextRange();
+      }
+    }
+    else if (guard instanceof DartFunctionDeclarationWithBodyOrNative) {
+      DartFunctionBody body = ((DartFunctionDeclarationWithBodyOrNative)guard).getFunctionBody();
+      if (body != null) {
+        inside = body.getTextRange();
+      }
+    }
+    else if (guard instanceof DartClassDefinition) {
+      DartClassBody body = ((DartClassDefinition)guard).getClassBody();
+      PsiElement lBrace = PsiTreeUtil.getChildOfType(body, LeafPsiElement.class);
+      if (lBrace != null && lBrace.getText().equals("{")) {
+        PsiElement rBrace = PsiTreeUtil.lastChild(body);
+        rBrace = PsiTreeUtil.skipSiblingsBackward(rBrace, PsiWhiteSpace.class, PsiComment.class);
+        if (rBrace != null && rBrace.getText().equals("}")) {
+          inside = new TextRange(lBrace.getTextOffset(), rBrace.getTextOffset());
+        }
+      }
+    }
+    return inside != null && inside.contains(offset);
+  }
+
+  private static boolean statementCanBePlacedAlong(final PsiElement element) {
+    if (element instanceof DartBlock) {
+      return false;
+    }
+    PsiElement parent = element.getParent();
+    if (parent instanceof DartStatements) {
+      parent = parent.getParent();
+      if (parent instanceof DartBlock) {
+        if (!isStatement(parent.getParent())) {
+          return true;
+        }
+        parent = parent.getParent();
+      }
+      else {
+        return false;
+      }
+    }
+    if (parent instanceof DartIfStatement) {
+      PsiElement thenBranch = DartPsiImplUtil.getThenBranch((DartIfStatement)parent);
+      PsiElement elseBranch = DartPsiImplUtil.getElseBranch((DartIfStatement)parent);
+      if (isSameStatement(element, thenBranch) || isSameStatement(element, elseBranch)) {
+        return true;
+      }
+    }
+    if (parent instanceof DartWhileStatement) {
+      PsiElement body = DartPsiImplUtil.getWhileBody((DartWhileStatement)parent);
+      if (isSameStatement(element, body)) {
+        return true;
+      }
+    }
+    if (parent instanceof DartDoWhileStatement) {
+      PsiElement body = DartPsiImplUtil.getDoBody((DartDoWhileStatement)parent);
+      if (isSameStatement(element, body)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isSameStatement(PsiElement element, PsiElement statement) {
+    if (element == statement) return true;
+    return expressionStatementTeminator(statement) == element;
+  }
+
+  private static boolean isStatement(PsiElement element) {
+    boolean[] result = new boolean[1];
+    result[0] = false;
+
+    element.accept(new DartVisitor() {
+      public void visitAssertStatement(@NotNull DartAssertStatement o) {
+        result[0] = true;
+      }
+
+      public void visitBreakStatement(@NotNull DartBreakStatement o) {
+        result[0] = true;
+      }
+
+      public void visitContinueStatement(@NotNull DartContinueStatement o) {
+        result[0] = true;
+      }
+
+      public void visitDoWhileStatement(@NotNull DartDoWhileStatement o) {
+        result[0] = true;
+      }
+
+      public void visitForStatement(@NotNull DartForStatement o) {
+        result[0] = true;
+      }
+
+      public void visitIfStatement(@NotNull DartIfStatement o) {
+        result[0] = true;
+      }
+
+      public void visitRethrowStatement(@NotNull DartRethrowStatement o) {
+        result[0] = true;
+      }
+
+      public void visitReturnStatement(@NotNull DartReturnStatement o) {
+        result[0] = true;
+      }
+
+      public void visitSwitchStatement(@NotNull DartSwitchStatement o) {
+        result[0] = true;
+      }
+
+      public void visitTryStatement(@NotNull DartTryStatement o) {
+        result[0] = true;
+      }
+
+      public void visitWhileStatement(@NotNull DartWhileStatement o) {
+        result[0] = true;
+      }
+
+      public void visitYieldEachStatement(@NotNull DartYieldEachStatement o) {
+        result[0] = true;
+      }
+
+      public void visitYieldStatement(@NotNull DartYieldStatement o) {
+        result[0] = true;
+      }
+
+      public void visitVarDeclarationList(@NotNull DartVarDeclarationList o) {
+        result[0] = expressionStatementTeminator(o) != null;
+      }
+
+      public void visitExpression(@NotNull DartExpression o) {
+        result[0] = expressionStatementTeminator(o) != null;
+      }
+    });
+    return result[0];
+  }
+
+  @Nullable
+  private static PsiElement expressionStatementTeminator(PsiElement element) {
+    if (element instanceof DartExpression || element instanceof DartVarDeclarationList) {
+      PsiElement token = PsiTreeUtil.skipSiblingsForward(element, PsiComment.class, PsiWhiteSpace.class);
+      if (DartPsiImplUtil.isSemicolon(token)) {
+        return token;
+      }
+    }
+    return null;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
@@ -1,21 +1,33 @@
 package com.jetbrains.lang.dart.psi.impl;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.lang.ASTNode;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.lang.dart.DartComponentType;
+import com.intellij.ui.RowIcon;
+import com.intellij.util.PlatformIcons;
 import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
 import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-public class DartFunctionExpressionBase extends DartExpressionImpl {
+abstract public class DartFunctionExpressionBase extends DartExpressionImpl {
 
   public DartFunctionExpressionBase(ASTNode node) {
     super(node);
+  }
+
+  @Override
+  public Icon getIcon(int flags) {
+    Icon icon = AllIcons.Nodes.Function;
+    RowIcon baseIcon = new RowIcon(2);
+    baseIcon.setIcon(icon, 0);
+    Icon visibility = PlatformIcons.PRIVATE_ICON;
+    baseIcon.setIcon(visibility, 1);
+    return baseIcon;
   }
 
   @Override
@@ -41,9 +53,7 @@ public class DartFunctionExpressionBase extends DartExpressionImpl {
         @Nullable
         @Override
         public Icon getIcon(boolean unused) {
-          DartComponentType type = DartComponentType.typeOf(DartFunctionExpressionBase.this);
-          assert type != null;
-          return type.getIcon();
+          return DartFunctionExpressionBase.this.getIcon(0);
         }
       };
     }

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFunctionExpressionBase.java
@@ -1,0 +1,52 @@
+package com.jetbrains.lang.dart.psi.impl;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.navigation.ItemPresentation;
+import com.intellij.navigation.NavigationItem;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.DartComponentType;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class DartFunctionExpressionBase extends DartExpressionImpl {
+
+  public DartFunctionExpressionBase(ASTNode node) {
+    super(node);
+  }
+
+  @Override
+  public ItemPresentation getPresentation() {
+    final PsiElement parent = PsiTreeUtil.getParentOfType(this, DartFunctionExpressionBase.class, DartMethodDeclaration.class,
+                                                          DartFunctionDeclarationWithBodyOrNative.class);
+    if (parent != null) {
+      return new ItemPresentation() {
+        @Nullable
+        @Override
+        public String getPresentableText() {
+          ItemPresentation container = ((NavigationItem)parent).getPresentation();
+          return container == null ? null : "() in " + container.getPresentableText();
+        }
+
+        @Nullable
+        @Override
+        public String getLocationString() {
+          ItemPresentation container = ((NavigationItem)parent).getPresentation();
+          return container == null ? null : container.getLocationString();
+        }
+
+        @Nullable
+        @Override
+        public Icon getIcon(boolean unused) {
+          DartComponentType type = DartComponentType.typeOf(DartFunctionExpressionBase.this);
+          assert type != null;
+          return type.getIcon();
+        }
+      };
+    }
+    return null;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/util/DartPsiImplUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartPsiImplUtil.java
@@ -4,8 +4,11 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiComment;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.ResolveState;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.util.*;
 import com.jetbrains.lang.dart.DartTokenTypes;
 import com.jetbrains.lang.dart.psi.*;
@@ -217,5 +220,48 @@ public class DartPsiImplUtil {
   @Nullable
   public static DartArguments getArguments(@NotNull final DartCallExpression callExpression) {
     return PsiTreeUtil.findChildOfType(callExpression, DartArguments.class);
+  }
+
+  @Nullable
+  public static DartExpression getCondition(@NotNull DartPsiCompositeElement ifStatement) {
+    return PsiTreeUtil.findChildOfType(ifStatement, DartExpression.class);
+  }
+
+  @Nullable
+  public static PsiElement getThenBranch(@NotNull DartIfStatement ifStatement) {
+    return getBranchAfter(getCondition(ifStatement));
+  }
+
+  @Nullable
+  public static PsiElement getElseBranch(@NotNull DartIfStatement ifStatement) {
+    return getBranchAfter(getThenBranch(ifStatement));
+  }
+
+  @Nullable
+  private static PsiElement getBranchAfter(@Nullable PsiElement child) {
+    return PsiTreeUtil.skipSiblingsForward(child, LeafPsiElement.class, PsiWhiteSpace.class, PsiComment.class);
+  }
+
+  @Nullable
+  public static PsiElement getDoBody(@NotNull DartDoWhileStatement doStatement) {
+    return getBranchAfter(doStatement);
+  }
+
+  @Nullable
+  public static PsiElement getWhileBody(@NotNull DartWhileStatement whileStatement) {
+    return getBranchAfter(getCondition(whileStatement));
+  }
+
+  public static boolean isRightBrace(PsiElement element) {
+    return isToken(element, "}");
+  }
+
+  public static boolean isSemicolon(PsiElement element) {
+    return isToken(element, ";");
+  }
+
+  private static boolean isToken(PsiElement element, String text) {
+    return element instanceof LeafPsiElement
+           && element.getText().trim().equals(text);
   }
 }

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/C.dart
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/C.dart
@@ -1,0 +1,11 @@
+foo() {
+  bar((q) {
+    bar((r) {
+      baz();
+    });
+    baz();
+  });
+  baz();
+}
+bar(a) {}
+void baz() {}

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/LocalFnInFunction_verification.xml
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInFunction/LocalFnInFunction_verification.xml
@@ -1,0 +1,5 @@
+<node text="baz() → void (C.dart)" base="true">
+  <node text="() in () in foo() (C.dart)"/>
+  <node text="() in foo() (C.dart)"/>
+  <node text="foo() (C.dart)"/>
+</node>

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/C.dart
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/C.dart
@@ -1,0 +1,14 @@
+class C {
+  int m() => 3;
+  foo() {
+    bar((q) {
+      bar((r) {
+        baz();
+      });
+      baz();
+    });
+    baz();
+  }
+}
+bar(a) {}
+void baz() {}

--- a/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/LocalFnInMethod_verification.xml
+++ b/Dart/testData/analysisServer/callHierarchy/LocalFnInMethod/LocalFnInMethod_verification.xml
@@ -1,0 +1,5 @@
+<node text="baz() → void (C.dart)" base="true">
+  <node text="() in () in foo() (C.dart)"/>
+  <node text="() in foo() (C.dart)"/>
+  <node text="C.foo() (C.dart)"/>
+</node>

--- a/Dart/testData/componentMover/ClassClass.dart
+++ b/Dart/testData/componentMover/ClassClass.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+class M1 {
+  int m() => 1;
+}
+
+class X <caret>extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ClassClass_afterDown.dart
+++ b/Dart/testData/componentMover/ClassClass_afterDown.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+class M1 {
+  int m() => 1;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class X <caret>extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ClassClass_afterUp.dart
+++ b/Dart/testData/componentMover/ClassClass_afterUp.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+class X <caret>extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class M1 {
+  int m() => 1;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ClassImport.dart
+++ b/Dart/testData/componentMover/ClassImport.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+<caret>class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ClassImport_afterDown.dart
+++ b/Dart/testData/componentMover/ClassImport_afterDown.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+<caret>class M1 {
+  int m() => 1;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ClassImport_afterUp.dart
+++ b/Dart/testData/componentMover/ClassImport_afterUp.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+<caret>class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/CommentImport.dart
+++ b/Dart/testData/componentMover/CommentImport.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*<caret>
+*/
+import "t2.dart";
+
+class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/CommentImport_afterDown.dart
+++ b/Dart/testData/componentMover/CommentImport_afterDown.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+import "t2.dart";
+/*<caret>
+*/
+
+class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/CommentImport_afterUp.dart
+++ b/Dart/testData/componentMover/CommentImport_afterUp.dart
@@ -1,0 +1,24 @@
+/*<caret>
+*/
+import "t1.dart"
+  as x;
+import "t2.dart";
+
+class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/FunctionTypedef.dart
+++ b/Dart/testData/componentMover/FunctionTypedef.dart
@@ -1,0 +1,13 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+typedef fn(int);
+
+<caret>f(x) => 4;
+
+class M1 {
+  int m() => 1;
+}

--- a/Dart/testData/componentMover/FunctionTypedef_afterDown.dart
+++ b/Dart/testData/componentMover/FunctionTypedef_afterDown.dart
@@ -1,0 +1,13 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+typedef fn(int);
+
+class M1 {
+  int m() => 1;
+}
+
+<caret>f(x) => 4;

--- a/Dart/testData/componentMover/FunctionTypedef_afterUp.dart
+++ b/Dart/testData/componentMover/FunctionTypedef_afterUp.dart
@@ -1,0 +1,13 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+<caret>f(x) => 4;
+
+typedef fn(int);
+
+class M1 {
+  int m() => 1;
+}

--- a/Dart/testData/componentMover/ImportClass.dart
+++ b/Dart/testData/componentMover/ImportClass.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";<caret>
+
+class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ImportClass_afterDown.dart
+++ b/Dart/testData/componentMover/ImportClass_afterDown.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";<caret>
+
+class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/ImportClass_afterUp.dart
+++ b/Dart/testData/componentMover/ImportClass_afterUp.dart
@@ -1,0 +1,24 @@
+import "t1.dart"
+  as x;
+import "t2.dart";<caret>
+/*
+*/
+
+class M1 {
+  int m() => 1;
+}
+
+class X extends x.C1a with M1 {
+  int m() => 5;
+}
+
+class Y extends C2a {
+  Y() : super();
+}
+
+class Z extends Y {
+  int m() => new x.C1a().m();
+}
+
+class Z1 extends Z {
+}

--- a/Dart/testData/componentMover/TypedefImport.dart
+++ b/Dart/testData/componentMover/TypedefImport.dart
@@ -1,0 +1,13 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+typedef fn(int);<caret>
+
+f(x) => 4;
+
+class M1 {
+  int m() => 1;
+}

--- a/Dart/testData/componentMover/TypedefImport_afterDown.dart
+++ b/Dart/testData/componentMover/TypedefImport_afterDown.dart
@@ -1,0 +1,13 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+f(x) => 4;
+
+typedef fn(int);<caret>
+
+class M1 {
+  int m() => 1;
+}

--- a/Dart/testData/componentMover/TypedefImport_afterUp.dart
+++ b/Dart/testData/componentMover/TypedefImport_afterUp.dart
@@ -1,0 +1,13 @@
+import "t1.dart"
+  as x;
+/*
+*/
+import "t2.dart";
+
+typedef fn(int);<caret>
+
+f(x) => 4;
+
+class M1 {
+  int m() => 1;
+}

--- a/Dart/testData/statementMover/DoIfBody.dart
+++ b/Dart/testData/statementMover/DoIfBody.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    int i=0;
+    if (x) n(); else {
+      m();
+    }
+<caret>    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/DoIfBody_afterDown.dart
+++ b/Dart/testData/statementMover/DoIfBody_afterDown.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    int i=0;
+    if (x) n(); else {
+      m();
+    }
+<caret>    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/DoIfBody_afterUp.dart
+++ b/Dart/testData/statementMover/DoIfBody_afterUp.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    int i=0;
+<caret>    do i++;
+    while (i < 3);
+    if (x) n(); else {
+      m();
+    }
+  }
+}

--- a/Dart/testData/statementMover/IfVarWhile.dart
+++ b/Dart/testData/statementMover/IfVarWhile.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    int i=0;
+    if (x) <caret>n(); else {
+      m();
+    }
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/IfVarWhile_afterDown.dart
+++ b/Dart/testData/statementMover/IfVarWhile_afterDown.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    int i=0;
+    do i++;
+    while (i < 3);
+    if (x) <caret>n(); else {
+      m();
+    }
+  }
+}

--- a/Dart/testData/statementMover/IfVarWhile_afterUp.dart
+++ b/Dart/testData/statementMover/IfVarWhile_afterUp.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    if (x) <caret>n(); else {
+      m();
+    }
+    int i=0;
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/VarIfCall.dart
+++ b/Dart/testData/statementMover/VarIfCall.dart
@@ -1,0 +1,14 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+<caret>    int i=0;
+    if (x) n(); else {
+      m();
+    }
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/VarIfCall_afterDown.dart
+++ b/Dart/testData/statementMover/VarIfCall_afterDown.dart
@@ -1,0 +1,14 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    if (x) n(); else {
+      m();
+    }
+<caret>    int i=0;
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/VarIfCall_afterUp.dart
+++ b/Dart/testData/statementMover/VarIfCall_afterUp.dart
@@ -1,0 +1,14 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+<caret>    int i=0;
+    m();
+    if (x) n(); else {
+      m();
+    }
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/VarIfDo.dart
+++ b/Dart/testData/statementMover/VarIfDo.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    if (x) n(); else {
+      m();
+    }
+<caret>    int i=0;
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testData/statementMover/VarIfDo_afterDown.dart
+++ b/Dart/testData/statementMover/VarIfDo_afterDown.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+    if (x) n(); else {
+      m();
+    }
+    do i++;
+    while (i < 3);
+<caret>    int i=0;
+  }
+}

--- a/Dart/testData/statementMover/VarIfDo_afterUp.dart
+++ b/Dart/testData/statementMover/VarIfDo_afterUp.dart
@@ -1,0 +1,15 @@
+class C2a extends C2 {
+  C2a();
+  int m() => 4;
+  static int n() => 7;
+  garvl(x) {
+    m();
+    n();
+<caret>    int i=0;
+    if (x) n(); else {
+      m();
+    }
+    do i++;
+    while (i < 3);
+  }
+}

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
@@ -181,6 +181,14 @@ public class DartCallHierarchyTest extends HierarchyViewTestBase {
     doCallHierarchyTest("A", "a", false, "A.dart", "B.dart", "C.dart");
   }
 
+  public void testLocalFnInMethod() throws Exception {
+    doCallHierarchyTest(null, "baz", true, "C.dart");
+  }
+
+  public void testLocalFnInFunction() throws Exception {
+    doCallHierarchyTest(null, "baz", true, "C.dart");
+  }
+
   private static class ExitVisitor extends Error {
   }
 }

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartCodeMoverTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartCodeMoverTest.java
@@ -1,0 +1,20 @@
+package com.jetbrains.lang.dart.ide.moveCode;
+
+import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
+
+abstract public class DartCodeMoverTest extends DartCodeInsightFixtureTestCase {
+
+  protected void doTest() {
+    final String testName = getTestName(true);
+    myFixture.configureByFile(testName + ".dart");
+    myFixture.performEditorAction(IdeActions.ACTION_MOVE_STATEMENT_UP_ACTION);
+    myFixture.checkResultByFile(testName + "_afterUp.dart", true);
+
+    FileDocumentManager.getInstance().reloadFromDisk(myFixture.getDocument(myFixture.getFile()));
+    myFixture.configureByFile(testName + ".dart");
+    myFixture.performEditorAction(IdeActions.ACTION_MOVE_STATEMENT_DOWN_ACTION);
+    myFixture.checkResultByFile(testName + "_afterDown.dart", true);
+  }
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartComponentMoverTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartComponentMoverTest.java
@@ -1,0 +1,32 @@
+package com.jetbrains.lang.dart.ide.moveCode;
+
+public class DartComponentMoverTest extends DartCodeMoverTest {
+
+  protected String getBasePath() {
+    return "/componentMover/";
+  }
+
+  public void testClassClass() {
+    doTest(); // swap two classes in the file
+  }
+
+  public void testClassImport() {
+    doTest(); // up: no change -- class does not move above import
+  }
+
+  public void testCommentImport() {
+    doTest(); // multi-line comment, multi-line import, single-line import: all move correctly
+  }
+
+  public void testImportClass() {
+    doTest(); // down: no change -- import does not move below class
+  }
+
+  public void testTypedefImport() {
+    doTest(); // down: up change
+  }
+
+  public void testFunctionTypedef() {
+    doTest();
+  }
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
@@ -1,0 +1,24 @@
+package com.jetbrains.lang.dart.ide.moveCode;
+
+public class DartStatementMoverTest extends DartCodeMoverTest {
+
+  protected String getBasePath() {
+    return "/statementMover/";
+  }
+
+  public void testIfVarWhile() {
+    doTest(); // Move IF above VAR and below DO
+  }
+
+  public void testVarIfDo() {
+    doTest(); // Move VAR above IF and below DO
+  }
+
+  public void testDoIfBody() {
+    doTest(); // Move DO above IF but not out of class body
+  }
+
+  public void testVarIfCall() {
+    doTest(); // Move VAR above CALL and below IF
+  }
+}


### PR DESCRIPTION
@alexander-doroshko This implements the Code menu items Move Statement Up & Down. It is still a work-in-progress, but does demonstrate the functionality.

It needs more tests. As I was working on tests I realized I had implemented it inconsistently with the Java version. This one moves statements over blocks, rather than into them, as Java does. I think I need to fix that before adding more tests. It works correctly for classes and functions.

Unfortunately, it includes the code from my other open pull request. It makes sense to review that one first then ignore those bits in here.