### PR TITLE
Support using constants for resource bundle names.

### DIFF
--- a/flex/flex-tests/testData/flex_highlighting/ResourceReferences2.mxml
+++ b/flex/flex-tests/testData/flex_highlighting/ResourceReferences2.mxml
@@ -25,7 +25,12 @@
     resourceManager.getResourceBundle('ru', '<error>mybundle2</error>')
     resourceManager.findResourceBundleWithResource('<error>mybundle2</error>', '<error>prompt1</error>')
     resourceManager.findResourceBundleWithResource('mybundle3', '<error>prompt2</error>')
-  }
+
+    resourceManager.getString('mybundle', '<error>prompt4</error>')
+    resourceManager.getString(MY_BUNDLE2, '<error>prompt4</error>')
+    }
+
+    private static const MY_BUNDLE2:String = "mybundle2";
 
     import mypackage.ResourceManager
     ResourceManager.getInstance().getString('<error>mybundle2</error>', '<error>prompt1</error>')

--- a/flex/src/com/intellij/javascript/flex/FlexPropertyReferenceProvider.java
+++ b/flex/src/com/intellij/javascript/flex/FlexPropertyReferenceProvider.java
@@ -76,22 +76,33 @@ public class FlexPropertyReferenceProvider extends PsiReferenceProvider {
           FlexPropertiesSupport.PropertyReferenceInfoProvider<JSLiteralExpressionImpl> provider =
             isSoft ? ourSoftPropertyInfoProvider : ourPropertyInfoProvider;
 
-          if (args.length > 1 && !isSoft && args[0] instanceof JSLiteralExpression) {
-            final String myText = args[0].getText();
-
-            provider = new FlexPropertiesSupport.PropertyReferenceInfoProvider<JSLiteralExpressionImpl>() {
-              public TextRange getReferenceRange(JSLiteralExpressionImpl element) {
-                return getValueRange(element);
+          if (args.length > 1 && !isSoft) {
+            JSExpression bundleExpression = args[0];
+            if (bundleExpression instanceof JSReferenceExpression) {
+              PsiElement resolved = ((JSReferenceExpression)bundleExpression).resolve();
+              if (resolved instanceof JSVariable) {
+                bundleExpression = ((JSVariable)resolved).getInitializer();
               }
+            }
+            if (bundleExpression instanceof JSLiteralExpression) {
+              final Object myValue = ((JSLiteralExpression)bundleExpression).getValue();
+              if (myValue instanceof String) {
+                final String myText = (String)myValue;
+                provider = new FlexPropertiesSupport.PropertyReferenceInfoProvider<JSLiteralExpressionImpl>() {
+                  public TextRange getReferenceRange(JSLiteralExpressionImpl element) {
+                    return getValueRange(element);
+                  }
 
-              public String getBundleName(JSLiteralExpressionImpl element) {
-                return StringUtil.stripQuotesAroundValue(myText);
-              }
+                  public String getBundleName(JSLiteralExpressionImpl element) {
+                    return myText;
+                  }
 
-              public boolean isSoft(JSLiteralExpressionImpl element) {
-                return false;
+                  public boolean isSoft(JSLiteralExpressionImpl element) {
+                    return false;
+                  }
+                };
               }
-            };
+            }
           }
           Collections.addAll(result, FlexPropertiesSupport.getPropertyReferences((JSLiteralExpressionImpl)element, provider));
         }


### PR DESCRIPTION
So far, IDEA only supports resource bundle references when given directly as string literals.
This changes additionally allows variables with a string literal initializer to be used.
This makes code more readable when (especially fully-qualified) resource bundle names are rather long.

Example:

    var foo:String = resourceManager.getString("my.very.long.package.MyBundle", "foo");
    var bar:String = resourceManager.getString("my.very.long.package.MyBundle", "bar");

is now also fully supported when introducing a constant:

    private static const MY_BUNDLE:String = "my.very.long.package.MyBundle";
    
    var foo:String = resourceManager.getString(MY_BUNDLE, "foo");
    var bar:String = resourceManager.getString(MY_BUNDLE, "bar");

Before, the second code would suggest / accept any key defined in any resource bundle,
not only the keys of `MyBundle`.

The adapted test (`ResourceReferences2.mxml`) proves that: The incorrect access to
key `prompt4` was not detected without the change to `FlexPropertyReferenceProvider`
(`FlexHighlightingTest#testResourceReferences2()` red), but after applying the changes
to `FlexPropertyReferenceProvider`, the test is green again.