### PR TITLE
Move list expressions

### DIFF
--- a/Dart/testData/statementMover/ListExpr1.dart
+++ b/Dart/testData/statementMover/ListExpr1.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),<caret>
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr1_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr1_afterDown.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr1_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr1_afterUp.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr2.dart
+++ b/Dart/testData/statementMover/ListExpr2.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        <caret>new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr2_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr2_afterDown.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr2_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr2_afterUp.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr3.dart
+++ b/Dart/testData/statementMover/ListExpr3.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),<caret>
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr3_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr3_afterDown.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr3_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr3_afterUp.dart
@@ -1,0 +1,75 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[0], style: descriptionStyle),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr4.dart
+++ b/Dart/testData/statementMover/ListExpr4.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        <caret>new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr4_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr4_afterDown.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr4_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr4_afterUp.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr5.dart
+++ b/Dart/testData/statementMover/ListExpr5.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        <caret>new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr5_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr5_afterDown.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr5_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr5_afterUp.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr6.dart
+++ b/Dart/testData/statementMover/ListExpr6.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        <caret>new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr6_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr6_afterDown.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr6_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr6_afterUp.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr7.dart
+++ b/Dart/testData/statementMover/ListExpr7.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        <caret>new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr7_afterDown.dart
+++ b/Dart/testData/statementMover/ListExpr7_afterDown.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testData/statementMover/ListExpr7_afterUp.dart
+++ b/Dart/testData/statementMover/ListExpr7_afterUp.dart
@@ -1,0 +1,74 @@
+class Bogus {
+  x() {
+    var destination, descriptionStyle, buttonStyle;
+
+    return new Bingo(
+      nothing: "some long string that will prevent lines collapsing here",
+      children: <Widget>[
+        new Text(destination.description[0], style: descriptionStyle),
+        new Text(destination.description[1], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[ // list
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARP', style: buttonStyle),
+              ),
+              new Text('EXPLODE', style: buttonStyle),
+            ],
+          ),
+        ),
+        new Text(destination.description[2], style: descriptionStyle),
+        new Flexible(
+          child: new Row(
+            justifyContent: FlexJustifyContent.start,
+            alignItems: FlexAlignItems.end,
+            children: <Widget>[
+              new Padding(
+                padding: const EdgeDims.only(right: 16.0),
+                child: new Text('SHARE', style: buttonStyle),
+              ),
+              new Text('EXPLORE', style: buttonStyle),
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class Bingo {
+  Bingo({nothing: null, children: null});
+}
+
+class Widget {}
+
+class Text extends Widget {
+  Text(a, {style: null});
+}
+
+class Flexible extends Widget {
+  Flexible({child: null});
+}
+
+class Padding extends Widget {
+  Padding({padding: null, child: null});
+}
+
+class Row extends Widget {
+  Row({justifyContent: null, alignItems: null, children: null});
+}
+
+class FlexJustifyContent {
+  static const start = null;
+}
+
+class FlexAlignItems {
+  static const end = null;
+}
+
+class EdgeDims {
+  const EdgeDims.only({right: null});
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
@@ -37,4 +37,32 @@ public class DartStatementMoverTest extends DartCodeMoverTest {
   public void testMinimalMain() {
     doTest(); // Ensure nothing happens even when destLine == 0
   }
+
+  public void testListExpr1() {
+    doTest();
+  }
+
+  public void testListExpr2() {
+    doTest();
+  }
+
+  public void testListExpr3() {
+    doTest();
+  }
+
+  public void testListExpr4() {
+    doTest();
+  }
+
+  public void testListExpr5() {
+    doTest();
+  }
+
+  public void testListExpr6() {
+    doTest(); // Do nothing when no trailing comma
+  }
+
+  public void testListExpr7() {
+    doTest(); // Do nothing when no trailing comma
+  }
 }


### PR DESCRIPTION
@alexander-doroshko Extend _Move Statement_ to allow rearranging full- and multi-line elements of lists. This is common in Flutter. Next will be extending to move elements in argument lists.

I see I forgot to delete ```/*&& down*/```. I will remove in the next PR.