### PR TITLE
update dart remote debug

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -258,9 +258,9 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
   public void guessRemoteProjectRoot(@NotNull final ElementList<LibraryRef> libraries) {
     final VirtualFile pubspec = myDartUrlResolver.getPubspecYamlFile();
-    if (pubspec == null) return; // no chance to guess project root
+    final VirtualFile projectRoot = pubspec != null ? pubspec.getParent() : myCurrentWorkingDirectory;
 
-    final VirtualFile localProjectRoot = pubspec.getParent();
+    if (projectRoot == null) return;
 
     for (LibraryRef library : libraries) {
       final String remoteUri = library.getUri();
@@ -269,7 +269,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
       final PsiFile[] localFilesWithSameName = ApplicationManager.getApplication().runReadAction((Computable<PsiFile[]>)() -> {
         final String remoteFileName = PathUtil.getFileName(remoteUri);
-        final GlobalSearchScope scope = GlobalSearchScopesCore.directoryScope(getSession().getProject(), localProjectRoot, true);
+        final GlobalSearchScope scope = GlobalSearchScopesCore.directoryScope(getSession().getProject(), projectRoot, true);
         return FilenameIndex.getFilesByName(getSession().getProject(), remoteFileName, scope);
       });
 
@@ -279,8 +279,8 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
         final VirtualFile file = DartResolveUtil.getRealVirtualFile(psiFile);
         if (file == null) continue;
 
-        LOG.assertTrue(file.getPath().startsWith(localProjectRoot.getPath() + "/"), file.getPath() + "," + localProjectRoot.getPath());
-        final String relPath = file.getPath().substring(localProjectRoot.getPath().length()); // starts with slash
+        LOG.assertTrue(file.getPath().startsWith(projectRoot.getPath() + "/"), file.getPath() + "," + projectRoot.getPath());
+        final String relPath = file.getPath().substring(projectRoot.getPath().length()); // starts with slash
         if (remoteUri.endsWith(relPath)) {
           howManyFilesMatch++;
           myRemoteProjectRootUri = remoteUri.substring(0, remoteUri.length() - relPath.length());
@@ -444,7 +444,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     }
 
     // remote prefix (if applicable)
-    if (myRemoteDebug && myRemoteProjectRootUri != null) {
+    if (myRemoteProjectRootUri != null) {
       final VirtualFile pubspec = myDartUrlResolver.getPubspecYamlFile();
       if (pubspec != null) {
         final String projectPath = pubspec.getParent().getPath();
@@ -479,7 +479,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       }
 
       final VirtualFile pubspec = myDartUrlResolver.getPubspecYamlFile();
-      if (myRemoteDebug && myRemoteProjectRootUri != null && uri.startsWith(myRemoteProjectRootUri) && pubspec != null) {
+      if (myRemoteProjectRootUri != null && uri.startsWith(myRemoteProjectRootUri) && pubspec != null) {
         final String localRootUri = StringUtil.trimEnd(myDartUrlResolver.getDartUrlForFile(pubspec.getParent()), '/');
         LOG.assertTrue(localRootUri.startsWith(DartUrlResolver.FILE_PREFIX), localRootUri);
 


### PR DESCRIPTION
When remote debugging, don't require that there be a pubspec.yaml file present. Fall back on using the specified cwd of the launch configuration.

@alexander-doroshko 