### PR TITLE
Fix WEB-25079

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/moveCode/DartStatementMover.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/moveCode/DartStatementMover.java
@@ -435,6 +435,12 @@ public class DartStatementMover extends LineMover {
         return true;
       }
     }
+    if (parent instanceof DartForStatement) {
+      PsiElement body = DartPsiImplUtil.getForBody((DartForStatement)parent);
+      if (isSameStatement(element, body)) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/util/DartPsiImplUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartPsiImplUtil.java
@@ -265,6 +265,11 @@ public class DartPsiImplUtil {
   }
 
   @Nullable
+  public static PsiElement getForBody(@NotNull DartForStatement forStatement) {
+    return forStatement.getLastChild();
+  }
+
+  @Nullable
   public static PsiElement getWhileBody(@NotNull DartWhileStatement whileStatement) {
     return getBranchAfter(getCondition(whileStatement));
   }

--- a/Dart/testData/statementMover/IntoFor1.dart
+++ b/Dart/testData/statementMover/IntoFor1.dart
@@ -1,0 +1,6 @@
+main() {
+  <caret>print("hello");
+  for (int i = 0; i < 10; i++) {
+    print("hi");
+  }
+}

--- a/Dart/testData/statementMover/IntoFor1_afterDown.dart
+++ b/Dart/testData/statementMover/IntoFor1_afterDown.dart
@@ -1,0 +1,6 @@
+main() {
+  for (int i = 0; i < 10; i++) {
+    print("hello");
+    print("hi");
+  }
+}

--- a/Dart/testData/statementMover/IntoFor1_afterUp.dart
+++ b/Dart/testData/statementMover/IntoFor1_afterUp.dart
@@ -1,0 +1,6 @@
+main() {
+  print("hello");
+  for (int i = 0; i < 10; i++) {
+    print("hi");
+  }
+}

--- a/Dart/testData/statementMover/IntoFor2.dart
+++ b/Dart/testData/statementMover/IntoFor2.dart
@@ -1,0 +1,6 @@
+main() {
+  for (int i = 0; i < 10; i++) {
+    print("hi");
+  }
+  <caret>print("hello");
+}

--- a/Dart/testData/statementMover/IntoFor2_afterDown.dart
+++ b/Dart/testData/statementMover/IntoFor2_afterDown.dart
@@ -1,0 +1,6 @@
+main() {
+  for (int i = 0; i < 10; i++) {
+    print("hi");
+  }
+  print("hello");
+}

--- a/Dart/testData/statementMover/IntoFor2_afterUp.dart
+++ b/Dart/testData/statementMover/IntoFor2_afterUp.dart
@@ -1,0 +1,6 @@
+main() {
+  for (int i = 0; i < 10; i++) {
+    print("hi");
+    print("hello");
+  }
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
@@ -65,4 +65,12 @@ public class DartStatementMoverTest extends DartCodeMoverTest {
   public void testListExpr7() {
     doTest(); // Do nothing when no trailing comma
   }
+
+  public void testIntoFor1() {
+    doTest();
+  }
+
+  public void testIntoFor2() {
+    doTest();
+  }
 }


### PR DESCRIPTION
@alexander-doroshko The reported problem was fixed earlier. This patch fixes the over-jump error you noticed. I didn't include a tests of for-statements with single-statement bodies because I believe it is already doing the right thing: moving past the entire statement.