### PR TITLE
Enhanced language guessing for markdown code blocks to support R-markdown

### DIFF
--- a/markdown/src/org/intellij/plugins/markdown/injection/LanguageGuesser.java
+++ b/markdown/src/org/intellij/plugins/markdown/injection/LanguageGuesser.java
@@ -50,7 +50,10 @@ public enum LanguageGuesser {
 
   @Nullable
   public Language guessLanguage(@NotNull String languageName) {
-    final Language languageFromMap = langIdToLanguage.getValue().get(languageName.toLowerCase(Locale.US));
+    // Add support for rmarkdown chunks (see http://rmarkdown.rstudio.com/authoring_rcodechunks.html)
+    languageName = languageName.startsWith("{r ") ? "r" : languageName;
+
+    final Language languageFromMap = langIdToLanguage.getValue().get(languageName);
     if (languageFromMap != null) {
       return languageFromMap;
     }

--- a/markdown/src/org/intellij/plugins/markdown/injection/LanguageGuesser.java
+++ b/markdown/src/org/intellij/plugins/markdown/injection/LanguageGuesser.java
@@ -50,6 +50,8 @@ public enum LanguageGuesser {
 
   @Nullable
   public Language guessLanguage(@NotNull String languageName) {
+    languageName = languageName.toLowerCase(Locale.US);
+
     // Add support for rmarkdown chunks (see http://rmarkdown.rstudio.com/authoring_rcodechunks.html)
     languageName = languageName.startsWith("{r ") ? "r" : languageName;
 


### PR DESCRIPTION
In its current implementation the "JetBrains Markdown" plugin fails to correctly inject R into r-codechunks.

A very popular approach in the R community is to write so-called [Rmd-files](http://rmarkdown.rstudio.com/) which are regular markdown files that are rendered into html/pdf/doc using tools like [knitr](https://yihui.name/knitr/). During the rendering process code chunks  are replaced with plots and results.

To guide formatting and to adjust chunk execution the initial line of the code chunks often includes some formatting and evaluation hints:
~~~~
```{r fig.height=23, eval=T}
1+1
plot(1:1)
```
~~~~

See http://rmarkdown.rstudio.com/authoring_rcodechunks.html for a reference.

The provided patch enhances the language guessing for markdown code blocks in the "Jetbrains Markdown" plugin to support the **r**markdown chunks as well.