### PR TITLE
Add default implementations of default methods

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -55,6 +55,14 @@ public class DartServerRootsHandler {
           DartAnalysisServerService.getInstance().updateVisibleFiles();
         }
       }
+
+      @Override
+      public void beforeProjectLoaded(@NotNull Project project) {
+      }
+
+      @Override
+      public void projectComponentsInitialized(@NotNull Project project) {
+      }
     });
   }
 


### PR DESCRIPTION
@alexander-doroshko These methods used to be implemented by ProjectLifecycleListener.Adapter but that was deprecated. New implementations were not provided, so here they are.

I only noticed this while testing a plugin I built from sources, as per the artifact-building instructions you sent me.