### PR TITLE
work around bad tokenPos values

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -160,6 +160,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
         }
         LOG.debug(message);
 
+        // TODO: We should find a more reliable way to notify on connection close.
         if (myRemoteDebug && message.equals("VM connection closed: " + getObservatoryUrl("ws", "/ws"))) {
           getSession().stop();
         }
@@ -468,6 +469,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
     if (file != null && tokenPosToLineAndColumn != null) {
       final Pair<Integer, Integer> lineAndColumn = tokenPosToLineAndColumn.get(tokenPos);
+      if (lineAndColumn == null) return XDebuggerUtil.getInstance().createPositionByOffset(file, 0);
       return XDebuggerUtil.getInstance().createPosition(file, lineAndColumn.first, lineAndColumn.second);
     }
 
@@ -486,6 +488,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     }
 
     final Pair<Integer, Integer> lineAndColumn = tokenPosToLineAndColumn.get(tokenPos);
+    if (lineAndColumn == null) return XDebuggerUtil.getInstance().createPositionByOffset(file, 0);
     return XDebuggerUtil.getInstance().createPosition(file, lineAndColumn.first, lineAndColumn.second);
   }
 


### PR DESCRIPTION
In some situations, the VM can return bad values for `tokenPos` (in the issue I hit, a negative value); this guards against those values.

Instead of returning null values for `XSourcePosition`, we return a position at offset 0 in the resolved file. 

@alexander-doroshko
