### PR TITLE
Fix for https://youtrack.jetbrains.com/issue/RUBY-18536

### DIFF
--- a/markdown/src/org/intellij/plugins/markdown/lang/psi/impl/MarkdownHeaderImpl.java
+++ b/markdown/src/org/intellij/plugins/markdown/lang/psi/impl/MarkdownHeaderImpl.java
@@ -3,6 +3,7 @@ package org.intellij.plugins.markdown.lang.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.navigation.DelegatingItemPresentation;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
 import org.intellij.plugins.markdown.lang.MarkdownElementTypes;
@@ -32,7 +33,7 @@ public class MarkdownHeaderImpl extends MarkdownCompositePsiElementBase {
           return null;
         }
         else {
-          return contentHolder.getText();
+          return StringUtil.trim(contentHolder.getText());
         }
       }
     };

--- a/markdown/src/org/intellij/plugins/markdown/structureView/MarkdownStructureElement.java
+++ b/markdown/src/org/intellij/plugins/markdown/structureView/MarkdownStructureElement.java
@@ -1,30 +1,34 @@
 package org.intellij.plugins.markdown.structureView;
 
+import com.intellij.ide.IdeBundle;
 import com.intellij.ide.structureView.StructureViewTreeElement;
+import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
 import com.intellij.ide.util.treeView.smartTree.SortableTreeElement;
-import com.intellij.ide.util.treeView.smartTree.TreeElement;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.navigation.LocationPresentation;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.impl.source.PsiFileImpl;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
-import com.intellij.util.ArrayUtil;
 import org.intellij.plugins.markdown.lang.MarkdownElementTypes;
 import org.intellij.plugins.markdown.lang.MarkdownTokenTypeSets;
-import org.intellij.plugins.markdown.lang.psi.impl.MarkdownBlockQuoteImpl;
-import org.intellij.plugins.markdown.lang.psi.impl.MarkdownCompositePsiElementBase;
 import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile;
