### PR TITLE
Remote debugging

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartRunner.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartRunner.java
@@ -101,6 +101,7 @@ public class DartRunner extends DefaultProgramRunner {
 
     final RunProfile runConfiguration = env.getRunProfile();
     final VirtualFile contextFileOrDir;
+    VirtualFile currentWorkingDirectory;
     final boolean entryPointInLibFolder;
     final ExecutionResult executionResult;
     final String debuggingHost;
@@ -111,6 +112,9 @@ public class DartRunner extends DefaultProgramRunner {
 
       final VirtualFile pubspec = PubspecYamlUtil.findPubspecYamlFile(env.getProject(), contextFileOrDir);
       entryPointInLibFolder = pubspec != null && contextFileOrDir.getPath().startsWith(pubspec.getParent().getPath() + "/lib/");
+
+      final String cwd = ((DartRunConfigurationBase)runConfiguration).getRunnerParameters().computeProcessWorkingDirectory(env.getProject());
+      currentWorkingDirectory = LocalFileSystem.getInstance().findFileByPath((cwd));
 
       executionResult = state.execute(env.getExecutor(), this);
       if (executionResult == null) {
@@ -127,6 +131,8 @@ public class DartRunner extends DefaultProgramRunner {
       if (contextFileOrDir == null) {
         throw new RuntimeConfigurationError("Folder not found: " + FileUtil.toSystemDependentName(path));
       }
+
+      currentWorkingDirectory = contextFileOrDir;
 
       executionResult = null;
 
@@ -154,7 +160,8 @@ public class DartRunner extends DefaultProgramRunner {
                                              dasExecutionContextId,
                                              runConfiguration instanceof DartRemoteDebugConfiguration,
                                              entryPointInLibFolder,
-                                             getTimeout());
+                                             getTimeout(),
+                                             currentWorkingDirectory);
       }
     });
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -1,5 +1,6 @@
 package com.jetbrains.lang.dart.ide.runner.server.vmService;
 
+import com.google.common.base.Charsets;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.ConsoleViewContentType;
@@ -383,6 +384,11 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     if (isolateRef.getId().equals(myLatestCurrentIsolateId)) {
       resume(getSession().getSuspendContext()); // otherwise no way no resume them from UI
     }
+  }
+
+  public void handleWriteEvent(String base64Data) {
+    String message = new String(Base64.getDecoder().decode(base64Data), Charsets.UTF_8);
+    getSession().getConsoleView().print(message, ConsoleViewContentType.NORMAL_OUTPUT);
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -146,11 +146,12 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
           return;
         }
 
-        if (myEntryPointInLibFolder && message.contains("\"code\":-32602,")) { // That's expected because we set one breakpoint twice
+        if (message.contains("\"method\":\"removeBreakpoint\"")) { // That's expected because we set one breakpoint twice
           return;
         }
 
-        LOG.warn(message);
+        getSession().getConsoleView().print("Error: " + message + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+        LOG.error(message);
       }
 
       @Override
@@ -292,8 +293,10 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
         }
       }
 
-      if (howManyFilesMatch > 0) {
+      if (howManyFilesMatch == 1) {
         break; // we did the best guess we could
+      } else if (howManyFilesMatch > 0) {
+        // TODO: Look for an additional way to determine `myRemoteProjectRootUri`.
       }
     }
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -74,7 +74,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   private final boolean myRemoteDebug;
   private final boolean myEntryPointInLibFolder;
   private final int myTimeout;
-  private final VirtualFile myCurrentWorkingDirectory;
+  @Nullable private final VirtualFile myCurrentWorkingDirectory;
 
   @Nullable String myRemoteProjectRootUri;
 
@@ -87,7 +87,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
                                    final boolean remoteDebug,
                                    final boolean entryPointInLibFolder,
                                    final int timeout,
