### PR TITLE
use LOG.warn() in the feedback provider

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1684,7 +1684,7 @@ public class DartAnalysisServerService {
       long timeStamp = System.currentTimeMillis();
       if (timeStamp - myPreviousTime < MIN_DISRUPTION_TIME) {
         if (messageDiffers(errorMessage)) {
-          LOG.error(errorMessage);
+          LOG.warn(errorMessage);
           if (myDisruptionCount > 0) {
             myDisruptionCount++; // The red flashing icon is somewhat disruptive, but we only count if the user has already been queried.
           }
@@ -1705,7 +1705,7 @@ public class DartAnalysisServerService {
             builder.sendFeedback(null, errorMessage);
           }
           else {
-            LOG.error(errorMessage);
+            LOG.warn(errorMessage);
           }
         });
       }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -48,7 +49,7 @@ public class DefaultDartFeedbackBuilder extends DartFeedbackBuilder {
     openBrowserOnFeedbackForm(template, project);
   }
 
-  public static void openBrowserOnFeedbackForm(String urlTemplate, Project project) {
+  public static void openBrowserOnFeedbackForm(@NotNull String urlTemplate, @Nullable Project project) {
     BrowserUtil.browse(urlTemplate, project);
   }
 


### PR DESCRIPTION
When handling exceptions from the analysis server, use LOG.warn() instead of LOG.error(). The error() method will show an exception toast from IntelliJ, and we're already offering to report the issue via the feedback provider.

@alexander-doroshko @stevemessick 