### PR TITLE
Parameterize observatory timeout.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartRunner.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartRunner.java
@@ -89,6 +89,10 @@ public class DartRunner extends DefaultProgramRunner {
     return null;
   }
 
+  protected int getTimeout() {
+    return 5000; // Allow 5 seconds to connect to the observatory.
+  }
+
   private RunContentDescriptor doExecuteDartDebug(final @NotNull RunProfileState state,
                                                   final @NotNull ExecutionEnvironment env,
                                                   final @Nullable String dasExecutionContextId) throws RuntimeConfigurationError,
@@ -162,7 +166,8 @@ public class DartRunner extends DefaultProgramRunner {
                                                dartUrlResolver,
                                                dasExecutionContextId,
                                                runConfiguration instanceof DartRemoteDebugConfiguration,
-                                               entryPointInLibFolder);
+                                               entryPointInLibFolder,
+                                               getTimeout());
       }
     });
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -72,6 +72,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   @Nullable private final String myDASExecutionContextId;
   private final boolean myRemoteDebug;
   private final boolean myEntryPointInLibFolder;
+  private final int myTimeout;
 
   @Nullable String myRemoteProjectRootUri;
 
@@ -82,7 +83,8 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
                                    @NotNull final DartUrlResolver dartUrlResolver,
                                    @Nullable final String dasExecutionContextId,
                                    final boolean remoteDebug,
-                                   final boolean entryPointInLibFolder) {
+                                   final boolean entryPointInLibFolder,
+                                   final int timeout) {
     super(session);
     myDebuggingHost = debuggingHost;
     myObservatoryPort = observatoryPort;
@@ -90,6 +92,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     myDartUrlResolver = dartUrlResolver;
     myRemoteDebug = remoteDebug;
     myEntryPointInLibFolder = entryPointInLibFolder;
+    myTimeout = timeout;
 
     myIsolatesInfo = new IsolatesInfo();
     final DartVmServiceBreakpointHandler breakpointHandler = new DartVmServiceBreakpointHandler(this);
@@ -174,7 +177,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
   public void scheduleConnect() {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      long timeout = 5000;
+      long timeout = (long)myTimeout;
       long startTime = System.currentTimeMillis();
 
       try {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -37,6 +37,8 @@ public class DartVmServiceListener implements VmServiceListener {
   public void received(@NotNull final String streamId, @NotNull final Event event) {
     switch (event.getKind()) {
       case BreakpointAdded:
+        // TODO Respond to breakpoints added by the observatory.
+        // myBreakpointHandler.vmBreakpointAdded(null, event.getIsolate().getId(), event.getBreakpoint());
         break;
       case BreakpointRemoved:
         break;


### PR DESCRIPTION
@alexander-doroshko Flutter needs more time to launch the process that is being debugged. I'd prefer a more deterministic approach than just allowing more time before failing, but this is gets my demo working while we figure out the long-term solution.

I added a TODO to remind us to finish hooking up two-way communications with the observatory. Given the expected user base of Flutter it seems likely that we'll need to write that code.