### PR TITLE
IDEA-138481 support subbundles

### DIFF
--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/BndWorkspaceBuildSession.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/BndWorkspaceBuildSession.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.osgi.jps.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jps.builders.logging.ProjectBuilderLogger;
+import org.jetbrains.jps.incremental.CompileContext;
+import org.jetbrains.jps.incremental.messages.BuildMessage;
+import org.jetbrains.jps.incremental.messages.CompilerMessage;
+import org.jetbrains.jps.incremental.messages.DoneSomethingNotification;
+import org.jetbrains.jps.incremental.messages.ProgressMessage;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.io.FileUtil;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Jar;
+
+public class BndWorkspaceBuildSession implements Reporter {
+  private static final Logger LOG = Logger.getInstance(BndWorkspaceBuildSession.class);
+
+  private String myMessagePrefix;
+  private String mySourceToReport = null;
+  private Project myProject;
+  private CompileContext myContext;
+
+  public void build(@NotNull OsmorcBuildTarget target, @NotNull CompileContext context) throws IOException {
+    myContext = context;
+    myProject = target.getProject();
+
+    myMessagePrefix = "[" + target.getModule().getName() + "] ";
+
+    progress("Building OSGi bundle");
+
+    try {
+      prepare();
+      doBuild();
+    }
+    catch (OsgiBuildException e) {
+      error(e.getMessage(), e.getCause(), e.getSourcePath());
+      return;
+    }
+
+    try {
+      Set<File> outputFiles = new HashSet<File>();
+      Collection<? extends Builder> subBuilders = myProject.getSubBuilders();
+      for (Builder subBuilder : subBuilders) {
+        File outputFile = myProject.getOutputFile(subBuilder.getBsn());
+        if (!outputFile.exists()) {
+          error("Bundle was not built", null, null);
+          return;
+        }
+      }
+
+      ProjectBuilderLogger logger = context.getLoggingManager().getProjectBuilderLogger();
+      if (logger.isEnabled()) {
+        logger.logCompiledFiles(outputFiles, OsmorcBuilder.ID, "Built OSGi bundles:");
+      }
+    } catch (Exception e) {
+      error(e.getMessage(), e.getCause(), null);
+      return;
+    }
+
+    context.processMessage(DoneSomethingNotification.INSTANCE);
+  }
+
+  private void prepare() throws OsgiBuildException {
+    try {
+      for (Builder subBuilder : myProject.getSubBuilders()) {
+        File outputRoot = myProject.getOutputFile(subBuilder.getBsn());
+        if (!FileUtil.delete(outputRoot)) {
+          throw new OsgiBuildException("Can't delete bundle file '" + outputRoot + "'.");
+        }
+        if (!FileUtil.createParentDirs(outputRoot)) {
+          throw new OsgiBuildException("Cannot create directory for bundle file '" + outputRoot + "'.");
+        }
+      }
+    } catch (Exception e) {
+      throw new OsgiBuildException("Unexpected build error " + e.getMessage(), e, null);
+    }
+  }
+
+  private void doBuild() throws OsgiBuildException {
+    progress("Running Bnd to build the bundle");
+
+    try {
+
+      ReportingProjectBuilder builder = new ReportingProjectBuilder(this, myProject);
+      builder.setBase(myProject.getBase());
+      List<Builder> subBuilders = builder.getSubBuilders();
+      for (Builder subBuilder : subBuilders) {
+        File propertiesFile = subBuilder == builder ? builder.getParent().getPropertiesFile() : subBuilder.getPropertiesFile();
+        mySourceToReport = propertiesFile.getAbsolutePath();
+        Jar jar = subBuilder.build();
+        jar.write(myProject.getOutputFile(subBuilder.getBsn()));
+        subBuilder.close();
+      }
+    } catch (Exception e) {
+      throw new OsgiBuildException("Unexpected build error " + e.getMessage(), e, null);
+    }
+    mySourceToReport = null;
+
+  }
+
+  @Override
+  public void progress(@NotNull String message) {
+    myContext.processMessage(new ProgressMessage(myMessagePrefix + message));
+  }
+
+  @Override
+  public void warning(@NotNull String message, @Nullable Throwable t, @Nullable String sourcePath) {
+    LOG.warn(message, t);
+    if (sourcePath == null) sourcePath = mySourceToReport;
+    myContext.processMessage(new CompilerMessage(OsmorcBuilder.ID, BuildMessage.Kind.WARNING, myMessagePrefix + message, sourcePath));
+  }
+
+  @Override
+  public void error(@NotNull String message, @Nullable Throwable t, @Nullable String sourcePath) {
+    LOG.warn(message, t);
+    if (sourcePath == null) sourcePath = mySourceToReport;
+    myContext.processMessage(new CompilerMessage(OsmorcBuilder.ID, BuildMessage.Kind.ERROR, myMessagePrefix + message, sourcePath));
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return LOG.isDebugEnabled();
+  }
+
+  @Override
+  public void debug(@NotNull String message) {
+    LOG.debug(message);
+  }
+}

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsmorcBuildTargetType.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsmorcBuildTargetType.java
@@ -1,17 +1,24 @@
 package org.jetbrains.osgi.jps.build;
 
