### PR TITLE
implement run to cursor

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -118,6 +118,9 @@ public class DartVmServiceListener implements VmServiceListener {
         LOG.error(vmBreakpoints.size() + " breakpoints hit in one shot.");
       }
 
+      // Remove any temporary (run to cursor) breakpoints.
+      myBreakpointHandler.removeTemporaryBreakpoints(isolateRef.getId());
+
       final XLineBreakpoint<XBreakpointProperties> xBreakpoint = myBreakpointHandler.getXBreakpoint(vmBreakpoints.get(0));
 
       if (xBreakpoint == null) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -198,6 +198,12 @@ public class VmServiceWrapper implements Disposable {
                             @NotNull final XLineBreakpoint<XBreakpointProperties> xBreakpoint,
                             @NotNull final VmServiceConsumers.BreakpointConsumerWrapper consumer) {
     final XSourcePosition position = xBreakpoint.getSourcePosition();
+    addBreakpointFromPosition(isolateId, position, consumer);
+  }
+
+  public void addBreakpointFromPosition(@NotNull final String isolateId,
+                                        @NotNull XSourcePosition position,
+                                        @NotNull final VmServiceConsumers.BreakpointConsumerWrapper consumer) {
     if (position == null || position.getFile().getFileType() != DartFileType.INSTANCE) {
       consumer.sourcePositionNotApplicable();
       return;
@@ -229,6 +235,24 @@ public class VmServiceWrapper implements Disposable {
         }
       });
     }
+  }
+
+  public void addTemporaryBreakpoint(@NotNull final XSourcePosition position,
+                                     @NotNull final String isolateId) {
+    addBreakpointFromPosition(isolateId, position, new VmServiceConsumers.BreakpointConsumerWrapper() {
+      @Override
+      void sourcePositionNotApplicable() {
+      }
+
+      @Override
+      public void received(Breakpoint vmBreakpoint) {
+        myBreakpointHandler.temporaryBreakpointAdded(isolateId, vmBreakpoint);
+      }
+
+      @Override
+      public void onError(RPCError error) {
+      }
+    });
   }
 
   public void removeBreakpoint(@NotNull final String isolateId, @NotNull final String vmBreakpointId) {


### PR DESCRIPTION
- implement the run to cursor functionality (using temporary breakpoints, removed on the next breakpoint pause event)
- fixed an issue found as part of this work, where we were not removing vm breakpoints from a collection when an IntelliJ breakpoint was removed (https://github.com/JetBrains/intellij-plugins/compare/master...devoncarew:run_to_cursor?expand=1#diff-aeaaa0c5a2f9ccc7970be0eac34e566cR49) (this fixes force run to cursor)
- (also, some minor renames in associated files)
- fix https://youtrack.jetbrains.com/issue/WEB-17091

@alexander-doroshko 