### PR TITLE
Add server log to feedback

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerStatusAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerStatusAction.java
@@ -26,7 +26,7 @@ public class AnalysisServerStatusAction extends DumbAwareAction {
   public void actionPerformed(AnActionEvent e) {
     DartFeedbackBuilder builder = DartFeedbackBuilder.getFeedbackBuilder();
     if (builder.showQuery(null)) {
-      builder.sendFeedback(e.getProject(), null);
+      builder.sendFeedback(e.getProject(), null, null);
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
@@ -58,8 +58,9 @@ public abstract class DartFeedbackBuilder {
    *
    * @param project the current project
    * @param errorMessage additional information for the issue, such as a tack trace
+   * @param serverLog recent requests made to the analysis server
    */
-  public abstract void sendFeedback(@Nullable Project project, @Nullable String errorMessage);
+  public abstract void sendFeedback(@Nullable Project project, @Nullable String errorMessage, @Nullable String serverLog);
 
   /**
    * Display a standard query dialog and return the user's response.


### PR DESCRIPTION
@alexander-doroshko Add most recent server log lines to the feedback file. Make the file always get written.

This may take a few iterations to determine just what log info the analyzer teams wants to see.

cc @devoncarew 