### PR TITLE
don't show lines in the analysis view

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -115,6 +115,8 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Data
                                           : "");
 
     table.setShowVerticalLines(false);
+    table.setShowHorizontalLines(false);
+    table.setMinRowHeight(20);
     return table;
   }
 


### PR DESCRIPTION
- don't show lines in the analysis view
- space the rows out a bit (they seem compressed currently; this spaces them out closer to how the other views (tree based) look)

I didn't see a good constant to use for the spacing, so just chose a min spacing (20) that looked good.

before:

<img width="1090" alt="screen shot 2016-12-07 at 6 47 45 pm" src="https://cloud.githubusercontent.com/assets/1269969/20995916/f48695be-bcae-11e6-851e-5a07b83b6f41.png">

after:

<img width="1092" alt="screen shot 2016-12-07 at 6 48 48 pm" src="https://cloud.githubusercontent.com/assets/1269969/20995920/fa110adc-bcae-11e6-9aa8-b7f33e4a2fcf.png">

