### PR TITLE
fix an issue with the observatory action in the test view

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -38,6 +38,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.StringTokenizer;
 
 public class DartCommandLineRunningState extends CommandLineState {
@@ -72,18 +75,17 @@ public class DartCommandLineRunningState extends CommandLineState {
 
   @Override
   protected AnAction[] createActions(final ConsoleView console, final ProcessHandler processHandler, final Executor executor) {
-    // These action is effectively added only to the Run tool window. For Debug see DartCommandLineDebugProcess.registerAdditionalActions()
-    final AnAction[] actions = super.createActions(console, processHandler, executor);
-    final AnAction[] newActions = new AnAction[actions.length + 2];
-    System.arraycopy(actions, 0, newActions, 0, actions.length);
+    // These actions are effectively added only to the Run tool window. For Debug see DartCommandLineDebugProcess.registerAdditionalActions()
+    final List<AnAction> actions = new ArrayList(Arrays.asList(super.createActions(console, processHandler, executor)));
+    addObservatoryActions(actions, processHandler);
+    return actions.toArray(new AnAction[actions.size()]);
+  }
 
-    newActions[newActions.length - 2] = new Separator();
-
-    newActions[newActions.length - 1] =
-      new OpenDartObservatoryUrlAction("http://" + NetUtils.getLocalHostString() + ":" + myObservatoryPort,
-                                       () -> !processHandler.isProcessTerminated());
-
-    return newActions;
+  protected void addObservatoryActions(List<AnAction> actions, final ProcessHandler processHandler) {
+    actions.add(new Separator());
+    actions.add(new OpenDartObservatoryUrlAction(
+      "http://" + NetUtils.getLocalHostString() + ":" + myObservatoryPort,
+      () -> !processHandler.isProcessTerminated()));
   }
 
   @NotNull

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
@@ -20,6 +20,7 @@ import com.intellij.execution.testframework.sm.runner.SMTestLocator;
 import com.intellij.execution.testframework.sm.runner.ui.SMTRunnerConsoleView;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.SystemInfo;
@@ -37,6 +38,8 @@ import com.jetbrains.lang.dart.util.DartUrlResolver;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class DartTestRunningState extends DartCommandLineRunningState {
   public static final String DART_FRAMEWORK_NAME = "DartTestRunner";
@@ -71,6 +74,12 @@ public class DartTestRunningState extends DartCommandLineRunningState {
     }
 
     return executionResult;
+  }
+
+  @Override
+  protected void addObservatoryActions(List<AnAction> actions, final ProcessHandler processHandler) {
+    // For now, don't add the Observatory button to the test view; it's currently a no-op.
+    // Until debugging works with package:test, the observatory URL we open here is 'http://127.0.0.1:-1'.
   }
 
   private static ConsoleView createConsole(@NotNull ExecutionEnvironment env) {


### PR DESCRIPTION
Remove the Observatory button from the test results view - the url we were trying to open was `http://127.0.0.1:-1` (no observatory port had been set up). We'll need debuggability of package:test tests to fix this.

<img width="76" alt="screen shot 2016-09-11 at 2 32 37 am" src="https://cloud.githubusercontent.com/assets/1269969/18416425/5a66873e-77c9-11e6-8e0a-7f16c512615a.png">

@alexander-doroshko @stevemessick 