### PR TITLE
change to a method which doesn't throw exceptions

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/StdioServerSocket.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/StdioServerSocket.java
@@ -83,14 +83,7 @@ public class StdioServerSocket implements AnalysisServerSocket {
 
   @Override
   public boolean isOpen() {
-    try {
-      if (process != null) {
-        process.exitValue();
-      }
-      return false;
-    } catch (IllegalThreadStateException ex) {
-      return true;
-    }
+    return process != null ? process.isAlive() : false;
   }
 
   /**


### PR DESCRIPTION
When debugging w/ break on exceptions on, we break on `process.exitValue()` frequently - it throws an exception when called if the process is still running.

This changes the isOpen() impl to process.isAlive(), which doesn't throw.

@alexander-doroshko