### PR TITLE
show more granular progress when analyzing

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -77,7 +77,9 @@ dart.color.settings.description.type.name.dynamic=Type 'dynamic'
 dart.color.settings.description.type.parameter=Type parameter
 dart.color.settings.description.unresolved.instance.member.reference=Unresolvable dynamic reference
 
-dart.analysis.progress.title=Dart Analysis
+dart.analysis.progress.title=Analyzing...
+dart.analysis.progress.with.file=Analyzing {0}
+
 cannot.resolve.reference=Can't resolve reference
 dart.file=Dart File
 new.dart.file.title=New Dart File


### PR DESCRIPTION
- show more granular progress when analyzing (fix https://youtrack.jetbrains.com/issue/WEB-23098)

@jwren @alexander-doroshko 

This uses `ProgressIndicator.setText()` to change the status line contribution when the status bar is visible, and update the text above the progress indicator when there is no status bar.