### PR TITLE
Fix IDEA-98836

### DIFF
--- a/flex/flex-tests/testData/flex_highlighting/ResourceReferencesWithPackages/ResourceReferencesWithPackages.mxml
+++ b/flex/flex-tests/testData/flex_highlighting/ResourceReferencesWithPackages/ResourceReferencesWithPackages.mxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<mx:Application xmlns:mx="http://www.adobe.com/2006/mxml">
+  <mx:Metadata>
+    [ResourceBundle("resourcepackage.mybundle4")]
+    [ResourceBundle("<error descr="Cannot resolve property bundle">mybundle4</error>")]
+  </mx:Metadata>
+  <mx:Script>
+    function foo() {
+      resourceManager.getString('resourcepackage.mybundle4', 'prompt5');
+      resourceManager.getString('<error descr="Cannot resolve property bundle">mybundle4</error>', '<error descr="Cannot resolve property key">prompt5</error>');
+    }
+  </mx:Script>
+  <mx:Label text="@Resource(key='prompt5', bundle='resourcepackage.mybundle4')"/>
+  <mx:Label text="@Resource(key='<error descr="Cannot resolve property key">prompt5</error>', bundle='<error descr="Cannot resolve property bundle">mybundle4</error>')"/>
+</mx:Application>

--- a/flex/flex-tests/testData/flex_highlighting/ResourceReferencesWithPackages/resourcepackage/mybundle4.properties
+++ b/flex/flex-tests/testData/flex_highlighting/ResourceReferencesWithPackages/resourcepackage/mybundle4.properties
@@ -1,0 +1,1 @@
+prompt5=foo

--- a/flex/flex-tests/testSrc/com/intellij/lang/javascript/FlexHighlightingTest.java
+++ b/flex/flex-tests/testSrc/com/intellij/lang/javascript/FlexHighlightingTest.java
@@ -1169,6 +1169,19 @@ public class FlexHighlightingTest extends ActionScriptDaemonAnalyzerTestCase {
     doTestFor(true, getTestName(false) + ".mxml", "mybundle.properties", "mybundle3.properties");
   }
 
+  @JSTestOptions(JSTestOption.WithFlexFacet)
+  public void testResourceReferencesWithPackages() throws Exception {
+    String testName = getTestName(false);
+    Collection<HighlightInfo> infoCollection = doTestFor(true, new File(getTestDataPath() + BASE_PATH + "/" + testName), (Runnable)null,
+                                                         testName + "/" + testName + ".mxml",
+                                                         testName + "/resourcepackage/mybundle4.properties");
+    findAndInvokeIntentionAction(infoCollection, PropertiesBundle.message("create.property.quickfix.text"), myEditor, myFile);
+
+    List<HighlightInfo> infoList = filterUnwantedInfos(doHighlighting(), this);
+    assertEquals(infoCollection.size(), infoList.size());
+  }
+
+
   @JSTestOptions({JSTestOption.WithFlexSdk, JSTestOption.WithJsSupportLoader})
   public void testResolveWithInclude() throws Exception {
     String testName = getTestName(false);

--- a/flex/src/com/intellij/javascript/flex/FlexPropertiesSupport.java
+++ b/flex/src/com/intellij/javascript/flex/FlexPropertiesSupport.java
@@ -2,12 +2,14 @@ package com.intellij.javascript.flex;
 
 import com.intellij.codeInsight.daemon.EmptyResolveMessageProvider;
 import com.intellij.lang.javascript.psi.impl.JSPropertyReference;
+import com.intellij.lang.javascript.psi.resolve.JSResolveUtil;
 import com.intellij.lang.properties.BundleNameEvaluator;
 import com.intellij.lang.properties.PropertiesReferenceManager;
 import com.intellij.lang.properties.ResourceBundleReference;
 import com.intellij.lang.properties.psi.PropertiesFile;
 import com.intellij.lang.properties.references.PropertyReference;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -25,7 +27,12 @@ public class FlexPropertiesSupport {
     public String evaluateBundleName(PsiFile psiFile) {
       final VirtualFile virtualFile = psiFile == null ? null : psiFile.getOriginalFile().getVirtualFile();
       if (virtualFile != null && psiFile instanceof PropertiesFile) {
-        return virtualFile.getNameWithoutExtension();
+        String className = virtualFile.getNameWithoutExtension();
+        String packageName = JSResolveUtil.getExpectedPackageNameFromFile(virtualFile, psiFile.getProject());
+        if (!StringUtil.isEmpty(packageName)) {
+          className = packageName + "." + className;
+        }
+        return className;
       }
       return null;
     }


### PR DESCRIPTION
"Good code red when using non top-level package resource bundle"
https://youtrack.jetbrains.com/issue/IDEA-98836

To resolve package name from relative file position, reused existing
utility method JSResolveUtil.getExpectedPackageNameFromFile().

Sorry that there are no tests, but there haven't been any tests for
FlexPropertySupport before so I don't really know where to start.