### PR TITLE
Add FLUTTER_ROOT env info to Flutter module Dart Pub actions.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/flutter/FlutterUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/flutter/FlutterUtil.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2016 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.lang.dart.flutter;
 
 import com.intellij.openapi.module.Module;

--- a/Dart/src/com/jetbrains/lang/dart/flutter/FlutterUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/flutter/FlutterUtil.java
@@ -4,14 +4,11 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
+import org.jetbrains.annotations.Nullable;
 
 public class FlutterUtil {
 
-  private static final String FLUTTER_MODULE_TYPE_NAME = "Flutter";
+  private static final String FLUTTER_MODULE_TYPE_ID = "FLUTTER_MODULE_TYPE";
 
   /**
    * Test if the given module is a Flutter module.
@@ -21,7 +18,7 @@ public class FlutterUtil {
    */
   public static boolean isFlutterModule(@NotNull Module module) {
     final ModuleType moduleType = ModuleType.get(module);
-    return FLUTTER_MODULE_TYPE_NAME.equals(moduleType.getName());
+    return FLUTTER_MODULE_TYPE_ID.equals(moduleType.getId());
   }
 
   /**
@@ -30,18 +27,10 @@ public class FlutterUtil {
    * @param dartSdk the Dart SDK
    * @return the relative Flutter root, or null if this SDK is not relative to one
    */
+  @Nullable
   public static String getFlutterRoot(@NotNull DartSdk dartSdk) {
-    // Navigate up from `bin/cache/dart-sdk/lib/`.
-    final File flutterRoot = new File(dartSdk.getHomePath() + "/../../..");
-    if (flutterRoot.exists()) {
-      try {
-        final URI uri = new URI(flutterRoot.getAbsolutePath()).normalize();
-        return uri.getPath();
-      }
-      catch (URISyntaxException e) {
-        // Ignored
-      }
-    }
-    return null;
+    final String dartPath = dartSdk.getHomePath();
+    final String suffix = "/bin/cache/dart-sdk";
+    return dartPath.endsWith(suffix) ? dartPath.substring(0, dartPath.length() - suffix.length()) : null;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/flutter/FlutterUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/flutter/FlutterUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.lang.dart.flutter;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleType;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class FlutterUtil {
+
+  private static final String FLUTTER_MODULE_TYPE_NAME = "Flutter";
+
+  /**
+   * Test if the given module is a Flutter module.
+   *
+   * @param module the module to test
+   * @return true if the module is a Flutter module, false otherwise
+   */
+  public static boolean isFlutterModule(@NotNull Module module) {
+    final ModuleType moduleType = ModuleType.get(module);
+    return FLUTTER_MODULE_TYPE_NAME.equals(moduleType.getName());
+  }
+
+  /**
+   * Get the Flutter root relative to the given Dart SDK.
+   *
+   * @param dartSdk the Dart SDK
+   * @return the relative Flutter root, or null if this SDK is not relative to one
+   */
+  public static String getFlutterRoot(@NotNull DartSdk dartSdk) {
+    // Navigate up from `bin/cache/dart-sdk/lib/`.
+    final File flutterRoot = new File(dartSdk.getHomePath() + "/../../..");
+    if (flutterRoot.exists()) {
+      try {
+        final URI uri = new URI(flutterRoot.getAbsolutePath()).normalize();
+        return uri.getPath();
+      }
+      catch (URISyntaxException e) {
+        // Ignored
+      }
+    }
+    return null;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.java
@@ -152,7 +152,7 @@ abstract public class DartPubActionBase extends AnAction implements DumbAware {
       if (FlutterUtil.isFlutterModule(module)) {
         final String flutterRoot = FlutterUtil.getFlutterRoot(sdk);
         if (flutterRoot != null) {
-          command.getEnvironment().put("FLUTTER_ROOT", flutterRoot);
+          command.getEnvironment().put("FLUTTER_ROOT", FileUtil.toSystemDependentName(flutterRoot));
         }
       }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.java
@@ -44,6 +44,7 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.content.MessageView;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartProjectComponent;
+import com.jetbrains.lang.dart.flutter.FlutterUtil;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
@@ -147,6 +148,14 @@ abstract public class DartPubActionBase extends AnAction implements DumbAware {
 
     if (pubParameters != null) {
       final GeneralCommandLine command = new GeneralCommandLine().withWorkDirectory(pubspecYamlFile.getParent().getPath());
+
+      if (FlutterUtil.isFlutterModule(module)) {
+        final String flutterRoot = FlutterUtil.getFlutterRoot(sdk);
+        if (flutterRoot != null) {
+          command.getEnvironment().put("FLUTTER_ROOT", flutterRoot);
+        }
+      }
+
       command.setExePath(pubFile.getPath());
       command.addParameters(pubParameters);
 


### PR DESCRIPTION
Checks if a module is a Flutter module and sets the `pub` environment variable appropriately.  This is required for `pub` to work in the context of Flutter.

Fixes: https://github.com/flutter/flutter-intellij/issues/271

/cc @alexander-doroshko @devoncarew 