### PR TITLE
move the errors status text to the view toolbar

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsView.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsView.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowAnchor;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowEx;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.util.Alarm;
@@ -94,6 +95,8 @@ public class DartProblemsView {
 
       final Content content = ContentFactory.SERVICE.getInstance().createContent(myPanel, "", false);
       toolWindow.getContentManager().addContent(content);
+      ((ToolWindowEx)toolWindow).setTitleActions(new AnalysisServerStatusAction());
+      myPanel.setContent(content);
 
       if (PropertiesComponent.getInstance(project).getBoolean("dart.analysis.tool.window.force.activate", true)) {
         PropertiesComponent.getInstance(project).setValue("dart.analysis.tool.window.force.activate", false, true);


### PR DESCRIPTION
- remove the dedicated JLabel below the problems view table
- use the view content's display name area to display the summary of the errors and warnings
- use the toolbar to hold the analysis server status and feedback icon

This change allows more of the area in the problems view to be used for displaying errors, and leverages some IntelliJ constructs (`setDisplayName()`) to display UI (helping us unify our look with other views).

<img width="933" alt="screen shot 2016-12-05 at 8 18 46 am" src="https://cloud.githubusercontent.com/assets/1269969/20893569/1ddbc482-bac7-11e6-8906-74acd062b37e.png">

<img width="215" alt="screen shot 2016-12-05 at 8 18 54 am" src="https://cloud.githubusercontent.com/assets/1269969/20893570/1ddc7fb2-bac7-11e6-8dd6-687bc514d864.png">

<img width="196" alt="screen shot 2016-12-05 at 8 19 15 am" src="https://cloud.githubusercontent.com/assets/1269969/20893571/1ddfd1a8-bac7-11e6-921e-01f7251f96b1.png">

@alexander-doroshko @stevemessick for thoughts
