### PR TITLE
have the content enabled checkbox selected

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.form
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.form
@@ -120,6 +120,7 @@
                 </constraints>
                 <properties>
                   <margin top="2" left="0" bottom="2" right="3"/>
+                  <selected value="true"/>
                   <text resource-bundle="com/jetbrains/lang/dart/DartBundle" key="dart.project.generate.sample.content.label"/>
                 </properties>
               </component>


### PR DESCRIPTION
- minor tweak to have the generate sample content checkbox selected by default

@alexander-doroshko @pq 

<img width="370" alt="screen shot 2016-09-16 at 8 20 53 am" src="https://cloud.githubusercontent.com/assets/1269969/18591289/e6749eca-7be6-11e6-9142-6046a7a7ea4d.png">
