### PR TITLE
ui tweaks to the pubspec.yaml notifications provider

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartEditorNotificationsProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartEditorNotificationsProvider.java
@@ -105,11 +105,14 @@ public class DartEditorNotificationsProvider extends EditorNotifications.Provide
   private static class PubActionsPanel extends EditorNotificationPanel {
     private PubActionsPanel() {
       super(EditorColors.GUTTER_BACKGROUND);
-      myLinksPanel.add(new JLabel("Pub actions:"));
+
+      icon(DartIcons.Dart_16);
+      text("Pub actions");
+
       createActionLabel(DartBundle.message("get.dependencies"), "Dart.pub.get");
       createActionLabel(DartBundle.message("upgrade.dependencies"), "Dart.pub.upgrade");
       createActionLabel("Build...", "Dart.pub.build");
-      myLinksPanel.add(new JLabel("        "));
+      myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
       createActionLabel("Repair cache...", "Dart.pub.cache.repair");
     }
   }


### PR DESCRIPTION
Some ui tweaks to the pubspec.yaml editor notifications provider:

- add an icon
- use the `text()` label (for a similar look to other notifications providers)
- as a JSeparator to separate package actions from global ones

<img width="686" alt="screen shot 2016-12-03 at 1 52 12 pm" src="https://cloud.githubusercontent.com/assets/1269969/20862463/3b7a4918-b960-11e6-9e12-f629ff1e3eaa.png">

@alexander-doroshko 