### PR TITLE
parse the PausePostRequest event

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -74,8 +74,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   private final boolean myRemoteDebug;
   private final int myTimeout;
   @Nullable private final VirtualFile myCurrentWorkingDirectory;
-
-  @Nullable String myRemoteProjectRootUri;
+  @Nullable protected String myRemoteProjectRootUri;
 
   public DartVmServiceDebugProcess(@NotNull final XDebugSession session,
                                    @NotNull final String debuggingHost,
@@ -335,6 +334,10 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     for (String isolateId : new ArrayList<>(mySuspendedIsolateIds)) {
       myVmServiceWrapper.resumeIsolate(isolateId, null);
     }
+  }
+
+  public void resumeIsolate(@NotNull final String isolateId, @Nullable final StepOption stepOption) {
+    myVmServiceWrapper.resumeIsolate(isolateId, stepOption);
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -78,6 +78,11 @@ public class DartVmServiceListener implements VmServiceListener {
           onIsolatePaused(event.getIsolate(), breakpoints, exception, event.getTopFrame(), event.getAtAsyncSuspension());
         });
         break;
+      case PausePostRequest:
+        // We get this event after an isolate reload call, when pause after reload has been requested.
+        // TODO: Set current breakpoints; resume the isolate.
+        myDebugProcess.resumeIsolate(event.getIsolate().getId(), null);
+        break;
       case PauseExit:
         break;
       case PauseStart:

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/EventKind.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/EventKind.java
@@ -99,6 +99,11 @@ public enum EventKind {
   PauseInterrupted,
 
   /**
+   * An isolate has paused after a service protocol request.
+   */
+  PausePostRequest,
+
+  /**
    * An isolate has paused at start, before executing code.
    */
   PauseStart,


### PR DESCRIPTION
Add support for the new `PausePostRequest` vm event type. This is sent by the VM after it has processed a hot reload call, when that reload call was invoked with the `pause` option, to pause execution of the isolate after the reload. This gives clients the ability to restore breakpoints before the program resumes.

@alexander-doroshko 