### PR TITLE
Restart if needed

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1386,6 +1386,15 @@ public class DartAnalysisServerService {
     }
   }
 
+  public boolean isServerProcessActive() {
+    synchronized (myLock) {
+      if (myServer == null || !myServer.isSocketOpen()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   public boolean serverReadyForRequest(@NotNull final Project project) {
     final DartSdk sdk = DartSdk.getDartSdk(project);
     if (sdk == null || !isDartSdkVersionSufficient(sdk)) {

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -49,6 +49,14 @@ public class DartServerRootsHandler {
           DartAnalysisServerService.getInstance().updateVisibleFiles();
         }
       }
+
+      @Override
+      public void beforeProjectLoaded(@NotNull Project project) {
+      }
+
+      @Override
+      public void projectComponentsInitialized(@NotNull Project project) {
+      }
     });
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -49,14 +49,6 @@ public class DartServerRootsHandler {
           DartAnalysisServerService.getInstance().updateVisibleFiles();
         }
       }
-
-      @Override
-      public void beforeProjectLoaded(@NotNull Project project) {
-      }
-
-      @Override
-      public void projectComponentsInitialized(@NotNull Project project) {
-      }
     });
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/ReanalyzeDartSourcesAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/ReanalyzeDartSourcesAction.java
@@ -36,7 +36,16 @@ public class ReanalyzeDartSourcesAction extends AnAction implements DumbAware {
   @Override
   public void actionPerformed(@NotNull final AnActionEvent e) {
     if (isApplicable(e.getProject())) {
-      DartAnalysisServerService.getInstance().analysis_reanalyze(null);
+      DartAnalysisServerService das = DartAnalysisServerService.getInstance();
+      if (das.isServerProcessActive()) {
+        das.analysis_reanalyze(null);
+      } else {
+        // Ensure the server is properly stopped.
+        das.restartServer();
+        // The list of projects was probably lost when the server crashed.
+        // Prime it with the current project to get the server restarted.
+        das.serverReadyForRequest(e.getProject());
+      }
     }
   }
 


### PR DESCRIPTION
@alexander-doroshko Brian mentioned that this might be the default behavior and, to me, it looks like a bug in the current implementation.

When `Reanalyze Sources` is clicked the server will be restarted if it is not currently running.

Once we implement the logic to automatically restart the server when it crashes this will be revised to work with that.

cc @bwilkerson