### PR TITLE
implement async step; update debugger library

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -32,6 +32,7 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.runner.base.DartDebuggerEditorsProvider;
 import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceStackFrame;
+import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceSuspendContext;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
@@ -298,7 +299,9 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   @Override
   public void startStepOver(@Nullable XSuspendContext context) {
     if (myLatestCurrentIsolateId != null && mySuspendedIsolateIds.contains(myLatestCurrentIsolateId)) {
-      myVmServiceWrapper.resumeIsolate(myLatestCurrentIsolateId, StepOption.Over);
+      DartVmServiceSuspendContext suspendContext = (DartVmServiceSuspendContext)context;
+      myVmServiceWrapper.resumeIsolate(myLatestCurrentIsolateId,
+                                       suspendContext.getAtAsyncSuspension() ? StepOption.OverAsyncSuspension : StepOption.Over);
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceSuspendContext.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceSuspendContext.java
@@ -19,19 +19,26 @@ public class DartVmServiceSuspendContext extends XSuspendContext {
   @NotNull private final DartVmServiceExecutionStack myActiveExecutionStack;
 
   private List<XExecutionStack> myExecutionStacks;
+  private boolean myAtAsyncSuspension;
 
   public DartVmServiceSuspendContext(@NotNull final DartVmServiceDebugProcess debugProcess,
                                      @NotNull final IsolateRef isolateRef,
                                      @NotNull final Frame topFrame,
-                                     @Nullable final InstanceRef exception) {
+                                     @Nullable final InstanceRef exception,
+                                     boolean atAsyncSuspension) {
     myDebugProcess = debugProcess;
     myActiveExecutionStack = new DartVmServiceExecutionStack(debugProcess, isolateRef.getId(), isolateRef.getName(), topFrame, exception);
+    myAtAsyncSuspension = atAsyncSuspension;
   }
 
   @NotNull
   @Override
   public XExecutionStack getActiveExecutionStack() {
     return myActiveExecutionStack;
+  }
+
+  public boolean getAtAsyncSuspension() {
+    return myAtAsyncSuspension;
   }
 
   @Override

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Breakpoint.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Breakpoint.java
@@ -38,7 +38,22 @@ public class Breakpoint extends Obj {
    * command?
    */
   public boolean getIsSyntheticAsyncContinuation() {
-    return json.get("isSyntheticAsyncContinuation").getAsBoolean();
+    return json.get("isSyntheticAsyncContinuation") == null ? false : json.get("isSyntheticAsyncContinuation").getAsBoolean();
+  }
+
+  /**
+   * SourceLocation when breakpoint is resolved, UnresolvedSourceLocation when a breakpoint is not
+   * resolved.
+   *
+   * @return one of <code>SourceLocation</code> or <code>UnresolvedSourceLocation</code>
+   */
+  public Object getLocation() {
+    JsonObject elem = (JsonObject)json.get("location");
+    if (elem == null) return null;
+
+    if (elem.get("type").getAsString() == "SourceLocation") return new SourceLocation(elem);
+    if (elem.get("type").getAsString() == "UnresolvedSourceLocation") return new UnresolvedSourceLocation(elem);
+    return null;
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/ClassObj.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/ClassObj.java
@@ -31,7 +31,7 @@ public class ClassObj extends Obj {
    * The error which occurred during class finalization, if it exists.
    */
   public ErrorRef getError() {
-    return new ErrorRef((JsonObject) json.get("error"));
+    return json.get("error") == null ? null : new ErrorRef((JsonObject) json.get("error"));
   }
 
   /**
@@ -83,7 +83,7 @@ public class ClassObj extends Obj {
    * The location of this class in the source code.
    */
   public SourceLocation getLocation() {
-    return new SourceLocation((JsonObject) json.get("location"));
+    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
   }
 
   /**
@@ -92,7 +92,7 @@ public class ClassObj extends Obj {
    * The value will be of the kind: Type.
    */
   public InstanceRef getMixin() {
-    return new InstanceRef((JsonObject) json.get("mixin"));
+    return json.get("mixin") == null ? null : new InstanceRef((JsonObject) json.get("mixin"));
   }
 
   /**
@@ -118,7 +118,7 @@ public class ClassObj extends Obj {
    * The superclass of this class, if any.
    */
   public ClassRef getSuperClass() {
-    return new ClassRef((JsonObject) json.get("super"));
+    return json.get("super") == null ? null : new ClassRef((JsonObject) json.get("super"));
   }
 
   /**
@@ -127,7 +127,7 @@ public class ClassObj extends Obj {
    * The value will be of the kind: Type.
    */
   public InstanceRef getSuperType() {
-    return new InstanceRef((JsonObject) json.get("superType"));
+    return json.get("superType") == null ? null : new InstanceRef((JsonObject) json.get("superType"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Context.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Context.java
@@ -38,7 +38,7 @@ public class Context extends Obj {
    * The enclosing context for this context.
    */
   public Context getParent() {
-    return new Context((JsonObject) json.get("parent"));
+    return json.get("parent") == null ? null : new Context((JsonObject) json.get("parent"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/ErrorObj.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/ErrorObj.java
@@ -30,7 +30,7 @@ public class ErrorObj extends Obj {
    * If this error is due to an unhandled exception, this is the exception thrown.
    */
   public InstanceRef getException() {
-    return new InstanceRef((JsonObject) json.get("exception"));
+    return json.get("exception") == null ? null : new InstanceRef((JsonObject) json.get("exception"));
   }
 
   /**
@@ -56,6 +56,6 @@ public class ErrorObj extends Obj {
    * If this error is due to an unhandled exception, this is the stacktrace object.
    */
   public InstanceRef getStacktrace() {
-    return new InstanceRef((JsonObject) json.get("stacktrace"));
+    return json.get("stacktrace") == null ? null : new InstanceRef((JsonObject) json.get("stacktrace"));
   }
 }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
@@ -36,7 +36,7 @@ public class Event extends Response {
    *  - PauseInterrupted
    */
   public boolean getAtAsyncSuspension() {
-    return json.get("atAsyncSuspension").getAsBoolean();
+    return json.get("atAsyncSuspension") == null ? false : json.get("atAsyncSuspension").getAsBoolean();
   }
 
   /**
@@ -49,7 +49,7 @@ public class Event extends Response {
    *  - BreakpointResolved
    */
   public Breakpoint getBreakpoint() {
-    return new Breakpoint((JsonObject) json.get("breakpoint"));
+    return json.get("breakpoint") == null ? null : new Breakpoint((JsonObject) json.get("breakpoint"));
   }
 
   /**
@@ -65,7 +65,7 @@ public class Event extends Response {
    * The exception associated with this event, if this is a PauseException event.
    */
   public InstanceRef getException() {
-    return new InstanceRef((JsonObject) json.get("exception"));
+    return json.get("exception") == null ? null : new InstanceRef((JsonObject) json.get("exception"));
   }
 
   /**
@@ -74,7 +74,7 @@ public class Event extends Response {
    * This is provided for the Extension event.
    */
   public ExtensionData getExtensionData() {
-    return new ExtensionData((JsonObject) json.get("extensionData"));
+    return json.get("extensionData") == null ? null : new ExtensionData((JsonObject) json.get("extensionData"));
   }
 
   /**
@@ -101,7 +101,7 @@ public class Event extends Response {
    * This is provided for the Inspect event.
    */
   public InstanceRef getInspectee() {
-    return new InstanceRef((JsonObject) json.get("inspectee"));
+    return json.get("inspectee") == null ? null : new InstanceRef((JsonObject) json.get("inspectee"));
   }
 
   /**
@@ -111,7 +111,7 @@ public class Event extends Response {
    *  - VMUpdate
    */
   public IsolateRef getIsolate() {
-    return new IsolateRef((JsonObject) json.get("isolate"));
+    return json.get("isolate") == null ? null : new IsolateRef((JsonObject) json.get("isolate"));
   }
 
   /**
@@ -185,7 +185,7 @@ public class Event extends Response {
    * event that is delivered when an isolate begins execution.
    */
   public Frame getTopFrame() {
-    return new Frame((JsonObject) json.get("topFrame"));
+    return json.get("topFrame") == null ? null : new Frame((JsonObject) json.get("topFrame"));
   }
 
   /**
@@ -195,6 +195,6 @@ public class Event extends Response {
    *  - VMUpdate
    */
   public VMRef getVm() {
-    return new VMRef((JsonObject) json.get("vm"));
+    return json.get("vm") == null ? null : new VMRef((JsonObject) json.get("vm"));
   }
 }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
@@ -39,7 +39,7 @@ public class Field extends Obj {
    * The location of this field in the source code.
    */
   public SourceLocation getLocation() {
-    return new SourceLocation((JsonObject) json.get("location"));
+    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
   }
 
   /**
@@ -60,7 +60,7 @@ public class Field extends Obj {
    * The value of this field, if the field is static.
    */
   public InstanceRef getStaticValue() {
-    return new InstanceRef((JsonObject) json.get("staticValue"));
+    return json.get("staticValue") == null ? null : new InstanceRef((JsonObject) json.get("staticValue"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Func.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Func.java
@@ -30,14 +30,14 @@ public class Func extends Obj {
    * The compiled code associated with this function.
    */
   public CodeRef getCode() {
-    return new CodeRef((JsonObject) json.get("code"));
+    return json.get("code") == null ? null : new CodeRef((JsonObject) json.get("code"));
   }
 
   /**
    * The location of this function in the source code.
    */
   public SourceLocation getLocation() {
-    return new SourceLocation((JsonObject) json.get("location"));
+    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
   }
 
   /**
@@ -45,5 +45,20 @@ public class Func extends Obj {
    */
   public String getName() {
     return json.get("name").getAsString();
+  }
+
+  /**
+   * The owner of this function, which can be a Library, Class, or a Function.
+   *
+   * @return one of <code>LibraryRef</code>, <code>ClassRef</code> or <code>FuncRef</code>
+   */
+  public Object getOwner() {
+    JsonObject elem = (JsonObject)json.get("owner");
+    if (elem == null) return null;
+
+    if (elem.get("type").getAsString() == "@Library") return new LibraryRef(elem);
+    if (elem.get("type").getAsString() == "@Class") return new ClassRef(elem);
+    if (elem.get("type").getAsString() == "@Func") return new FuncRef(elem);
+    return null;
   }
 }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FuncRef.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FuncRef.java
@@ -34,6 +34,21 @@ public class FuncRef extends ObjRef {
   }
 
   /**
+   * The owner of this function, which can be a Library, Class, or a Function.
+   *
+   * @return one of <code>LibraryRef</code>, <code>ClassRef</code> or <code>FuncRef</code>
+   */
+  public Object getOwner() {
+    JsonObject elem = (JsonObject)json.get("owner");
+    if (elem == null) return null;
+
+    if (elem.get("type").getAsString() == "@Library") return new LibraryRef(elem);
+    if (elem.get("type").getAsString() == "@Class") return new ClassRef(elem);
+    if (elem.get("type").getAsString() == "@Func") return new FuncRef(elem);
+    return null;
+  }
+
+  /**
    * Is this function const?
    */
   public boolean isConst() {

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
@@ -53,7 +53,7 @@ public class Instance extends Obj {
    *  - TypeParameter
    */
   public InstanceRef getBound() {
-    return new InstanceRef((JsonObject) json.get("bound"));
+    return json.get("bound") == null ? null : new InstanceRef((JsonObject) json.get("bound"));
   }
 
   /**
@@ -95,7 +95,7 @@ public class Instance extends Obj {
    *  - Closure
    */
   public ContextRef getClosureContext() {
-    return new ContextRef((JsonObject) json.get("closureContext"));
+    return json.get("closureContext") == null ? null : new ContextRef((JsonObject) json.get("closureContext"));
   }
 
   /**
@@ -105,7 +105,7 @@ public class Instance extends Obj {
    *  - Closure
    */
   public FuncRef getClosureFunction() {
-    return new FuncRef((JsonObject) json.get("closureFunction"));
+    return json.get("closureFunction") == null ? null : new FuncRef((JsonObject) json.get("closureFunction"));
   }
 
   /**
@@ -171,7 +171,7 @@ public class Instance extends Obj {
    *  - RegExp
    */
   public boolean getIsCaseSensitive() {
-    return json.get("isCaseSensitive").getAsBoolean();
+    return json.get("isCaseSensitive") == null ? false : json.get("isCaseSensitive").getAsBoolean();
   }
 
   /**
@@ -181,7 +181,7 @@ public class Instance extends Obj {
    *  - RegExp
    */
   public boolean getIsMultiLine() {
-    return json.get("isMultiLine").getAsBoolean();
+    return json.get("isMultiLine") == null ? false : json.get("isMultiLine").getAsBoolean();
   }
 
   /**
@@ -230,7 +230,7 @@ public class Instance extends Obj {
    *  - MirrorReference
    */
   public InstanceRef getMirrorReferent() {
-    return new InstanceRef((JsonObject) json.get("mirrorReferent"));
+    return json.get("mirrorReferent") == null ? null : new InstanceRef((JsonObject) json.get("mirrorReferent"));
   }
 
   /**
@@ -287,7 +287,7 @@ public class Instance extends Obj {
    *  - TypeParameter
    */
   public ClassRef getParameterizedClass() {
-    return new ClassRef((JsonObject) json.get("parameterizedClass"));
+    return json.get("parameterizedClass") == null ? null : new ClassRef((JsonObject) json.get("parameterizedClass"));
   }
 
   /**
@@ -307,7 +307,7 @@ public class Instance extends Obj {
    *  - WeakProperty
    */
   public InstanceRef getPropertyKey() {
-    return new InstanceRef((JsonObject) json.get("propertyKey"));
+    return json.get("propertyKey") == null ? null : new InstanceRef((JsonObject) json.get("propertyKey"));
   }
 
   /**
@@ -317,7 +317,7 @@ public class Instance extends Obj {
    *  - WeakProperty
    */
   public InstanceRef getPropertyValue() {
-    return new InstanceRef((JsonObject) json.get("propertyValue"));
+    return json.get("propertyValue") == null ? null : new InstanceRef((JsonObject) json.get("propertyValue"));
   }
 
   /**
@@ -330,7 +330,7 @@ public class Instance extends Obj {
    *  - TypeRef
    */
   public InstanceRef getTargetType() {
-    return new InstanceRef((JsonObject) json.get("targetType"));
+    return json.get("targetType") == null ? null : new InstanceRef((JsonObject) json.get("targetType"));
   }
 
   /**
@@ -340,7 +340,7 @@ public class Instance extends Obj {
    *  - Type
    */
   public TypeArgumentsRef getTypeArguments() {
-    return new TypeArgumentsRef((JsonObject) json.get("typeArguments"));
+    return json.get("typeArguments") == null ? null : new TypeArgumentsRef((JsonObject) json.get("typeArguments"));
   }
 
   /**
@@ -350,7 +350,7 @@ public class Instance extends Obj {
    *  - Type
    */
   public ClassRef getTypeClass() {
-    return new ClassRef((JsonObject) json.get("typeClass"));
+    return json.get("typeClass") == null ? null : new ClassRef((JsonObject) json.get("typeClass"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/InstanceRef.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/InstanceRef.java
@@ -90,7 +90,7 @@ public class InstanceRef extends ObjRef {
    *  - TypeParameter
    */
   public ClassRef getParameterizedClass() {
-    return new ClassRef((JsonObject) json.get("parameterizedClass"));
+    return json.get("parameterizedClass") == null ? null : new ClassRef((JsonObject) json.get("parameterizedClass"));
   }
 
   /**
@@ -102,7 +102,7 @@ public class InstanceRef extends ObjRef {
    *  - RegExp
    */
   public InstanceRef getPattern() {
-    return new InstanceRef((JsonObject) json.get("pattern"));
+    return json.get("pattern") == null ? null : new InstanceRef((JsonObject) json.get("pattern"));
   }
 
   /**
@@ -112,7 +112,7 @@ public class InstanceRef extends ObjRef {
    *  - Type
    */
   public ClassRef getTypeClass() {
-    return new ClassRef((JsonObject) json.get("typeClass"));
+    return json.get("typeClass") == null ? null : new ClassRef((JsonObject) json.get("typeClass"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
@@ -44,7 +44,7 @@ public class Isolate extends Response {
    * The error that is causing this isolate to exit, if applicable.
    */
   public ErrorObj getError() {
-    return new ErrorObj((JsonObject) json.get("error"));
+    return json.get("error") == null ? null : new ErrorObj((JsonObject) json.get("error"));
   }
 
   /**
@@ -129,7 +129,7 @@ public class Isolate extends Response {
    * Guaranteed to be initialized when the IsolateRunnable event fires.
    */
   public LibraryRef getRootLib() {
-    return new LibraryRef((JsonObject) json.get("rootLib"));
+    return json.get("rootLib") == null ? null : new LibraryRef((JsonObject) json.get("rootLib"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Message.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Message.java
@@ -31,7 +31,7 @@ public class Message extends Response {
    * A reference to the function that will be invoked to handle this message.
    */
   public FuncRef getHandler() {
-    return new FuncRef((JsonObject) json.get("handler"));
+    return json.get("handler") == null ? null : new FuncRef((JsonObject) json.get("handler"));
   }
 
   /**
@@ -46,7 +46,7 @@ public class Message extends Response {
    * The source location of handler.
    */
   public SourceLocation getLocation() {
-    return new SourceLocation((JsonObject) json.get("location"));
+    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Obj.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Obj.java
@@ -35,7 +35,7 @@ public class Obj extends Response {
    * other than Instance.
    */
   public ClassRef getClassRef() {
-    return new ClassRef((JsonObject) json.get("class"));
+    return json.get("class") == null ? null : new ClassRef((JsonObject) json.get("class"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/SourceReportRange.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/SourceReportRange.java
@@ -40,7 +40,7 @@ public class SourceReportRange extends Element {
    * requested and the range has been compiled.
    */
   public SourceReportCoverage getCoverage() {
-    return new SourceReportCoverage((JsonObject) json.get("coverage"));
+    return json.get("coverage") == null ? null : new SourceReportCoverage((JsonObject) json.get("coverage"));
   }
 
   /**
@@ -55,7 +55,7 @@ public class SourceReportRange extends Element {
    * forceCompile=true.
    */
   public ErrorRef getError() {
-    return new ErrorRef((JsonObject) json.get("error"));
+    return json.get("error") == null ? null : new ErrorRef((JsonObject) json.get("error"));
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/UnresolvedSourceLocation.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/UnresolvedSourceLocation.java
@@ -48,7 +48,7 @@ public class UnresolvedSourceLocation extends Response {
    * The script containing the source location if the script has been loaded.
    */
   public ScriptRef getScript() {
-    return new ScriptRef((JsonObject) json.get("script"));
+    return json.get("script") == null ? null : new ScriptRef((JsonObject) json.get("script"));
   }
 
   /**


### PR DESCRIPTION
- implement async stepping (fix https://youtrack.jetbrains.com/issue/WEB-22910)
- update the debugger library to the latest; this properly supports optional fields in the protocol (and avoids an NPE), and exposes a few fields that had not yet been exposed

@alexander-doroshko, @jwren, @danrubel

This implementation essentially store the `atAsyncSuspension` field when an isolate pauses, and when the user steps, we either issue a `StepOption.OverAsyncSuspension` or a `StepOption.Over`.

