### PR TITLE
Restore restart

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -49,6 +49,14 @@ public class DartServerRootsHandler {
           DartAnalysisServerService.getInstance().updateVisibleFiles();
         }
       }
+
+      @Override
+      public void beforeProjectLoaded(@NotNull Project project) {
+      }
+
+      @Override
+      public void projectComponentsInitialized(@NotNull Project project) {
+      }
     });
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -49,14 +49,6 @@ public class DartServerRootsHandler {
           DartAnalysisServerService.getInstance().updateVisibleFiles();
         }
       }
-
-      @Override
-      public void beforeProjectLoaded(@NotNull Project project) {
-      }
-
-      @Override
-      public void projectComponentsInitialized(@NotNull Project project) {
-      }
     });
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -178,11 +178,10 @@ public class DartProblemsViewPanel extends JPanel implements DataProvider, CopyP
       group.add(reanalyzeAction);
     }
 
-    // Restart action is now discoverable using Find Action only
-    //final AnAction restartAction = ActionManager.getInstance().getAction("Dart.Restart.Analysis.Server");
-    //if (restartAction != null) {
-    //  group.add(restartAction);
-    //}
+    final AnAction restartAction = ActionManager.getInstance().getAction("Dart.Restart.Analysis.Server");
+    if (restartAction != null) {
+      group.add(restartAction);
+    }
   }
 
   private void addAutoScrollToSourceAction(@NotNull final DefaultActionGroup group) {


### PR DESCRIPTION
@alexander-doroshko Restore the `Restart Dart Analysis Server` button. It still has the old icon; that will be changed later.

Verified by checking that process IDs are different before and after clicking the button.

```bash
$ ps xa | grep dart | grep -v java
45451   ??  S      0:04.69 /Users/messick/src/flutter/flutter/bin/cache/dart-sdk/bin/dart /Users/messick/src/flutter/flutter/bin/cache/dart-sdk/bin/snapshots/analysis_server.dart.snapshot --client-id=IntelliJ_IDEA --client-version=IC-171.SNAPSHOT --useAnalysisHighlight2
59587   ??  S      2:02.66 /Users/messick/src/flutter/flutter/bin/cache/dart-sdk/bin/dart /Users/messick/src/flutter/flutter/bin/cache/flutter_tools.snapshot daemon
45462 s001  S+     0:00.00 grep dart
$ ps xa | grep dart | grep -v java
45574   ??  S      0:03.98 /Users/messick/src/flutter/flutter/bin/cache/dart-sdk/bin/dart /Users/messick/src/flutter/flutter/bin/cache/dart-sdk/bin/snapshots/analysis_server.dart.snapshot --client-id=IntelliJ_IDEA --client-version=IC-171.SNAPSHOT --useAnalysisHighlight2
59587   ??  S      2:02.76 /Users/messick/src/flutter/flutter/bin/cache/dart-sdk/bin/dart /Users/messick/src/flutter/flutter/bin/cache/flutter_tools.snapshot daemon
45585 s001  S+     0:00.00 grep dart
```
cc @devoncarew 