### PR TITLE
change the label of the dart format action; add a keybinding

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -231,7 +231,7 @@
             text="Restart Dart Analysis Server" description="Restart Dart Analysis Server">
     </action>
     <action id="Dart.DartStyle" class="com.jetbrains.lang.dart.ide.actions.DartStyleAction"
-            text="Reformat with Dart Style" description="Format your Dart code using the dart_style formatter">
+            text="Reformat Code with dartfmt" description="Format your Dart code using dartfmt (the Dart Style formatter)">
       <add-to-group group-id="CodeFormatGroup" anchor="last"/>
       <add-to-group group-id="EditorPopupMenu" relative-to-action="EditorPopupMenu1" anchor="after"/>
       <add-to-group group-id="ProjectViewPopupMenuModifyGroup" anchor="before" relative-to-action="$Delete"/>

--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -234,19 +234,19 @@ dart.sort.members.action.name=Sort Members in Dart File
 dart.sort.members.action.name.ellipsis=Sort Members in Dart files...
 dart.sort.members.action.description=Sort members in your Dart files
 dart.sort.members.hint.failed=Failed to sort members
-dart.sort.members.hint.already.good=Sort members: the code is already properly sorted
+dart.sort.members.hint.already.good=Sort members: members already sorted
 dart.sort.members.hint.success=The code has been successfully sorted
 dart.sort.members.files.no.dart.files=No applicable Dart files were found.
 dart.sort.members.files.dialog.question=Run Dart member sorter on {0, choice, 1#the selected file|2#the {0} selected Dart files}?
 
-dart.style.action.name=Reformat with Dart Style
-dart.style.action.name.ellipsis=Reformat with Dart Style...
-dart.style.action.description=Format your Dart code using the dart_style formatter
-dart.style.hint.failed=Failed to reformat the code with Dart Style
-dart.style.hint.already.good=Dart Style: the code is already properly formatted
-dart.style.hint.success=The code has been successfully reformatted with Dart Style
+dart.style.action.name=Reformat Code with dartfmt
+dart.style.action.name.ellipsis=Reformat Code with dartfmt...
+dart.style.action.description=Format your Dart code using dartfmt (the Dart Style formatter)
+dart.style.hint.failed=Failed to reformat code
+dart.style.hint.already.good=Reformat: no formatting changes
+dart.style.hint.success=Reformat: code successfully formatted
 dart.style.files.no.dart.files=No applicable Dart files were found.
-dart.style.files.dialog.question=Run Dart Style formatter on {0, choice, 1#the selected file|2#the {0} selected Dart files}?
+dart.style.files.dialog.question=Run dartfmt on {0, choice, 1#the selected file|2#the {0} selected Dart files}?
 organized.directives=organized directives
 
 failed.to.create.file.0.1=Failed to create file {0}:\n{1}


### PR DESCRIPTION
- change the label of the dart format action; we use `dartfmt` now, in order to reduce any confusion about which formatter will run dartfmt
- add a keybinding. The normal formatting keybinding on a mac is cmd-alt-L. I looked at using shift-cmd-alt-L for the dart formatter, but unfortunately that binding is already used (to open a formatting dialog). I used ctrl-alt-L; this was not bound to anything, and mirrors the similar organize imports action's binding (ctrl-alt-O). On a mac, the action does respond to the keybinding (and the normal IntelliJ formatter responds to the cmd-alt-L). In the keybinding pres dialog however, I do see that IntelliJ thinks the dartfmt action is bound to both ctrl-alt-L and cmd-alt-L. Not sure how to clear that up.

Hopefully address much of https://youtrack.jetbrains.com/issue/WEB-25401.

<img width="460" alt="screen shot 2017-02-12 at 2 26 23 pm" src="https://cloud.githubusercontent.com/assets/1269969/22866713/c5b3a10e-f12f-11e6-9612-a0d30452d203.png">

@jwren @alexander-doroshko 