### PR TITLE
Prompt user to report analysis server errors

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -267,8 +267,10 @@ analysis.server.status.unknown.desc=Analysis server is running but has been busy
 analysis.server.status.bad.text=Analyzer: Submit Feedback (analysis process not active)
 analysis.server.status.bad.desc=Analysis server needs to be restarted
 
-dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Analyzer Feedback from IntelliJ\n\
-  IDEA: {0} Dart: {1} {2}
+dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=# Analyzer Feedback from IntelliJ\n\
+  IDEA: {0} Dart: {1}\n\
+  ## Configuration{2}\n\
+  ## Stack
 dart.analysis.server.error=Dart analysis server error
 dart.error.file.instructions=Please insert the content of this file here:\n\
   file://{0}

--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -269,3 +269,6 @@ analysis.server.status.bad.desc=Analysis server needs to be restarted
 
 dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Analyzer Feedback from IntelliJ\n\
   IDEA: {0} Dart: {1} {2}
+dart.analysis.server.error=Dart analysis server error
+dart.error.file.instructions=Please insert the content of this file here:\n\
+  file://{0}

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerStatusAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerStatusAction.java
@@ -27,11 +27,7 @@ public class AnalysisServerStatusAction extends DumbAwareAction {
   @Override
   public void actionPerformed(AnActionEvent e) {
     DartFeedbackBuilder builder = DartFeedbackBuilder.getFeedbackBuilder();
-
-    if (MessageDialogBuilder.yesNo(builder.title(), builder.prompt())
-          .icon(Messages.getQuestionIcon())
-          .yesText(builder.label())
-          .show() == Messages.YES) {
+    if (builder.showQuery(null)) {
       builder.sendFeedback(e.getProject());
     }
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
@@ -2,6 +2,8 @@ package com.jetbrains.lang.dart.ide.errorTreeView;
 
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageDialogBuilder;
+import com.intellij.openapi.ui.Messages;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,6 +13,8 @@ import org.jetbrains.annotations.Nullable;
  * send issues to the flutter project on github.
  */
 public interface DartFeedbackBuilder {
+  int MAX_URL_LENGTH = 4000;
+
   ExtensionPointName<DartFeedbackBuilder> EP_NAME = ExtensionPointName.create("Dart.feedbackBuilder");
 
   @NotNull
@@ -46,9 +50,28 @@ public interface DartFeedbackBuilder {
   }
 
   /**
+   * Set the text of the message to be optionally included in the report.
+   *
+   * @param message
+   */
+  default void setMessage(String message) {
+  }
+
+  /**
    * Perform the action required to send feedback.
    *
    * @param project the current project
    */
   void sendFeedback(@Nullable Project project);
+
+  /**
+   * Display a standard query dialog and return the user's response.
+   */
+  default boolean showQuery(String message) {
+    return
+      (MessageDialogBuilder.yesNo(title(), message == null ? prompt() : message + "\n" + prompt())
+         .icon(Messages.getQuestionIcon())
+         .yesText(label())
+         .show() == Messages.YES);
+  }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
@@ -29,9 +29,10 @@ public class DefaultDartFeedbackBuilder implements DartFeedbackBuilder {
     boolean eap = appInfo.isEAP();
     String ijBuild = eap ? appInfo.getBuild().asStringWithoutProductCode() : appInfo.getBuild().asString();
     String sdkVsn = getSdkVersion(project);
-    String platDescr = getDescription();
+    String platDescr = getDescription().replaceAll(";", " ");
     String template = DartBundle.message("dart.feedback.url.template", ijBuild, sdkVsn, platDescr);
     if (myMessage != null) {
+      myMessage = "```dart\n" + myMessage + "```";
       String potentialTemplate = template + "\n\n" + myMessage;
       if (potentialTemplate.length() <= MAX_URL_LENGTH) {
         template = potentialTemplate;

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
@@ -3,16 +3,25 @@ package com.jetbrains.lang.dart.ide.errorTreeView;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.application.ex.ApplicationInfoEx;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
+import java.io.IOException;
+
 import static com.intellij.ide.actions.SendFeedbackAction.getDescription;
 
 public class DefaultDartFeedbackBuilder implements DartFeedbackBuilder {
+  private String myMessage;
 
   public String prompt() {
     return "Create issue on github?";
+  }
+
+  public void setMessage(String message) {
+    myMessage = message;
   }
 
   public void sendFeedback(@Nullable Project project) {
@@ -22,6 +31,22 @@ public class DefaultDartFeedbackBuilder implements DartFeedbackBuilder {
     String sdkVsn = getSdkVersion(project);
     String platDescr = getDescription();
     String template = DartBundle.message("dart.feedback.url.template", ijBuild, sdkVsn, platDescr);
+    if (myMessage != null) {
+      String potentialTemplate = template + "\n\n" + myMessage;
+      if (potentialTemplate.length() <= MAX_URL_LENGTH) {
+        template = potentialTemplate;
+      } else {
+        try {
+          File file = FileUtil.createTempFile("report", ".txt");
+          FileUtil.writeToFile(file, myMessage);
+          potentialTemplate = template + "\n\n" + DartBundle.message("dart.error.file.instructions", file.getAbsolutePath()) + "\n\n" + myMessage;
+          template = potentialTemplate.substring(0, MAX_URL_LENGTH);
+        }
+        catch (IOException e) {
+          // ignore it
+        }
+      }
+    }
     openBrowserOnFeedbackForm(template, project);
   }
 


### PR DESCRIPTION
@alexander-doroshko When an error in the analysis server is reported to IntelliJ we now prompt the user to submit feedback to github.

Testing was difficult. I had to make a repository that causes the analyzer to throw an error. I got it to do the same error twice, quickly, and tuned the code to filter out too many disruptions. Then added a counter heuristic to keep from being totally obnoxious about asking the user to report errors.

Stack traces can be quite long. For those that do not fit within IE's (current) URL length limit we dump the trace to a file and ask the user to insert the content of the file into the issue. To make that easy, the file is reported as a URL that can be opened in a browser.

@devoncarew This does not have the "Do not ask again" checkbox that I plan to add to the query, but I haven't forgotten about it.