### PR TITLE
Use balloon instead of modal query

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -276,4 +276,3 @@ dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Anal
 dart.analysis.server.error=Encountered a Dart Analysis Server error.
 dart.error.file.instructions=Please append the contents of:\n\
   file://{0}
-dart.report.options.do.not.ask=Don't ask again this session

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1692,16 +1692,7 @@ public class DartAnalysisServerService implements Disposable {
           DartFeedbackBuilder builder = DartFeedbackBuilder.getFeedbackBuilder();
           final boolean[] reportIt = new boolean[1];
           myDisruptionCount++;
-          ApplicationManager.getApplication().invokeAndWait(() -> {
-            reportIt[0] = builder.showQuery(DartBundle.message("dart.analysis.server.error"));
-            myPreviousTime = System.currentTimeMillis();
-          });
-          if (reportIt[0]) {
-            builder.sendFeedback(myProject, errorMessage, debugLog);
-          }
-          else {
-            LOG.warn(errorMessage);
-          }
+          builder.showNotification(DartBundle.message("dart.analysis.server.error"), myProject, errorMessage, debugLog);
         });
       }
       myPreviousMessage = errorMessage;


### PR DESCRIPTION
@alexander-doroshko This changes the UI for the server bug reporter to use a non-modal balloon instead of the modal query.  It plays nicely with the standard IntelliJ error balloon: they stack and disappear in the order they appear. You can make it go away faster by clicking the X or you can click the link to open the github issue tracker in your web browser.

Thanks for changing the Dart SDK to be project-specific!