### PR TITLE
Some UI tweaks to the Dart problems view

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -25,7 +25,7 @@ public class DartProblem {
 
   @Nullable private VirtualFile myFile;
   @Nullable private VirtualFile myPackageRoot;
-  @Nullable private VirtualFile myModuleRoot;
+  @Nullable private VirtualFile myContentRoot;
 
   private String myPresentableLocationWithoutLineNumber;
 
@@ -68,30 +68,30 @@ public class DartProblem {
     final String dartPackageName;
     final String presentableFilePath;
     final VirtualFile packageRoot;
-    final VirtualFile moduleRoot;
+    final VirtualFile contentRoot;
 
     file = LocalFileSystem.getInstance().findFileByPath(getSystemIndependentPath());
     if (file == null) {
       dartPackageName = null;
       packageRoot = null;
-      moduleRoot = null;
+      contentRoot = null;
       presentableFilePath = myAnalysisError.getLocation().getFile();
     }
     else {
-      moduleRoot = ProjectRootManager.getInstance(myProject).getFileIndex().getContentRootForFile(file, false);
+      contentRoot = ProjectRootManager.getInstance(myProject).getFileIndex().getContentRootForFile(file, false);
 
       final VirtualFile pubspec = Registry.is("dart.projects.without.pubspec", false)
                                   ? DartBuildFileUtil.findPackageRootBuildFile(myProject, file)
                                   : PubspecYamlUtil.findPubspecYamlFile(myProject, file);
       if (pubspec == null) {
         dartPackageName = null;
-        if (moduleRoot == null) {
+        if (contentRoot == null) {
           packageRoot = null;
           presentableFilePath = myAnalysisError.getLocation().getFile();
         }
         else {
-          packageRoot = moduleRoot;
-          final String relativePath = VfsUtilCore.getRelativePath(file, moduleRoot, File.separatorChar);
+          packageRoot = contentRoot;
+          final String relativePath = VfsUtilCore.getRelativePath(file, contentRoot, File.separatorChar);
           presentableFilePath = relativePath != null ? relativePath : myAnalysisError.getLocation().getFile();
         }
       }
@@ -108,7 +108,7 @@ public class DartProblem {
 
     myFile = file;
     myPackageRoot = packageRoot;
-    myModuleRoot = moduleRoot;
+    myContentRoot = contentRoot;
     myPresentableLocationWithoutLineNumber = dartPackageName == null ? presentableFilePath
                                                                      : ("[" + dartPackageName + "] " + presentableFilePath);
   }
@@ -142,8 +142,8 @@ public class DartProblem {
   }
 
   @Nullable
-  public VirtualFile getModuleRoot() {
+  public VirtualFile getContentRoot() {
     ensureInitialized();
-    return myModuleRoot;
+    return myContentRoot;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -25,7 +25,8 @@ public class DartProblem {
 
   @Nullable private VirtualFile myFile;
   @Nullable private VirtualFile myPackageRoot;
-  @Nullable private VirtualFile myContentRoot;
+  @Nullable private VirtualFile myModuleRoot;
+
   private String myPresentableLocationWithoutLineNumber;
 
   public DartProblem(@NotNull final Project project, @NotNull final AnalysisError error) {
@@ -67,30 +68,30 @@ public class DartProblem {
     final String dartPackageName;
     final String presentableFilePath;
     final VirtualFile packageRoot;
-    final VirtualFile contentRoot;
+    final VirtualFile moduleRoot;
 
     file = LocalFileSystem.getInstance().findFileByPath(getSystemIndependentPath());
     if (file == null) {
       dartPackageName = null;
       packageRoot = null;
-      contentRoot = null;
+      moduleRoot = null;
       presentableFilePath = myAnalysisError.getLocation().getFile();
     }
     else {
-      contentRoot = ProjectRootManager.getInstance(myProject).getFileIndex().getContentRootForFile(file, false);
+      moduleRoot = ProjectRootManager.getInstance(myProject).getFileIndex().getContentRootForFile(file, false);
 
       final VirtualFile pubspec = Registry.is("dart.projects.without.pubspec", false)
                                   ? DartBuildFileUtil.findPackageRootBuildFile(myProject, file)
                                   : PubspecYamlUtil.findPubspecYamlFile(myProject, file);
       if (pubspec == null) {
         dartPackageName = null;
-        if (contentRoot == null) {
+        if (moduleRoot == null) {
           packageRoot = null;
           presentableFilePath = myAnalysisError.getLocation().getFile();
         }
         else {
-          packageRoot = contentRoot;
-          final String relativePath = VfsUtilCore.getRelativePath(file, contentRoot, File.separatorChar);
+          packageRoot = moduleRoot;
+          final String relativePath = VfsUtilCore.getRelativePath(file, moduleRoot, File.separatorChar);
           presentableFilePath = relativePath != null ? relativePath : myAnalysisError.getLocation().getFile();
         }
       }
@@ -107,11 +108,10 @@ public class DartProblem {
 
     myFile = file;
     myPackageRoot = packageRoot;
-    myContentRoot = contentRoot;
+    myModuleRoot = moduleRoot;
     myPresentableLocationWithoutLineNumber = dartPackageName == null ? presentableFilePath
                                                                      : ("[" + dartPackageName + "] " + presentableFilePath);
   }
-
 
   /**
    * Returns Dart package name in brackets and relative path form Dart package root to the file.
@@ -142,8 +142,8 @@ public class DartProblem {
   }
 
   @Nullable
-  public VirtualFile getContentRoot() {
+  public VirtualFile getModuleRoot() {
     ensureInitialized();
-    return myContentRoot;
+    return myModuleRoot;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilter.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilter.java
@@ -15,7 +15,7 @@ import javax.swing.*;
 
 public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Integer> {
 
-  public enum FileFilterMode {All, Module, DartPackage, Directory, File}
+  public enum FileFilterMode {All, ContentRoot, DartPackage, Directory, File}
 
   private static final boolean SHOW_ERRORS_DEFAULT = true;
   private static final boolean SHOW_WARNINGS_DEFAULT = true;
@@ -32,8 +32,8 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
   @Nullable private VirtualFile myCurrentFile;
   private boolean myDartPackageRootUpToDate = false;
   @Nullable private VirtualFile myCurrentDartPackageRoot;
-  private boolean myModuleRootUpToDate = false;
-  @Nullable private VirtualFile myCurrentModuleRoot;
+  private boolean myContentRootUpToDate = false;
+  @Nullable private VirtualFile myCurrentContentRoot;
 
   public DartProblemsFilter(@NotNull final Project project) {
     myProject = project;
@@ -73,7 +73,7 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
     else {
       myCurrentFile = file;
       myDartPackageRootUpToDate = false;
-      myModuleRootUpToDate = false;
+      myContentRootUpToDate = false;
       return true;
     }
   }
@@ -125,9 +125,9 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
       }
     }
 
-    if (myFileFilterMode == FileFilterMode.Module) {
+    if (myFileFilterMode == FileFilterMode.ContentRoot) {
       ensureContentRootUpToDate();
-      if (myCurrentModuleRoot == null || !myCurrentModuleRoot.equals(problem.getModuleRoot())) {
+      if (myCurrentContentRoot == null || !myCurrentContentRoot.equals(problem.getContentRoot())) {
         return false;
       }
     }
@@ -163,11 +163,11 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
   }
 
   private void ensureContentRootUpToDate() {
-    if (myModuleRootUpToDate) return;
+    if (myContentRootUpToDate) return;
 
-    myCurrentModuleRoot = myCurrentFile == null
+    myCurrentContentRoot = myCurrentFile == null
                            ? null
                            : ProjectRootManager.getInstance(myProject).getFileIndex().getContentRootForFile(myCurrentFile, false);
-    myModuleRootUpToDate = true;
+    myContentRootUpToDate = true;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilter.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilter.java
@@ -15,7 +15,7 @@ import javax.swing.*;
 
 public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Integer> {
 
-  public enum FileFilterMode {All, ContentRoot, Package, Directory, File}
+  public enum FileFilterMode {All, Module, DartPackage, Directory, File}
 
   private static final boolean SHOW_ERRORS_DEFAULT = true;
   private static final boolean SHOW_WARNINGS_DEFAULT = true;
@@ -30,10 +30,10 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
   private FileFilterMode myFileFilterMode;
 
   @Nullable private VirtualFile myCurrentFile;
-  private boolean myPackageRootUpToDate = false;
-  @Nullable private VirtualFile myCurrentPackageRoot;
-  private boolean myContentRootUpToDate = false;
-  @Nullable private VirtualFile myCurrentContentRoot;
+  private boolean myDartPackageRootUpToDate = false;
+  @Nullable private VirtualFile myCurrentDartPackageRoot;
+  private boolean myModuleRootUpToDate = false;
+  @Nullable private VirtualFile myCurrentModuleRoot;
 
   public DartProblemsFilter(@NotNull final Project project) {
     myProject = project;
@@ -72,8 +72,8 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
     }
     else {
       myCurrentFile = file;
-      myPackageRootUpToDate = false;
-      myContentRootUpToDate = false;
+      myDartPackageRootUpToDate = false;
+      myModuleRootUpToDate = false;
       return true;
     }
   }
@@ -118,16 +118,16 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
       }
     }
 
-    if (myFileFilterMode == FileFilterMode.Package) {
+    if (myFileFilterMode == FileFilterMode.DartPackage) {
       ensurePackageRootUpToDate();
-      if (myCurrentPackageRoot == null || !myCurrentPackageRoot.equals(problem.getPackageRoot())) {
+      if (myCurrentDartPackageRoot == null || !myCurrentDartPackageRoot.equals(problem.getPackageRoot())) {
         return false;
       }
     }
 
-    if (myFileFilterMode == FileFilterMode.ContentRoot) {
+    if (myFileFilterMode == FileFilterMode.Module) {
       ensureContentRootUpToDate();
-      if (myCurrentContentRoot == null || !myCurrentContentRoot.equals(problem.getContentRoot())) {
+      if (myCurrentModuleRoot == null || !myCurrentModuleRoot.equals(problem.getModuleRoot())) {
         return false;
       }
     }
@@ -136,7 +136,7 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
   }
 
   private void ensurePackageRootUpToDate() {
-    if (myPackageRootUpToDate) return;
+    if (myDartPackageRootUpToDate) return;
 
     // temp var to make sure that value is initialized
     final VirtualFile packageRoot;
@@ -158,16 +158,16 @@ public class DartProblemsFilter extends RowFilter<DartProblemsTableModel, Intege
       }
     }
 
-    myCurrentPackageRoot = packageRoot;
-    myPackageRootUpToDate = true;
+    myCurrentDartPackageRoot = packageRoot;
+    myDartPackageRootUpToDate = true;
   }
 
   private void ensureContentRootUpToDate() {
-    if (myContentRootUpToDate) return;
+    if (myModuleRootUpToDate) return;
 
-    myCurrentContentRoot = myCurrentFile == null
+    myCurrentModuleRoot = myCurrentFile == null
                            ? null
                            : ProjectRootManager.getInstance(myProject).getFileIndex().getContentRootForFile(myCurrentFile, false);
-    myContentRootUpToDate = true;
+    myModuleRootUpToDate = true;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.form
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.form
@@ -30,13 +30,13 @@
           <text value="Wh&amp;ole project"/>
         </properties>
       </component>
-      <component id="5d338" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentModuleRootRadioButton">
+      <component id="5d338" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentContentRootRadioButton">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <margin top="0" left="2" bottom="0" right="2"/>
-          <text value="Current &amp;module"/>
+          <text value="Current &amp;content root"/>
         </properties>
       </component>
       <component id="6d10f" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentDirectoryRadioButton">

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.form
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.form
@@ -30,13 +30,13 @@
           <text value="Wh&amp;ole project"/>
         </properties>
       </component>
-      <component id="5d338" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentContentRootRadioButton">
+      <component id="5d338" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentModuleRootRadioButton">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <margin top="0" left="2" bottom="0" right="2"/>
-          <text value="Current &amp;content root"/>
+          <text value="Current &amp;module"/>
         </properties>
       </component>
       <component id="6d10f" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentDirectoryRadioButton">
@@ -121,13 +121,13 @@
           <grid row="0" column="4" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
-      <component id="f4b5d" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentPackageRadioButton">
+      <component id="f4b5d" class="com.intellij.ui.components.JBRadioButton" binding="myCurrentDartPackageRadioButton">
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <margin top="0" left="2" bottom="0" right="2"/>
-          <text value="Current &amp;package"/>
+          <text value="Current Dart &amp;package"/>
         </properties>
       </component>
       <component id="b56c4" class="com.intellij.ui.components.JBCheckBox" binding="myHintsCheckBox" default-binding="true">

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.java
@@ -30,8 +30,8 @@ public class DartProblemsFilterForm {
   private JBCheckBox myHintsCheckBox;
 
   private JBRadioButton myWholeProjectRadioButton;
-  private JBRadioButton myCurrentContentRootRadioButton;
-  private JBRadioButton myCurrentPackageRadioButton;
+  private JBRadioButton myCurrentModuleRootRadioButton;
+  private JBRadioButton myCurrentDartPackageRadioButton;
   private JBRadioButton myCurrentDirectoryRadioButton;
   private JBRadioButton myCurrentFileRadioButton;
 
@@ -44,9 +44,7 @@ public class DartProblemsFilterForm {
     myResetFilterHyperlink.addHyperlinkListener(new HyperlinkAdapter() {
       @Override
       protected void hyperlinkActivated(final HyperlinkEvent e) {
-        for (FilterListener listener : myListeners) {
-          listener.filtersResetRequested();
-        }
+        myListeners.forEach(FilterListener::filtersResetRequested);
       }
     });
   }
@@ -62,11 +60,11 @@ public class DartProblemsFilterForm {
     else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.Directory) {
       myCurrentDirectoryRadioButton.setSelected(true);
     }
-    else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.Package) {
-      myCurrentPackageRadioButton.setSelected(true);
+    else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.DartPackage) {
+      myCurrentDartPackageRadioButton.setSelected(true);
     }
-    else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.ContentRoot) {
-      myCurrentContentRootRadioButton.setSelected(true);
+    else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.Module) {
+      myCurrentModuleRootRadioButton.setSelected(true);
     }
     else {
       myWholeProjectRadioButton.setSelected(true);
@@ -88,8 +86,8 @@ public class DartProblemsFilterForm {
     myHintsCheckBox.addActionListener(listener);
 
     myWholeProjectRadioButton.addActionListener(listener);
-    myCurrentContentRootRadioButton.addActionListener(listener);
-    myCurrentPackageRadioButton.addActionListener(listener);
+    myCurrentModuleRootRadioButton.addActionListener(listener);
+    myCurrentDartPackageRadioButton.addActionListener(listener);
     myCurrentDirectoryRadioButton.addActionListener(listener);
     myCurrentFileRadioButton.addActionListener(listener);
   }
@@ -113,8 +111,8 @@ public class DartProblemsFilterForm {
   public DartProblemsFilter.FileFilterMode getFileFilterMode() {
     if (myCurrentFileRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.File;
     if (myCurrentDirectoryRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.Directory;
-    if (myCurrentPackageRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.Package;
-    if (myCurrentContentRootRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.ContentRoot;
+    if (myCurrentDartPackageRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.DartPackage;
+    if (myCurrentModuleRootRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.Module;
     return DartProblemsFilter.FileFilterMode.All;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsFilterForm.java
@@ -30,7 +30,7 @@ public class DartProblemsFilterForm {
   private JBCheckBox myHintsCheckBox;
 
   private JBRadioButton myWholeProjectRadioButton;
-  private JBRadioButton myCurrentModuleRootRadioButton;
+  private JBRadioButton myCurrentContentRootRadioButton;
   private JBRadioButton myCurrentDartPackageRadioButton;
   private JBRadioButton myCurrentDirectoryRadioButton;
   private JBRadioButton myCurrentFileRadioButton;
@@ -63,8 +63,8 @@ public class DartProblemsFilterForm {
     else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.DartPackage) {
       myCurrentDartPackageRadioButton.setSelected(true);
     }
-    else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.Module) {
-      myCurrentModuleRootRadioButton.setSelected(true);
+    else if (filter.getFileFilterMode() == DartProblemsFilter.FileFilterMode.ContentRoot) {
+      myCurrentContentRootRadioButton.setSelected(true);
     }
     else {
       myWholeProjectRadioButton.setSelected(true);
@@ -86,7 +86,7 @@ public class DartProblemsFilterForm {
     myHintsCheckBox.addActionListener(listener);
 
     myWholeProjectRadioButton.addActionListener(listener);
-    myCurrentModuleRootRadioButton.addActionListener(listener);
+    myCurrentContentRootRadioButton.addActionListener(listener);
     myCurrentDartPackageRadioButton.addActionListener(listener);
     myCurrentDirectoryRadioButton.addActionListener(listener);
     myCurrentFileRadioButton.addActionListener(listener);
@@ -112,7 +112,7 @@ public class DartProblemsFilterForm {
     if (myCurrentFileRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.File;
     if (myCurrentDirectoryRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.Directory;
     if (myCurrentDartPackageRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.DartPackage;
-    if (myCurrentModuleRootRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.Module;
+    if (myCurrentContentRootRadioButton.isSelected()) return DartProblemsFilter.FileFilterMode.ContentRoot;
     return DartProblemsFilter.FileFilterMode.All;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsTableModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsTableModel.java
@@ -360,7 +360,14 @@ class DartProblemsTableModel extends ListTableModel<DartProblem> {
       summary.add(myHintCountAfterFilter > 1 ? myHintCountAfterFilter + " hints" : "1 hint");
     }
 
-    if (summary.isEmpty()) return "";
+    if (summary.isEmpty()) {
+      if (myFilter.areFiltersApplied()) {
+        return getFilterTypeText();
+      }
+      else {
+        return "";
+      }
+    }
 
     if (summary.size() == 2) {
       b.append(StringUtil.join(summary, " and "));
@@ -371,31 +378,38 @@ class DartProblemsTableModel extends ListTableModel<DartProblem> {
 
     if (myFilter.areFiltersApplied()) {
       b.append(" (");
-      switch (myFilter.getFileFilterMode()) {
-        case All:
-          break;
-        case Module:
-          b.append("filtering by current module");
-          break;
-        case DartPackage:
-          b.append("filtering by current package");
-          break;
-        case Directory:
-          b.append("filtering by current directory");
-          break;
-        case File:
-          b.append("filtering by current file");
-          break;
-      }
-
-      if (!myFilter.isShowErrors() || !myFilter.isShowWarnings() || !myFilter.isShowHints()) {
-        b.append(" and severity");
-      }
-
+      b.append(getFilterTypeText());
       b.append(")");
     }
 
     return b.toString();
+  }
+
+  private String getFilterTypeText() {
+    final StringBuilder builder = new StringBuilder();
+
+    switch (myFilter.getFileFilterMode()) {
+      case All:
+        break;
+      case ContentRoot:
+        builder.append("filtering by current content root");
+        break;
+      case DartPackage:
+        builder.append("filtering by current Dart package");
+        break;
+      case Directory:
+        builder.append("filtering by current directory");
+        break;
+      case File:
+        builder.append("filtering by current file");
+        break;
+    }
+
+    if (!myFilter.isShowErrors() || !myFilter.isShowWarnings() || !myFilter.isShowHints()) {
+      builder.append(" and severity");
+    }
+
+    return builder.toString();
   }
 
   private class DartProblemsComparator implements Comparator<DartProblem> {

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -29,7 +29,10 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.pom.Navigatable;
-import com.intellij.ui.*;
+import com.intellij.ui.AutoScrollToSourceHandler;
+import com.intellij.ui.PopupHandler;
+import com.intellij.ui.ScrollPaneFactory;
+import com.intellij.ui.TableSpeedSearch;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.table.TableView;
@@ -42,7 +45,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.RowSorterEvent;
 import javax.swing.event.RowSorterListener;
 import java.awt.*;
@@ -58,9 +60,8 @@ public class DartProblemsViewPanel extends JPanel implements DataProvider, CopyP
   @NotNull private final Project myProject;
   @NotNull private final TableView<DartProblem> myTable;
   @NotNull private JBLabel mySummaryLabel = new JBLabel();
-  @NotNull private HoverHyperlinkLabel myResetFilterHyperlink = new HoverHyperlinkLabel(DartBundle.message("reset.filter") + ".");
 
-  // may be remember settings and filters in workspace.xml? (see ErrorTreeViewConfiguration)
+  // TODO: Remember settings and filters in workspace.xml. (see ErrorTreeViewConfiguration)
   private boolean myAutoScrollToSource = false;
 
   @NotNull private final DartProblemsFilter myFilter;
@@ -165,24 +166,21 @@ public class DartProblemsViewPanel extends JPanel implements DataProvider, CopyP
   private JPanel createStatusBar() {
     final JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
     panel.add(mySummaryLabel);
-    panel.add(myResetFilterHyperlink);
-    myResetFilterHyperlink.addHyperlinkListener(new HyperlinkAdapter() {
-      @Override
-      protected void hyperlinkActivated(HyperlinkEvent e) {
-        myFilter.resetAllFilters();
-        fireGroupingOrFilterChanged();
-      }
-    });
-
     mySummaryLabel.setText("");
-    myResetFilterHyperlink.setVisible(false);
 
     return panel;
   }
 
   private void updateStatusBar() {
-    mySummaryLabel.setText(((DartProblemsTableModel)myTable.getModel()).getStatusText());
-    myResetFilterHyperlink.setVisible(myFilter.areFiltersApplied());
+    String statusText = ((DartProblemsTableModel)myTable.getModel()).getStatusText();
+
+    if (statusText == null) {
+      mySummaryLabel.setVisible(false);
+      mySummaryLabel.setText(statusText);
+    } else {
+      mySummaryLabel.setVisible(true);
+      mySummaryLabel.setText(statusText);
+    }
   }
 
   private static void addReanalyzeAndRestartActions(@NotNull final DefaultActionGroup group) {


### PR DESCRIPTION
Some UI tweaks to the Dart problems view:

- in the filter dialog for the Dart problems view, rename `content root` to `module` (I think this maps closer to IntelliJ concepts the user would be familiar with)
- rename `package` to `Dart package`

<img width="378" alt="screen shot 2016-09-05 at 12 19 55 pm" src="https://cloud.githubusercontent.com/assets/1269969/18258200/06939292-7386-11e6-99b1-ca52a4e63bd2.png">

- if there are no issues in the problems view, hide the status label at the bottom
- change the summary text at the bottom to just show counts for the items displayed in the errors view, and if a filter is active, tell the user what we're filtering on

<img width="451" alt="screen shot 2016-09-05 at 12 18 50 pm" src="https://cloud.githubusercontent.com/assets/1269969/18258196/fd9a973a-7385-11e6-9c25-23abfb009a4c.png">

@alexander-doroshko @jwren