### PR TITLE
remove the 'Observatory listening on' message from the console output

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -191,6 +191,7 @@
     <runConfigurationProducer implementation="com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfigurationProducer"/>
 
     <programRunner implementation="com.jetbrains.lang.dart.ide.runner.DartRunner"/>
+    <consoleInputFilterProvider implementation="com.jetbrains.lang.dart.ide.runner.DartConsoleInputFilterProvider"/>
 
     <localInspection bundle="com.jetbrains.lang.dart.DartBundle" key="outdated.dependencies.inspection.name"
                      groupName="Dart" enabledByDefault="true" level="WARNING" language="Dart"

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartConsoleFilter.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartConsoleFilter.java
@@ -30,7 +30,7 @@ public class DartConsoleFilter implements Filter {
   private final @Nullable DartUrlResolver myDartUrlResolver;
   private Collection<VirtualFile> myAllPubspecYamlFiles;
 
-  private static final String OBSERVATORY_LISTENING_ON = "Observatory listening on ";
+  static final String OBSERVATORY_LISTENING_ON = "Observatory listening on ";
 
   public DartConsoleFilter(final @NotNull Project project) {
     this(project, null);

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartConsoleInputFilterProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartConsoleInputFilterProvider.java
@@ -1,0 +1,29 @@
+package com.jetbrains.lang.dart.ide.runner;
+
+import com.intellij.execution.filters.ConsoleInputFilterProvider;
+import com.intellij.execution.filters.InputFilter;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DartConsoleInputFilterProvider implements ConsoleInputFilterProvider {
+  @NotNull
+  @Override
+  public InputFilter[] getDefaultFilters(@NotNull Project project) {
+    return new InputFilter[]{new InputFilter() {
+      @Nullable
+      @Override
+      public List<Pair<String, ConsoleViewContentType>> applyFilter(String text, ConsoleViewContentType outputType) {
+        if (text.startsWith(DartConsoleFilter.OBSERVATORY_LISTENING_ON)) {
+          return Collections.emptyList();
+        }
+        return Collections.singletonList(Pair.create(text, outputType));
+      }
+    }};
+  }
+}


### PR DESCRIPTION
This PR removes the `Observatory listening on http://...` message from the console output on Dart CLI runs. Printing it each time adds clutter to the runs, especially as there's a toolbar button to open the Observatory directly.

@alexander-doroshko 