### PR TITLE
change how we listen for debugger connection close

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -163,11 +163,6 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
           message = message.substring(0, 300) + "..." + message.substring(message.length() - 200);
         }
         LOG.debug(message);
-
-        // TODO: We should find a more reliable way to notify on connection close.
-        if (myRemoteDebug && message.equals("VM connection closed: " + getObservatoryUrl("ws", "/ws"))) {
-          getSession().stop();
-        }
       }
 
       @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -34,6 +34,11 @@ public class DartVmServiceListener implements VmServiceListener {
   }
 
   @Override
+  public void connectionOpened() {
+
+  }
+
+  @Override
   public void received(@NotNull final String streamId, @NotNull final Event event) {
     switch (event.getKind()) {
       case BreakpointAdded:
@@ -81,6 +86,13 @@ public class DartVmServiceListener implements VmServiceListener {
         break;
       case Unknown:
         break;
+    }
+  }
+
+  @Override
+  public void connectionClosed() {
+    if (myDebugProcess.isRemoteDebug()) {
+      myDebugProcess.getSession().stop();
     }
   }
 

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -89,6 +89,8 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void onClose() {
         Logging.getLogger().logInformation("VM connection closed: " + url);
+
+        vmService.connectionClosed();
       }
 
       @Override
@@ -104,6 +106,8 @@ abstract class VmServiceBase implements VmServiceConst {
 
       @Override
       public void onOpen() {
+        vmService.connectionOpened();
+
         Logging.getLogger().logInformation("VM connection open: " + url);
       }
 
@@ -295,12 +299,32 @@ abstract class VmServiceBase implements VmServiceConst {
     requestSink.add(request);
   }
 
+  public void connectionOpened() {
+    for (VmServiceListener listener : vmListeners) {
+      try {
+        listener.connectionOpened();
+      } catch (Exception e) {
+        Logging.getLogger().logError("Exception notifying listener", e);
+      }
+    }
+  }
+
   private void forwardEvent(String streamId, Event event) {
     for (VmServiceListener listener : vmListeners) {
       try {
         listener.received(streamId, event);
       } catch (Exception e) {
         Logging.getLogger().logError("Exception processing event: " + streamId + ", " + event.getJson(), e);
+      }
+    }
+  }
+
+  public void connectionClosed() {
+    for (VmServiceListener listener : vmListeners) {
+      try {
+        listener.connectionClosed();
+      } catch (Exception e) {
+        Logging.getLogger().logError("Exception notifying listener", e);
       }
     }
   }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceListener.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceListener.java
@@ -19,6 +19,7 @@ import org.dartlang.vm.service.element.Event;
  * Interface used by {@link VmService} to notify others of VM events.
  */
 public interface VmServiceListener {
+  public void connectionOpened();
 
   /**
    * Called when a VM event has been received.
@@ -26,4 +27,6 @@ public interface VmServiceListener {
    * @param event the event
    */
   public void received(String streamId, Event event);
+
+  public void connectionClosed();
 }


### PR DESCRIPTION
Change how we listen for debugger connection close. Previously we scrapped debugger connection logging text. We now use a (newly added) explicit close notification from the debugger connection.

@alexander-doroshko 