-import org.intellij.plugins.markdown.lang.psi.impl.MarkdownListItemImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
-public class MarkdownStructureElement implements StructureViewTreeElement, SortableTreeElement {
+import static org.intellij.plugins.markdown.lang.MarkdownTokenTypeSets.*;
+
+public class MarkdownStructureElement extends PsiTreeElementBase<PsiElement> implements  SortableTreeElement, LocationPresentation {
+
   private static final ItemPresentation DUMMY_PRESENTATION = new MarkdownBasePresentation() {
+
     @Nullable
     @Override
     public String getPresentableText() {
@@ -38,107 +42,149 @@ public class MarkdownStructureElement implements StructureViewTreeElement, Sorta
     }
   };
 
-  static final TokenSet PRESENTABLE_TYPES =
-    TokenSet.orSet(MarkdownTokenTypeSets.HEADERS,
-                   TokenSet.create(MarkdownElementTypes.PARAGRAPH,
-                                   MarkdownElementTypes.ORDERED_LIST,
-                                   MarkdownElementTypes.UNORDERED_LIST,
-                                   MarkdownElementTypes.LIST_ITEM,
-                                   MarkdownElementTypes.BLOCK_QUOTE,
-                                   MarkdownElementTypes.CODE_FENCE,
-                                   MarkdownElementTypes.CODE_BLOCK,
-                                   MarkdownElementTypes.HTML_BLOCK,
-                                   MarkdownElementTypes.LINK_DEFINITION,
-                                   MarkdownElementTypes.TABLE,
-                                   MarkdownElementTypes.TABLE_HEADER,
-                                   MarkdownElementTypes.TABLE_ROW,
-                                   MarkdownElementTypes.TABLE_CELL));
+  static final TokenSet PRESENTABLE_TYPES = TokenSet.orSet(MarkdownTokenTypeSets.HEADERS);
 
-  @NotNull
-  private final PsiElement myElement;
-
-  public MarkdownStructureElement(@NotNull PsiElement element) {
-    myElement = element;
+  MarkdownStructureElement(@NotNull PsiElement element) {
+    super(element);
   }
 
-  @Override
-  public Object getValue() {
-    return myElement;
-  }
-
-  @Override
-  public void navigate(boolean requestFocus) {
-    if (myElement instanceof NavigationItem) {
-      ((NavigationItem)myElement).navigate(requestFocus);
-    }
-  }
 
   @Override
   public boolean canNavigate() {
-    return myElement instanceof NavigationItem && ((NavigationItem)myElement).canNavigate();
+    return getElement() instanceof NavigationItem && ((NavigationItem) getElement()).canNavigate();
   }
 
   @Override
   public boolean canNavigateToSource() {
-    return myElement instanceof NavigationItem && ((NavigationItem)myElement).canNavigateToSource();
+    return getElement() instanceof NavigationItem && ((NavigationItem) getElement()).canNavigateToSource();
   }
+
+
+  @Override
+  public void navigate(boolean requestFocus) {
+    if (getElement() instanceof NavigationItem) {
+      ((NavigationItem) getElement()).navigate(requestFocus);
+    }
+  }
+
 
   @NotNull
   @Override
   public String getAlphaSortKey() {
-    return StringUtil.notNullize(myElement instanceof NavigationItem ? ((NavigationItem)myElement).getName() : null);
+    return StringUtil.notNullize(getElement() instanceof NavigationItem ?
+            ((NavigationItem) getElement()).getName() : null);
+  }
+
+  @Override
+  public boolean isSearchInLocationString() {
+    return true;
+  }
+
+  @Nullable
+  @Override
+  public String getPresentableText() {
+    final PsiElement tag = getElement();
+    if (tag == null) {
+      return IdeBundle.message("node.structureview.invalid");
+    }
+    return getPresentation().getPresentableText();
+  }
+
+
+  @Override
+  public String getLocationString() {
+    return getPresentation().getLocationString();
   }
 
   @NotNull
   @Override
   public ItemPresentation getPresentation() {
-    final ItemPresentation result = getPresentationImpl();
-
-    if (result != null) {
-      return result;
-    }
-    else {
-      return DUMMY_PRESENTATION;
-    }
-  }
-
-  @Nullable
-  private ItemPresentation getPresentationImpl() {
-    if (myElement instanceof PsiFileImpl) {
-      return ((PsiFileImpl)myElement).getPresentation();
-    }
-    if (myElement instanceof NavigationItem) {
-      return ((NavigationItem)myElement).getPresentation();
+    if (getElement() instanceof PsiFileImpl) {
+      ItemPresentation filePresent = ((PsiFileImpl) getElement()).getPresentation();
+      return filePresent!=null ? filePresent : DUMMY_PRESENTATION;
     }
 
-    return null;
+    if (getElement() instanceof NavigationItem) {
+      final ItemPresentation itemPresent = ((NavigationItem) getElement()).getPresentation();
+      if (itemPresent != null) {
+        return itemPresent;
+      }
+    }
+
+    return DUMMY_PRESENTATION;
   }
 
   @NotNull
   @Override
-  public TreeElement[] getChildren() {
-    final PsiElement parentToTraverse = myElement instanceof MarkdownFile ? myElement.getFirstChild() : myElement;
+  public Collection<StructureViewTreeElement> getChildrenBase() {
+    final List<StructureViewTreeElement> childrenElements = new ArrayList<StructureViewTreeElement>();
 
-    if (hasTrivialChild(parentToTraverse)) return EMPTY_ARRAY;
+    final PsiElement myElement = getElement();
+    if(myElement==null) return childrenElements;
 
-    List<TreeElement> result = new ArrayList<>();
-    for (PsiElement element : parentToTraverse.getChildren()) {
-      final IElementType type = element.getNode().getElementType();
-      if (!PRESENTABLE_TYPES.contains(type)) {
-        continue;
+    PsiElement nextSibling = myElement instanceof MarkdownFile ?
+            myElement.getFirstChild().getFirstChild() :
+            myElement.getNextSibling();
+
+    PsiElement maxContentLevel = null;
+
+    while (nextSibling != null) {
+      if (isSameLevelOrHigher(nextSibling, myElement)) {
+        break;
       }
 
-      result.add(new MarkdownStructureElement(element));
+      if (maxContentLevel == null || isSameLevelOrHigher(nextSibling, maxContentLevel)) {
+        maxContentLevel = nextSibling;
+
+        final IElementType type = nextSibling.getNode().getElementType();
+        if (PRESENTABLE_TYPES.contains(type)) {
+          childrenElements.add(new MarkdownStructureElement(nextSibling));
+        }
+      }
+
+      nextSibling = nextSibling.getNextSibling();
     }
-    return ArrayUtil.toObjectArray(result, TreeElement.class);
+
+    return childrenElements;
   }
 
-  public static boolean hasTrivialChild(@NotNull PsiElement parentToTraverse) {
-    if ((parentToTraverse instanceof MarkdownListItemImpl
-         || parentToTraverse instanceof MarkdownBlockQuoteImpl) &&
-        ((MarkdownCompositePsiElementBase)parentToTraverse).hasTrivialChildren()) {
-      return true;
+
+  private boolean isSameLevelOrHigher(@NotNull PsiElement psiA, @NotNull PsiElement psiB) {
+    IElementType typeA = psiA.getNode().getElementType();
+    IElementType typeB = psiB.getNode().getElementType();
+
+    return headerLevel(typeA) <= headerLevel(typeB);
+  }
+
+
+  private int headerLevel(@NotNull IElementType curLevelType) {
+    for (int i = 0; i < HEADER_ORDER.size(); i++) {
+      if (HEADER_ORDER.get(i).contains(curLevelType)) {
+        return i;
+      }
     }
-    return false;
+
+    // not a header so return lowest level
+    return Integer.MAX_VALUE;
+  }
+
+
+  private static final List<TokenSet> HEADER_ORDER = Arrays.asList(
+          TokenSet.create(MarkdownElementTypes.MARKDOWN_FILE_ELEMENT_TYPE),
+          HEADER_LEVEL_1_SET,
+          HEADER_LEVEL_2_SET,
+          HEADER_LEVEL_3_SET,
+          HEADER_LEVEL_4_SET,
+          HEADER_LEVEL_5_SET,
+          HEADER_LEVEL_6_SET);
+
+  @Override
+  public String getLocationPrefix() {
+    return " ";
+  }
+
+  @Override
+  public String getLocationSuffix() {
+    return "";
   }
 }

--- a/markdown/src/org/intellij/plugins/markdown/structureView/MarkdownStructureViewFactory.java
+++ b/markdown/src/org/intellij/plugins/markdown/structureView/MarkdownStructureViewFactory.java
@@ -8,10 +8,17 @@ import com.intellij.lang.PsiStructureViewFactory;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
+import org.intellij.plugins.markdown.lang.MarkdownElementTypes;
+import org.intellij.plugins.markdown.lang.psi.impl.MarkdownFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.intellij.plugins.markdown.structureView.MarkdownStructureElement.PRESENTABLE_TYPES;
+
 public class MarkdownStructureViewFactory implements PsiStructureViewFactory {
+
+
   @Nullable
   @Override
   public StructureViewBuilder getStructureViewBuilder(final PsiFile psiFile) {
@@ -29,19 +36,21 @@ public class MarkdownStructureViewFactory implements PsiStructureViewFactory {
       super(psiFile, editor, new MarkdownStructureElement(psiFile));
     }
 
+    @Nullable
     @Override
-    protected boolean isSuitable(PsiElement element) {
-      if (element == null) {
-        return false;
+    protected Object findAcceptableElement(PsiElement element) {
+      // walk up the psi-tree until we find an element from the structure view
+      while (element != null && !PRESENTABLE_TYPES.contains(element.getNode().getElementType())) {
+        IElementType elementType = element.getParent().getNode().getElementType();
+
+        if (elementType.equals(MarkdownElementTypes.MARKDOWN_FILE)) {
+          element = element.getPrevSibling();
+        } else {
+          element = element.getParent();
+        }
       }
-      if (!MarkdownStructureElement.PRESENTABLE_TYPES.contains(element.getNode().getElementType())) {
-        return false;
-      }
-      final PsiElement parent = element.getParent();
-      if (MarkdownStructureElement.hasTrivialChild(parent)) {
-        return false;
-      }
-      return true;
+
+      return element;
     }
   }
 }


### PR DESCRIPTION
The PR implements a new structure view model that shows sections in a cascading tree. This seems to most natural way to visualize the structure of a Markdown file.

Before: 
![image](https://cloud.githubusercontent.com/assets/200952/22541264/a01d8976-e925-11e6-91fd-7df7116bde79.png)

WIth PR:
![image](https://cloud.githubusercontent.com/assets/200952/22541316/eaf216ba-e925-11e6-84e4-7d1022b09a88.png)

Let me know if there are any questions