### PR TITLE
fold exception traces

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartConsoleFolding.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartConsoleFolding.java
@@ -14,16 +14,23 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class DartConsoleFolding extends ConsoleFolding {
 
   private static final String DART_MARKER = SystemInfo.isWindows ? "\\bin\\dart.exe " : "/bin/dart ";
   private static final String TEST_RUNNER_MARKER = "pub.dart.snapshot run test:test -r json "; // see DartTestRunningState.startProcess()
 
+  //  #1      main (file:///Users/foo/projects/bar/tool/generate.dart:30:3)
+  private static final Pattern EXCEPTION_PREFIX = Pattern.compile("#\\d+ +[^ ].*");
+
   @Override
   public boolean shouldFoldLine(@NotNull final String line) {
     // fold Dart VM command line created in DartCommandLineRunningState.createCommandLine() together with the following "Observatory listening on ..." message
     if (line.startsWith(DartConsoleFilter.OBSERVATORY_LISTENING_ON)) return true;
+
+    // check for a stack trace
+    if (EXCEPTION_PREFIX.matcher(line).matches()) return true;
 
     final int index = line.indexOf(DART_MARKER);
     if (index < 0) return false;
@@ -47,6 +54,11 @@ public class DartConsoleFolding extends ConsoleFolding {
 
     if (lines.size() == 1 && lines.get(0).contains(TEST_RUNNER_MARKER)) {
       return foldTestRunnerCommand(lines.get(0));
+    }
+
+    // exception folding
+    if (EXCEPTION_PREFIX.matcher(lines.get(0)).matches()) {
+      return " [" + lines.size() + " " + StringUtil.pluralize("frame", lines.size()) + "]";
     }
 
     final String fullText = StringUtil.join(lines, "\n");


### PR DESCRIPTION
Fold exception traces in the console. This takes potentially very long traces, and folds the `#0 ...` lines.

before:
<img width="422" alt="screen shot 2017-02-07 at 3 04 53 pm" src="https://cloud.githubusercontent.com/assets/1269969/22717984/ed54d84e-ed52-11e6-9927-818ddfca58aa.png">

after:
<img width="209" alt="screen shot 2017-02-07 at 4 27 16 pm" src="https://cloud.githubusercontent.com/assets/1269969/22717971/e14e1e0c-ed52-11e6-9910-878be8d62289.png">

@alexander-doroshko 