-                                   final VirtualFile currentWorkingDirectory) {
+                                   @Nullable final VirtualFile currentWorkingDirectory) {
     super(session);
     myDebuggingHost = debuggingHost;
     myObservatoryPort = observatoryPort;
@@ -286,7 +286,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
         LOG.assertTrue(file.getPath().startsWith(localProjectRoot.getPath() + "/"), file.getPath() + "," + localProjectRoot.getPath());
         final String relPath = file.getPath().substring(localProjectRoot.getPath().length()); // starts with slash
-        if (relPath.startsWith("/lib/") && remoteUri.endsWith(relPath)) {
+        if (remoteUri.endsWith(relPath)) {
           howManyFilesMatch++;
           myRemoteProjectRootUri = remoteUri.substring(0, remoteUri.length() - relPath.length());
         }
@@ -456,7 +456,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
         if (filePath.startsWith(projectPath)) {
           result.add(myRemoteProjectRootUri + filePath.substring(projectPath.length()));
         }
-      } else {
+      } else  if (myCurrentWorkingDirectory != null) {
         // Handle projects with no pubspecs.
         final String projectPath = myCurrentWorkingDirectory.getPath();
         final String filePath = file.getPath();

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -214,9 +214,13 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
   private void connect() throws IOException {
     final VmService vmService = VmService.connect(getObservatoryUrl("ws", "/ws"));
-    vmService.addVmServiceListener(new DartVmServiceListener(this, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]));
+    final DartVmServiceListener vmServiceListener = new DartVmServiceListener(
+      this, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]);
 
-    myVmServiceWrapper = new VmServiceWrapper(this, vmService, myIsolatesInfo, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]);
+    vmService.addVmServiceListener(vmServiceListener);
+
+    myVmServiceWrapper = new VmServiceWrapper(
+      this, vmService, vmServiceListener, myIsolatesInfo, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]);
     myVmServiceWrapper.handleDebuggerConnected();
 
     myVmConnected = true;

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -40,8 +40,6 @@ public class DartVmServiceListener implements VmServiceListener {
 
   @Override
   public void received(@NotNull final String streamId, @NotNull final Event event) {
-    //LOG.warn(event.getKind().toString());
-
     switch (event.getKind()) {
       case BreakpointAdded:
         // TODO Respond to breakpoints added by the observatory.
@@ -93,6 +91,7 @@ public class DartVmServiceListener implements VmServiceListener {
       case VMUpdate:
         break;
       case WriteEvent:
+        myDebugProcess.handleWriteEvent(event.getBytes());
         break;
       case Unknown:
         break;

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -40,6 +40,8 @@ public class DartVmServiceListener implements VmServiceListener {
 
   @Override
   public void received(@NotNull final String streamId, @NotNull final Event event) {
+    //LOG.warn(event.getKind().toString());
+
     switch (event.getKind()) {
       case BreakpointAdded:
         // TODO Respond to breakpoints added by the observatory.
@@ -81,7 +83,7 @@ public class DartVmServiceListener implements VmServiceListener {
       case PauseExit:
         break;
       case PauseStart:
-        myDebugProcess.getVmServiceWrapper().handleIsolatePausedOnStart(event.getIsolate());
+        myDebugProcess.getVmServiceWrapper().handleIsolate(event.getIsolate(), true);
         break;
       case Resume:
         myDebugProcess.isolateResumed(event.getIsolate());

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -105,11 +105,11 @@ public class DartVmServiceListener implements VmServiceListener {
     }
   }
 
-  private void onIsolatePaused(@NotNull final IsolateRef isolateRef,
-                               @Nullable final ElementList<Breakpoint> vmBreakpoints,
-                               @Nullable final InstanceRef exception,
-                               @Nullable final Frame vmTopFrame,
-                               boolean atAsyncSuspension) {
+  void onIsolatePaused(@NotNull final IsolateRef isolateRef,
+                       @Nullable final ElementList<Breakpoint> vmBreakpoints,
+                       @Nullable final InstanceRef exception,
+                       @Nullable final Frame vmTopFrame,
+                       boolean atAsyncSuspension) {
     if (vmTopFrame == null) {
       myDebugProcess.getSession().positionReached(new XSuspendContext() {
       });

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/IsolatesInfo.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/IsolatesInfo.java
@@ -14,6 +14,8 @@ public class IsolatesInfo {
   public static class IsolateInfo {
     private final String myIsolateId;
     private final String myIsolateName;
+    private boolean breakpointsSet = false;
+    private boolean shouldInitialResume = false;
 
     public IsolateInfo(@NotNull final String isolateId, @NotNull final String isolateName) {
       myIsolateId = isolateId;
@@ -33,6 +35,29 @@ public class IsolatesInfo {
 
   public boolean addIsolate(@NotNull final IsolateRef isolateRef) {
     return myIsolateIdToInfoMap.put(isolateRef.getId(), new IsolateInfo(isolateRef.getId(), isolateRef.getName())) == null;
+  }
+
+  public void setBreakpointsSet(@NotNull final IsolateRef isolateRef) {
+    IsolateInfo info = myIsolateIdToInfoMap.get(isolateRef.getId());
+    if (info != null) {
+      info.breakpointsSet = true;
+    }
+  }
+
+  public void setShouldInitialResume(@NotNull final IsolateRef isolateRef) {
+    IsolateInfo info = myIsolateIdToInfoMap.get(isolateRef.getId());
+    if (info != null) {
+      info.shouldInitialResume = true;
+    }
+  }
+
+  public boolean getShouldInitialResume(@NotNull final IsolateRef isolateRef) {
+    IsolateInfo info = myIsolateIdToInfoMap.get(isolateRef.getId());
+    if (info != null) {
+      return info.breakpointsSet && info.shouldInitialResume;
+    } else {
+      return false;
+    }
   }
 
   public void deleteIsolate(@NotNull final IsolateRef isolateRef) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -97,6 +97,8 @@ public class VmServiceWrapper implements Disposable {
                   Logging.getLogger().logError("No isolates found after VM start: " + vm.getIsolates().size());
                 }
 
+                // TODO: When remote debugging, handle the case that an isolate is paused at a breakpoint when we connect.
+
                 for (final IsolateRef isolateRef : vm.getIsolates()) {
                   getIsolate(isolateRef.getId(), new VmServiceConsumers.GetIsolateConsumerWrapper() {
                     @Override
@@ -112,6 +114,11 @@ public class VmServiceWrapper implements Disposable {
         });
       }
     });
+
+    if (myDebugProcess.isRemoteDebug()) {
+      streamListen(VmService.STDOUT_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+      streamListen(VmService.STDERR_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    }
   }
 
   private void streamListen(@NotNull final String streamId, @NotNull final SuccessConsumer consumer) {

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -23,7 +23,6 @@ import de.roderick.weberknecht.WebSocketEventHandler;
 import de.roderick.weberknecht.WebSocketException;
 import de.roderick.weberknecht.WebSocketMessage;
 
-import org.dartlang.vm.service.consumer.BreakpointConsumer;
 import org.dartlang.vm.service.consumer.Consumer;
 import org.dartlang.vm.service.consumer.GetInstanceConsumer;
 import org.dartlang.vm.service.consumer.GetLibraryConsumer;


### PR DESCRIPTION
Fix several issues in the Dart remote debugging launch config:
- when remote debugging an app that does not use a pubspec.yaml file, resolve some urls relative to the source location given in the remote debug dialog
- when remote debugging, register for stdout and stderr events from the vm (WriteEvents) and display them to the output console
- `getUrisForFile()` now returns a few more types, including `package:` (if relevant), `file:`, remote prefixed paths, and straight file paths (`/path/to/file`); straight file paths are used for some Flutter VM embedders
- handle a race condition between setting breakpoints and resuming. We now resume an isolate once all breakpoints have been set on it, and we've received the `StartPaused` event (the logic is tracked in the `IsolateInfo` class and the `checkInitialResume()` method)
- register all isolates when we first connect, not just one (there can be more than one when connecting to an already running VM)
- handle the case where we connect to an already running VM and there are existing paused isolates (say, paused at breakpoints)
- fix https://youtrack.jetbrains.com/issue/WEB-23266, fix https://youtrack.jetbrains.com/issue/WEB-23278

@alexander-doroshko, this is not a huge PR, but does address several (related) issues. Would definitely appreciate feedback on it! I may or may not have some follow-up to this after some additional testing Monday.