### PR TITLE
Adjust timing of status changes

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1395,15 +1395,17 @@ public class DartAnalysisServerService {
   }
 
   public boolean isServerResponsive() {
-    // TODO(messick): Make this adaptive.
     if (maxMillisToWaitForServerResponse == 0L) return true; // UI has not finished initialization yet.
-    long millis;
+    if (!(myAnalysisInProgress || myPubListInProgress)) return true;
+    long responseMillis, requestMillis;
     synchronized (myLock) {
       if (myServer == null) return false;
-      millis = myServer.getLastResponseMillis();
+      responseMillis = myServer.getLastResponseMillis();
+      requestMillis = myServer.getLastRequestMillis();
     }
-    if (millis == 0L) return true; // Allow UI to start in good state even if it becomes unknown later.
-    long delta = System.currentTimeMillis() - millis;
+    if (responseMillis == 0L) return true; // Allow UI to start in good state even if it becomes unknown later.
+    if (requestMillis <= responseMillis) return true;
+    long delta = System.currentTimeMillis() - requestMillis;
     return delta > maxMillisToWaitForServerResponse;
   }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -582,6 +582,12 @@ public interface AnalysisServer {
   public void start() throws Exception;
 
   /**
+   * Return the number of milliseconds that have passed since the last request was sent
+   * to the analysis server.
+   */
+  public long getLastRequestMillis();
+
+  /**
    * Return the number of milliseconds that have passed since the last response was received
    * from the analysis server.
    */

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -88,6 +88,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   private ResponseStream responseStream;
   private LineReaderStream errorStream;
   private final AtomicLong lastResponseTime = new AtomicLong(0);
+  private final AtomicLong lastRequestTime = new AtomicLong(0);
 
   /**
    * The listener that will receive notification when new analysis results become available.
@@ -648,6 +649,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     synchronized (consumerMapLock) {
       consumerMap.put(id, consumer);
     }
+    lastRequestTime.set(System.currentTimeMillis());
     synchronized (requestSinkLock) {
       requestSink.add(request);
     }
@@ -806,6 +808,10 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
 //        sleep(millisToRestart);
       }
     }
+  }
+
+  public long getLastRequestMillis() {
+    return lastRequestTime.get();
   }
 
   public long getLastResponseMillis() {


### PR DESCRIPTION
@alexander-doroshko This makes it much less likely that the yellow status icon will appear.

Tested by 'renice 20 -p 1904' where 1904 is the pid of the analysis server, then opening the Dart SDK and waiting until it started analyzing something fairly large. The change in process priority kept the analyzer from updating as frequently as it usually does, and the yellow icon appeared for a while. Once that file was done the icon switched to green with the next UI update.

/cc @devoncarew 