### PR TITLE
make scheduleConnect public

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -197,7 +197,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     });
   }
 
-  private void scheduleConnect(@NotNull final String url) {
+  public void scheduleConnect(@NotNull final String url) {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       long timeout = (long)myTimeout;
       long startTime = System.currentTimeMillis();

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -197,7 +197,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     });
   }
 
-  public void scheduleConnect(@NotNull final String url) {
+  protected void scheduleConnect(@NotNull final String url) {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       long timeout = (long)myTimeout;
       long startTime = System.currentTimeMillis();


### PR DESCRIPTION
- make `scheduleConnect()` public (this will help us override its behavior in the Flutter subclass)

@alexander-doroshko 