### PR TITLE
Newlining

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/editor/DartLineIndentProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/editor/DartLineIndentProvider.java
@@ -42,6 +42,7 @@ public class DartLineIndentProvider extends JavaLikeLangLineIndentProvider {
     SYNTAX_MAP.put(DartTokenTypesSets.MULTI_LINE_DOC_COMMENT_START, DocBlockStart);
     SYNTAX_MAP.put(DartTokenTypes.COMMA, Comma);
     SYNTAX_MAP.put(DartTokenTypesSets.SINGLE_LINE_COMMENT, LineComment);
+    SYNTAX_MAP.put(DartTokenTypesSets.SINGLE_LINE_DOC_COMMENT, LineComment);
   }
 
   @Nullable
@@ -63,7 +64,7 @@ public class DartLineIndentProvider extends JavaLikeLangLineIndentProvider {
   @Nullable
   @Override
   protected IndentCalculator getIndent(@NotNull Project project, @NotNull Editor editor, @Nullable Language language, int offset) {
-    if (getPosition(editor, offset).matchesRule(position -> position.before().isAt(LeftParenthesis))) {
+    if (getPosition(editor, offset).matchesRule(position -> position.before().isAtAnyOf(LeftParenthesis, Comma))) {
       // Need to skip a common logic and force formatter-based line indent provider to work, because
       // there may be different indents inside parentheses, see https://github.com/dart-lang/dart_style/issues/551
       return null;

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlock.java
@@ -33,19 +33,21 @@ public class DartBlock extends AbstractBlock implements BlockWithParent {
   private final DartWrappingProcessor myWrappingProcessor;
   private final DartAlignmentProcessor myAlignmentProcessor;
   private final CodeStyleSettings mySettings;
+  private final DartBlockContext myContext;
   private Wrap myChildWrap = null;
   private final Indent myIndent;
   private BlockWithParent myParent;
   private List<DartBlock> mySubDartBlocks;
 
-  protected DartBlock(ASTNode node, Wrap wrap, Alignment alignment, CodeStyleSettings settings) {
+  protected DartBlock(ASTNode node, Wrap wrap, Alignment alignment, CodeStyleSettings settings, DartBlockContext context) {
     super(node, wrap, alignment);
     mySettings = settings;
-    myIndentProcessor = new DartIndentProcessor(mySettings.getCommonSettings(DartLanguage.INSTANCE));
-    mySpacingProcessor = new DartSpacingProcessor(node, mySettings.getCommonSettings(DartLanguage.INSTANCE));
-    myWrappingProcessor = new DartWrappingProcessor(node, mySettings.getCommonSettings(DartLanguage.INSTANCE));
-    myAlignmentProcessor = new DartAlignmentProcessor(node, mySettings.getCommonSettings(DartLanguage.INSTANCE));
-    myIndent = myIndentProcessor.getChildIndent(myNode);
+    myContext = context;
+    myIndentProcessor = new DartIndentProcessor(context.getDartSettings());
+    mySpacingProcessor = new DartSpacingProcessor(node, context.getDartSettings());
+    myWrappingProcessor = new DartWrappingProcessor(node, context.getDartSettings());
+    myAlignmentProcessor = new DartAlignmentProcessor(node, context.getDartSettings());
+    myIndent = myIndentProcessor.getChildIndent(myNode, context.getMode());
   }
 
   @Override
@@ -66,7 +68,7 @@ public class DartBlock extends AbstractBlock implements BlockWithParent {
     final ArrayList<Block> tlChildren = new ArrayList<>();
     for (ASTNode childNode = getNode().getFirstChildNode(); childNode != null; childNode = childNode.getTreeNext()) {
       if (FormatterUtil.containsWhiteSpacesOnly(childNode)) continue;
-      final DartBlock childBlock = new DartBlock(childNode, createChildWrap(childNode), createChildAlignment(childNode), mySettings);
+      final DartBlock childBlock = new DartBlock(childNode, createChildWrap(childNode), createChildAlignment(childNode), mySettings, myContext);
       childBlock.setParent(this);
       tlChildren.add(childBlock);
     }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlockContext.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartBlockContext.java
@@ -1,0 +1,30 @@
+package com.jetbrains.lang.dart.ide.formatter;
+
+import com.intellij.formatting.FormattingMode;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.jetbrains.lang.dart.DartLanguage;
+
+public class DartBlockContext {
+  private final CodeStyleSettings mySettings;
+  private final FormattingMode myMode;
+  private final CommonCodeStyleSettings myDartSettings;
+
+  public DartBlockContext(CodeStyleSettings settings, FormattingMode mode) {
+    mySettings = settings;
+    myMode = mode;
+    myDartSettings = settings.getCommonSettings(DartLanguage.INSTANCE);
+  }
+
+  public CodeStyleSettings getSettings() {
+    return mySettings;
+  }
+
+  public CommonCodeStyleSettings getDartSettings() {
+    return myDartSettings;
+  }
+
+  public FormattingMode getMode() {
+    return myMode;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartFormattingModelBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartFormattingModelBuilder.java
@@ -1,31 +1,46 @@
 package com.jetbrains.lang.dart.ide.formatter;
 
-import com.intellij.formatting.FormattingModel;
-import com.intellij.formatting.FormattingModelBuilder;
+import com.intellij.formatting.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.psi.formatter.DocumentBasedFormattingModel;
 import com.jetbrains.lang.dart.psi.DartFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class DartFormattingModelBuilder implements FormattingModelBuilder {
+public class DartFormattingModelBuilder implements FormattingModelBuilderEx {
   @NotNull
   @Override
   public FormattingModel createModel(@NotNull final PsiElement element, @NotNull final CodeStyleSettings settings) {
-    // element can be DartFile, DartEmbeddedContent, DartExpressionCodeFragment
-    final PsiFile psiFile = element.getContainingFile();
-    final ASTNode rootNode = psiFile instanceof DartFile ? psiFile.getNode() : element.getNode();
-    final DartBlock rootBlock = new DartBlock(rootNode, null, null, settings);
-    return new DocumentBasedFormattingModel(rootBlock, element.getProject(), settings, psiFile.getFileType(), psiFile);
+    return createModel(element, settings, FormattingMode.REFORMAT);
   }
 
   @Nullable
   @Override
   public TextRange getRangeAffectingIndent(PsiFile file, int offset, ASTNode elementAtOffset) {
+    return null;
+  }
+
+  @NotNull
+  @Override
+  public FormattingModel createModel(@NotNull PsiElement element, @NotNull CodeStyleSettings settings, @NotNull FormattingMode mode) {
+    // element can be DartFile, DartEmbeddedContent, DartExpressionCodeFragment
+    final PsiFile psiFile = element.getContainingFile();
+    final ASTNode rootNode = psiFile instanceof DartFile ? psiFile.getNode() : element.getNode();
+    final DartBlockContext context = new DartBlockContext(settings, mode);
+    final DartBlock rootBlock = new DartBlock(rootNode, null, null, settings, context);
+    return new DocumentBasedFormattingModel(rootBlock, element.getProject(), settings, psiFile.getFileType(), psiFile);
+  }
+
+  @Nullable
+  @Override
+  public CommonCodeStyleSettings.IndentOptions getIndentOptionsToUse(@NotNull PsiFile file,
+                                                                     @NotNull FormatTextRanges ranges,
+                                                                     @NotNull CodeStyleSettings settings) {
     return null;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -1,5 +1,6 @@
 package com.jetbrains.lang.dart.ide.formatter;
 
+import com.intellij.formatting.FormattingMode;
 import com.intellij.formatting.Indent;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
@@ -31,7 +32,7 @@ public class DartIndentProcessor {
     this.settings = settings;
   }
 
-  public Indent getChildIndent(final ASTNode node) {
+  public Indent getChildIndent(final ASTNode node, final FormattingMode mode) {
     final IElementType elementType = node.getElementType();
     final ASTNode prevSibling = UsefulPsiTreeUtil.getPrevSiblingSkipWhiteSpacesAndComments(node);
     final IElementType prevSiblingType = prevSibling == null ? null : prevSibling.getElementType();
@@ -125,11 +126,16 @@ public class DartIndentProcessor {
       return Indent.getNormalIndent();
     }
     if (parentType == ARGUMENTS) {
-      ASTNode last = node.getLastChildNode();
-      if (last == null) return Indent.getNoneIndent();
+      if (mode == FormattingMode.ADJUST_INDENT_ON_ENTER) {
+        ASTNode last = node.getLastChildNode();
+        if (last == null) return Indent.getNoneIndent();
         return last.getElementType() == COMMA && superParentType != METADATA
-             ? Indent.getNormalIndent()
-             : Indent.getNoneIndent();
+               ? Indent.getNormalIndent()
+               : Indent.getNoneIndent();
+      }
+      else {
+        return Indent.getNoneIndent();
+      }
     }
     if (parentType == ARGUMENT_LIST) {
       // see https://github.com/dart-lang/dart_style/issues/551
@@ -246,7 +252,8 @@ public class DartIndentProcessor {
     return Indent.getNoneIndent();
   }
 
-  private static boolean isBetweenBraces(@NotNull final ASTNode node) {
+  private static boolean isBetweenBraces(@NotNull
+                                         final ASTNode node) {
     final IElementType elementType = node.getElementType();
     if (elementType == LBRACE || elementType == RBRACE) return false;
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/formatter/DartIndentProcessor.java
@@ -125,7 +125,11 @@ public class DartIndentProcessor {
       return Indent.getNormalIndent();
     }
     if (parentType == ARGUMENTS) {
-      return Indent.getNoneIndent();
+      ASTNode last = node.getLastChildNode();
+      if (last == null) return Indent.getNoneIndent();
+        return last.getElementType() == COMMA && superParentType != METADATA
+             ? Indent.getNormalIndent()
+             : Indent.getNoneIndent();
     }
     if (parentType == ARGUMENT_LIST) {
       // see https://github.com/dart-lang/dart_style/issues/551

--- a/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -596,6 +596,23 @@ public class DartTypingTest extends DartCodeInsightFixtureTestCase {
                  "}");
   }
 
+  public void testEnterInMultiLineArg() {
+    doTypingTest('\n',
+                 "m(l) {\n" +
+                 "  return new X(\n" +
+                 "    1,\n" +
+                 "    2,<caret>\n" +
+                 "  );\n" +
+                 "}",
+                 "m(l) {\n" +
+                 "  return new X(\n" +
+                 "    1,\n" +
+                 "    2,\n" +
+                 "    <caret>\n" +
+                 "  );\n" +
+                 "}");
+  }
+
   public void testEnterInMultilineString() {
     doTypingTest('\n', "var a = <caret>r''' ''';", "var a = \n<caret>r''' ''';"); // indent should be here, need to fix formatter
     doTypingTest('\n', "var a = r<caret>''' ''';", "var a = r\n<caret>''' ''';"); // indent should be here, need to fix formatter


### PR DESCRIPTION
@alexander-doroshko Make the Dart indenter be sensitive to whether it is doing a wholesale reformat or a local indentation computation. It should reduce GC churn slightly, too.

This gives us the framework to resolve other discrepancies between what the formatter does and what the user expects while typing code, once we identify them.

This PR should get cherry-picked into the current plugin release, if possible.

/cc @devoncarew 