### PR TITLE
Add Do Not Ask button to reporting query

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -274,3 +274,4 @@ dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=# An
 dart.analysis.server.error=Dart analysis server error
 dart.error.file.instructions=Please insert the content of this file here:\n\
   file://{0}
+dart.report.options.do.not.ask=Do not ask until restart

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1684,8 +1684,6 @@ public class DartAnalysisServerService {
       if (messageDiffers(errorMessage)) {
         myErrorReporter.add(() -> {
           DartFeedbackBuilder builder = DartFeedbackBuilder.getFeedbackBuilder();
-          builder.setMessage(errorMessage);
-
           final boolean[] reportIt = new boolean[1];
           myDisruptionCount++;
           ApplicationManager.getApplication().invokeAndWait(() -> {
@@ -1693,7 +1691,7 @@ public class DartAnalysisServerService {
             myPreviousTime = System.currentTimeMillis();
           });
           if (reportIt[0]) {
-            builder.sendFeedback(null);
+            builder.sendFeedback(null, errorMessage);
           }
           else {
             LOG.error(errorMessage);

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerStatusAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerStatusAction.java
@@ -28,7 +28,7 @@ public class AnalysisServerStatusAction extends DumbAwareAction {
   public void actionPerformed(AnActionEvent e) {
     DartFeedbackBuilder builder = DartFeedbackBuilder.getFeedbackBuilder();
     if (builder.showQuery(null)) {
-      builder.sendFeedback(e.getProject());
+      builder.sendFeedback(e.getProject(), null);
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
@@ -2,8 +2,10 @@ package com.jetbrains.lang.dart.ide.errorTreeView;
 
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.MessageDialogBuilder;
 import com.intellij.openapi.ui.Messages;
+import com.jetbrains.lang.dart.DartBundle;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,13 +14,15 @@ import org.jetbrains.annotations.Nullable;
  * for projects other than the Dart plugin. For example, the Flutter plugin may
  * send issues to the flutter project on github.
  */
-public interface DartFeedbackBuilder {
-  int MAX_URL_LENGTH = 4000;
+public abstract class DartFeedbackBuilder {
+  public static final int MAX_URL_LENGTH = 4000;
+  // TODO(messick): Change ShowPrompt to a Dart preference
+  private static boolean ShowPrompt = true;
 
-  ExtensionPointName<DartFeedbackBuilder> EP_NAME = ExtensionPointName.create("Dart.feedbackBuilder");
+  private static ExtensionPointName<DartFeedbackBuilder> EP_NAME = ExtensionPointName.create("Dart.feedbackBuilder");
 
   @NotNull
-  static DartFeedbackBuilder getFeedbackBuilder() {
+  public static DartFeedbackBuilder getFeedbackBuilder() {
     final DartFeedbackBuilder[] builders = EP_NAME.getExtensions();
     assert builders.length > 0;
     return builders[0];
@@ -29,7 +33,7 @@ public interface DartFeedbackBuilder {
    *
    * @return The string to display in the title of the confirmation dialog.
    */
-  default String title() {
+  public String title() {
     return "Open Browser";
   }
 
@@ -38,40 +42,61 @@ public interface DartFeedbackBuilder {
    *
    * @return The string to display in the confirmation dialog.
    */
-  String prompt();
+  public abstract String prompt();
 
   /**
    * The label should indicate what is going to happen when clicked (eg send feedback).
    *
    * @return The string to display as the label of the yes-button in the confirmation dialog.
    */
-  default String label() {
+  public String label() {
     return "Send feedback";
-  }
-
-  /**
-   * Set the text of the message to be optionally included in the report.
-   *
-   * @param message
-   */
-  default void setMessage(String message) {
   }
 
   /**
    * Perform the action required to send feedback.
    *
    * @param project the current project
+   * @param errorMessage additional information for the issue, such as a tack trace
    */
-  void sendFeedback(@Nullable Project project);
+  public abstract void sendFeedback(@Nullable Project project, String errorMessage);
 
   /**
    * Display a standard query dialog and return the user's response.
    */
-  default boolean showQuery(String message) {
-    return
-      (MessageDialogBuilder.yesNo(title(), message == null ? prompt() : message + "\n" + prompt())
-         .icon(Messages.getQuestionIcon())
-         .yesText(label())
-         .show() == Messages.YES);
+  public boolean showQuery(String message) {
+    if (ShowPrompt) {
+      return
+        (MessageDialogBuilder.yesNo(title(), message == null ? prompt() : message + "\n" + prompt())
+           .icon(Messages.getQuestionIcon())
+           .doNotAsk(getDoNotAskOption())
+           .yesText(label())
+           .show() == Messages.YES);
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Return a DoNotAskOption option for the MessageDialogBuilder.
+   */
+  public DialogWrapper.DoNotAskOption getDoNotAskOption() {
+    return getDefaultDoNotAskOption();
+  }
+
+  static DialogWrapper.DoNotAskOption getDefaultDoNotAskOption() {
+    return new DialogWrapper.DoNotAskOption.Adapter() {
+      @Override
+      public void rememberChoice(boolean isSelected, int exitCode) {
+        //noinspection AssignmentToStaticFieldFromInstanceMethod
+        ShowPrompt = !isSelected;
+      }
+
+      @NotNull
+      @Override
+      public String getDoNotShowMessage() {
+        return DartBundle.message("dart.report.options.do.not.ask");
+      }
+    };
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
@@ -3,9 +3,11 @@ package com.jetbrains.lang.dart.ide.errorTreeView;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.application.ex.ApplicationInfoEx;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.util.io.FileUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -13,34 +15,29 @@ import java.io.IOException;
 
 import static com.intellij.ide.actions.SendFeedbackAction.getDescription;
 
-public class DefaultDartFeedbackBuilder implements DartFeedbackBuilder {
-  private String myMessage;
+public class DefaultDartFeedbackBuilder extends DartFeedbackBuilder {
 
   public String prompt() {
     return "Create issue on github?";
   }
 
-  public void setMessage(String message) {
-    myMessage = message;
-  }
-
-  public void sendFeedback(@Nullable Project project) {
+  public void sendFeedback(@Nullable Project project, String errorMessage) {
     final ApplicationInfoEx appInfo = ApplicationInfoEx.getInstanceEx();
     boolean eap = appInfo.isEAP();
     String ijBuild = eap ? appInfo.getBuild().asStringWithoutProductCode() : appInfo.getBuild().asString();
     String sdkVsn = getSdkVersion(project);
     String platDescr = getDescription().replaceAll(";", " ");
     String template = DartBundle.message("dart.feedback.url.template", ijBuild, sdkVsn, platDescr);
-    if (myMessage != null) {
-      myMessage = "```dart\n" + myMessage + "```";
-      String potentialTemplate = template + "\n\n" + myMessage;
+    if (errorMessage != null) {
+      errorMessage = "```dart\n" + errorMessage + "```";
+      String potentialTemplate = template + "\n\n" + errorMessage;
       if (potentialTemplate.length() <= MAX_URL_LENGTH) {
         template = potentialTemplate;
       } else {
         try {
           File file = FileUtil.createTempFile("report", ".txt");
-          FileUtil.writeToFile(file, myMessage);
-          potentialTemplate = template + "\n\n" + DartBundle.message("dart.error.file.instructions", file.getAbsolutePath()) + "\n\n" + myMessage;
+          FileUtil.writeToFile(file, errorMessage);
+          potentialTemplate = template + "\n\n" + DartBundle.message("dart.error.file.instructions", file.getAbsolutePath()) + "\n\n" + errorMessage;
           template = potentialTemplate.substring(0, MAX_URL_LENGTH);
         }
         catch (IOException e) {


### PR DESCRIPTION
@alexander-doroshko Add a Do Not Ask button to the dialog that requests an issue report.

This also makes the builder stateless, which should fix the duplicate style issue reported earlier today.

Eventually, the value saved from the Do Not Ask check box should be stored as a preference.