### PR TITLE
don't warn if dartium is not configured

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -196,7 +196,6 @@ enable.dart.support.for.project.0=&Enable Dart support for the project ''{0}''
 error.path.to.sdk.not.specified=Error: path to the Dart SDK is not specified.
 error.folder.specified.as.sdk.not.exists=Error: the folder specified as the Dart SDK home does not exist.
 error.sdk.not.found.in.specified.location=Error: Dart SDK is not found in the specified location.
-warning.dartium.path.not.specified=Warning: path to the Dartium browser is not specified.
 warning.invalid.dartium.path=Warning: invalid path to the Dartium browser.
 dartium.path.label=Da&rtium path:
 dartium.settings.button=&Settings...

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/client/DartiumUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/client/DartiumUtil.java
@@ -65,10 +65,11 @@ public class DartiumUtil {
 
   @Nullable
   public static String getErrorMessageIfWrongDartiumPath(final @NotNull String dartiumPath) {
-    if (dartiumPath.isEmpty()) return DartBundle.message("warning.dartium.path.not.specified");
+    // Don't warn if Dartium is not configured.
+    if (dartiumPath.isEmpty()) return null;
 
     final File file = new File(dartiumPath);
-    if (SystemInfo.isMac && !file.exists() || !SystemInfo.isMac && !file.isFile()) {
+    if (SystemInfo.isMac && !file.isDirectory() || !SystemInfo.isMac && !file.isFile()) {
       return DartBundle.message("warning.invalid.dartium.path");
     }
 


### PR DESCRIPTION
- don't warn if dartium is not configured

You can still run Dart CLI apps w/o having Dartium configured, and going forward we'll favor the DDC based workflow. I.e., not having Dartium installed won't be as much of an error condition.

@alexander-doroshko 

/cc @pq, since we saw this while doing other work