### PR TITLE
enable the template select box the first time through

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
@@ -172,8 +172,9 @@ public class DartGeneratorPeer implements WebProjectGenerator.GeneratorPeer<Dart
     myCreateSampleProjectCheckBox.setEnabled(true);
     myTemplatesList.setEnabled(true);
 
-    final String selectedTemplateName = PropertiesComponent.getInstance().getValue(DART_PROJECT_TEMPLATE);
-    myCreateSampleProjectCheckBox.setSelected(selectedTemplateName != null);
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    final String selectedTemplateName = properties.getValue(DART_PROJECT_TEMPLATE);
+    myCreateSampleProjectCheckBox.setSelected(selectedTemplateName != null || !properties.isValueSet(DART_PROJECT_TEMPLATE));
     myTemplatesList.setEnabled(myCreateSampleProjectCheckBox.isSelected());
 
     DartProjectTemplate selectedTemplate = null;


### PR DESCRIPTION
Follow up to https://github.com/JetBrains/intellij-plugins/pull/421, enable the template select box the first time through. The first time through there would be no value for the previous dart template setting, which would cause the checkbox to not be selected.

@alexander-doroshko 