### PR TITLE
avoid an npe in the debugger

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandler.java
@@ -100,7 +100,11 @@ public class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLineBrea
 
   public void breakpointResolved(@NotNull final Breakpoint vmBreakpoint) {
     final XLineBreakpoint<XBreakpointProperties> xBreakpoint = myVmBreakpointIdToXBreakpointMap.get(vmBreakpoint.getId());
-    myDebugProcess.getSession().updateBreakpointPresentation(xBreakpoint, Db_verified_breakpoint, null);
+
+    // This can be null when the breakpoint has been set by another debugger client.
+    if (xBreakpoint != null) {
+      myDebugProcess.getSession().updateBreakpointPresentation(xBreakpoint, Db_verified_breakpoint, null);
+    }
   }
 
   public void breakpointFailed(@NotNull final XLineBreakpoint<XBreakpointProperties> xBreakpoint) {


### PR DESCRIPTION
Avoid an NPE in the debugger when using the `Dart Remote Debug` launch type. This can happen when the breakpoint has been set by another debugger client.

@alexander-doroshko 