-import com.intellij.util.containers.ContainerUtil;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.builders.BuildTargetLoader;
 import org.jetbrains.jps.builders.ModuleBasedBuildTargetType;
 import org.jetbrains.jps.model.JpsModel;
 import org.jetbrains.jps.model.module.JpsModule;
+import org.jetbrains.jps.model.serialization.JpsModelSerializationDataService;
 import org.jetbrains.osgi.jps.model.JpsOsmorcExtensionService;
 import org.jetbrains.osgi.jps.model.JpsOsmorcModuleExtension;
+import org.jetbrains.osgi.jps.model.JpsOsmorcProjectExtension;
 
-import java.util.List;
-import java.util.Map;
+import com.intellij.util.containers.ContainerUtil;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
 
 /**
  * @author michael.golubev
@@ -27,11 +34,31 @@ public class OsmorcBuildTargetType extends ModuleBasedBuildTargetType<OsmorcBuil
   @Override
   public List<OsmorcBuildTarget> computeAllTargets(@NotNull JpsModel model) {
     List<OsmorcBuildTarget> targets = ContainerUtil.newArrayList();
-    for (JpsModule module : model.getProject().getModules()) {
-      JpsOsmorcModuleExtension extension = JpsOsmorcExtensionService.getExtension(module);
-      if (extension != null) {
-        targets.add(new OsmorcBuildTarget(extension, module));
+
+    try {
+      JpsOsmorcProjectExtension projectExtension = JpsOsmorcExtensionService.getExtension(model.getProject());
+      Workspace workspace = null;
+      if (projectExtension.isBndWorkspace()) {
+        File baseDirectory = JpsModelSerializationDataService.getBaseDirectory(model.getProject());
+        workspace = Workspace.getWorkspace(baseDirectory);
       }
+
+      for (JpsModule module : model.getProject().getModules()) {
+        Project project = workspace != null ? workspace.getProject(module.getName()): null;
+        if (project != null && !project.isNoBundles()) {
+          // Module is part of the bnd workspace
+          targets.add(new OsmorcBuildTarget(project, module));
+        }
+        else {
+          // Module is not part of the bnd workspace, check if it has the OSGi facet
+          JpsOsmorcModuleExtension extension = JpsOsmorcExtensionService.getExtension(module);
+          if (extension != null) {
+            targets.add(new OsmorcBuildTarget(extension, module));
+          }
+        }
+      }
+    } catch(Exception e){
+      throw new RuntimeException("Unexpected error " + e.getMessage(), e);
     }
     return targets;
   }

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsmorcBuilder.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsmorcBuilder.java
@@ -23,6 +23,7 @@ import org.jetbrains.jps.builders.java.JavaBuilderUtil;
 import org.jetbrains.jps.incremental.CompileContext;
 import org.jetbrains.jps.incremental.ProjectBuildException;
 import org.jetbrains.jps.incremental.TargetBuilder;
+import org.jetbrains.osgi.jps.model.JpsOsmorcExtensionService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -48,7 +49,11 @@ public class OsmorcBuilder extends TargetBuilder<BuildRootDescriptor, OsmorcBuil
                     @NotNull DirtyFilesHolder<BuildRootDescriptor, OsmorcBuildTarget> holder,
                     @NotNull BuildOutputConsumer outputConsumer,
                     @NotNull CompileContext context) throws ProjectBuildException, IOException {
-    if (target.getExtension().isAlwaysRebuildBundleJar() ||
+
+    if (target.getProject() != null) {
+      new BndWorkspaceBuildSession().build(target, context);
+    }
+    else if (JpsOsmorcExtensionService.getExtension(target.getModule()).isAlwaysRebuildBundleJar() ||
         JavaBuilderUtil.isForcedRecompilationAllJavaModules(context) ||
         holder.hasDirtyFiles() || holder.hasRemovedFiles()) {
       new OsgiBuildSession().build(target, context);

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/ReportingProjectBuilder.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/ReportingProjectBuilder.java
@@ -17,6 +17,7 @@ package org.jetbrains.osgi.jps.build;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectBuilder;
+import aQute.bnd.osgi.Builder;
 import org.jetbrains.annotations.NotNull;
 
 public class ReportingProjectBuilder extends ProjectBuilder {
@@ -24,6 +25,11 @@ public class ReportingProjectBuilder extends ProjectBuilder {
 
   public ReportingProjectBuilder(@NotNull Reporter reporter, @NotNull Project project) {
     super(project);
+    myReporter = reporter;
+  }
+
+  public ReportingProjectBuilder(@NotNull Reporter reporter, @NotNull ProjectBuilder parent) {
+    super(parent);
     myReporter = reporter;
   }
 
@@ -59,4 +65,13 @@ public class ReportingProjectBuilder extends ProjectBuilder {
   public void trace(String format, Object... args) {
     myReporter.debug(formatArrays(format, args));
   }
+
+  @Override
+  public Builder getSubBuilder() throws Exception {
+    ReportingProjectBuilder builder = new ReportingProjectBuilder(myReporter, this);
+    builder.setBase(this.getBase());
+    builder.use(this);
+    return builder;
+  }
+
 }

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/JpsOsmorcProjectExtension.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/JpsOsmorcProjectExtension.java
@@ -13,4 +13,6 @@ public interface JpsOsmorcProjectExtension extends JpsElement {
   String getBundlesOutputPath();
 
   String getDefaultManifestFileLocation();
+
+  boolean isBndWorkspace();
 }

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/JpsOsmorcProjectExtensionImpl.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/JpsOsmorcProjectExtensionImpl.java
@@ -41,6 +41,11 @@ public class JpsOsmorcProjectExtensionImpl extends JpsElementBase<JpsOsmorcProje
     return myProperties.myDefaultManifestFileLocation;
   }
 
+  @Override
+  public boolean isBndWorkspace() {
+    return Boolean.TRUE.equals(myProperties.myBndWorkspace);
+  }
+
   @NotNull
   public static String getDefaultBundlesOutputPath(JpsProject project) {
     JpsJavaExtensionService service = JpsJavaExtensionService.getInstance();

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/OsmorcProjectExtensionProperties.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/OsmorcProjectExtensionProperties.java
@@ -13,4 +13,7 @@ public class OsmorcProjectExtensionProperties {
 
   @OptionTag("defaultManifestFileLocation")
   public String myDefaultManifestFileLocation = JarFile.MANIFEST_NAME;
+
+  @OptionTag("bndWorkspace")
+  public Boolean myBndWorkspace;
 }

--- a/osmorc/src/org/jetbrains/osgi/bnd/imp/BndProjectImporter.java
+++ b/osmorc/src/org/jetbrains/osgi/bnd/imp/BndProjectImporter.java
@@ -18,7 +18,6 @@ package org.jetbrains.osgi.bnd.imp;
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
-import aQute.bnd.header.Attrs;
 import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.RepositoryPlugin;
 import com.intellij.compiler.CompilerConfiguration;
@@ -61,11 +60,7 @@ import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.java.compiler.JpsJavaCompilerOptions;
-import org.jetbrains.osgi.jps.model.ManifestGenerationMode;
-import org.jetbrains.osgi.jps.model.OutputPathType;
 import org.osmorc.facet.OsmorcFacet;
-import org.osmorc.facet.OsmorcFacetConfiguration;
-import org.osmorc.facet.OsmorcFacetType;
 
 import java.io.File;
 import java.io.IOException;
@@ -316,26 +311,8 @@ public class BndProjectImporter {
     CompilerConfiguration.getInstance(myProject).setBytecodeTargetLevel(module, targetLevel);
 
     OsmorcFacet facet = OsmorcFacet.getInstance(module);
-
-    if (project.isNoBundles() && facet != null) {
-      FacetUtil.deleteFacet(facet);
-      facet = null;
-    }
-    else if (!project.isNoBundles() && facet == null) {
-      facet = FacetUtil.addFacet(module, OsmorcFacetType.getInstance());
-    }
-
     if (facet != null) {
-      OsmorcFacetConfiguration facetConfig = facet.getConfiguration();
-
-      facetConfig.setManifestGenerationMode(ManifestGenerationMode.Bnd);
-      facetConfig.setBndFileLocation(FileUtil.getRelativePath(path(project.getBase()), path(project.getPropertiesFile()), '/'));
-
-      Map.Entry<String, Attrs> bsn = project.getBundleSymbolicName();
-      File bundle = project.getOutputFile(bsn != null ? bsn.getKey() : name, project.getBundleVersion());
-      facetConfig.setJarFileLocation(path(bundle), OutputPathType.SpecificOutputPath);
-
-      facetConfig.setDoNotSynchronizeWithMaven(true);
+      FacetUtil.deleteFacet(facet);
     }
 
     return rootModel;
@@ -512,10 +489,6 @@ public class BndProjectImporter {
 
   private static boolean booleanProperty(String value) {
     return "on".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value);
-  }
-
-  private static String path(File file) {
-    return FileUtil.toSystemIndependentName(file.getPath());
   }
 
   private static String url(File file) {

--- a/osmorc/src/org/osmorc/settings/ProjectSettings.java
+++ b/osmorc/src/org/osmorc/settings/ProjectSettings.java
@@ -53,6 +53,7 @@ public class ProjectSettings implements PersistentStateComponent<ProjectSettings
   private String myDefaultManifestFileLocation = "META-INF/MANIFEST.MF";
   private String myBundlesOutputPath;
   private boolean myBndAutoImport = false;
+  private boolean myBndWorkspace = false;
 
   /**
    * Returns the default output path for bundles. This is the compiler output path plus "/bundles" (e.g. $PROJECT_ROOT/out/bundles).
@@ -125,6 +126,14 @@ public class ProjectSettings implements PersistentStateComponent<ProjectSettings
 
   public void setBndAutoImport(boolean bndAutoImport) {
     myBndAutoImport = bndAutoImport;
+  }
+
+  public boolean isBndWorkspace() {
+    return myBndWorkspace;
+  }
+
+  public void setBndWorkspace(boolean bndWorkspace) {
+    this.myBndWorkspace = bndWorkspace;
   }
 
   @NotNull

--- a/osmorc/src/org/osmorc/settings/ProjectSettingsEditorComponent.form
+++ b/osmorc/src/org/osmorc/settings/ProjectSettingsEditorComponent.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.osmorc.settings.ProjectSettingsEditorComponent">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="577" height="468"/>
@@ -122,9 +122,18 @@
       </component>
       <vspacer id="7bee">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="352c6" class="com.intellij.ui.components.JBCheckBox" binding="myBndWorkspace">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Bnd workspace"/>
+          <toolTipText value="Update IDEA project model each time bnd.bnd or build.bnd file is changed "/>
+        </properties>
+      </component>
     </children>
   </grid>
   <inspectionSuppressions>

--- a/osmorc/src/org/osmorc/settings/ProjectSettingsEditorComponent.java
+++ b/osmorc/src/org/osmorc/settings/ProjectSettingsEditorComponent.java
@@ -60,6 +60,7 @@ public class ProjectSettingsEditorComponent {
   private TextFieldWithBrowseButton myBundleOutputPath;
   private JButton myApplyToAllButton;
   private JBCheckBox myBndAutoImport;
+  private JBCheckBox myBndWorkspace;
 
   private Project myProject;
   private ProjectSettings mySettings;
@@ -128,6 +129,7 @@ public class ProjectSettingsEditorComponent {
     settings.setBundlesOutputPath(!StringUtil.isEmptyOrSpaces(outputPath) ? outputPath : null);
 
     settings.setBndAutoImport(myBndAutoImport.isSelected());
+    settings.setBndWorkspace(myBndWorkspace.isSelected());
 
     myModified = false;
   }
@@ -148,6 +150,7 @@ public class ProjectSettingsEditorComponent {
     }
 
     myBndAutoImport.setSelected(settings.isBndAutoImport());
+    myBndWorkspace.setSelected(settings.isBndWorkspace());
 
     myModified = false;
   }


### PR DESCRIPTION

 - Added a configuration option to indicate that a project should be considered to be a bnd workspace
 - osmorc-jps-plugin: to use the bnd project to configure the builder (if the project is marked as a bnd workspace)
 - bnd project import: Not to add the OSGi facet (and remove it if it's already there)
 - bnd project import: For module dependencies also add the generated bundle as dependency. 
 	Not necessarily required to get subbundles to work but I needed this for some of the workspaces I've tested the changes with as with bnd it's possible add classes from the module buildpath or even from files that are not on the module buildpath to a bundle using Export-Package and Include-Resource instructions. Because of this it's possible that classes that are available in the bundle bundle jar are not available when only adding the module dependency. (Bndtools has the same "fix" for this issue). 