### PR TITLE
remove a separator in the problems view

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -141,14 +141,12 @@ public class DartProblemsViewPanel extends JPanel implements DataProvider, CopyP
     addReanalyzeAndRestartActions(group);
     group.addSeparator();
 
-    addAutoScrollToSourceAction(group);
     // may be add 'Scroll from source' or 'Autoscroll from source' action (WEB-15792)
-    group.addSeparator();
-
+    addAutoScrollToSourceAction(group);
     addGroupBySeverityAction(group);
     group.addAction(new FilterProblemsAction());
-
     group.addSeparator();
+
     group.addAction(new ContextHelpAction("reference.toolWindow.DartAnalysis"));
 
     return ActionManager.getInstance().createActionToolbar(ActionPlaces.COMPILER_MESSAGES_TOOLBAR, group, false).getComponent();


### PR DESCRIPTION
- very minor tweak to the Dart problems view; remove a separator (group related items together)
- follow up from https://github.com/JetBrains/intellij-plugins/pull/419

<img width="99" alt="screen shot 2016-09-14 at 8 49 44 pm" src="https://cloud.githubusercontent.com/assets/1269969/18537814/cc656ddc-7abc-11e6-9c2b-80c2c8faffdd.png">

@alexander-doroshko 
