### PR TITLE
display casual frames when debugging

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -13,6 +13,7 @@ import com.intellij.xdebugger.evaluation.XDebuggerEvaluator;
 import com.intellij.xdebugger.frame.XExecutionStack;
 import com.intellij.xdebugger.frame.XStackFrame;
 import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartAsyncMarkerFrame;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceEvaluator;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceStackFrame;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
@@ -33,6 +34,9 @@ public class VmServiceWrapper implements Disposable {
 
   public static final Logger LOG = Logger.getInstance(VmServiceWrapper.class.getName());
   private static final long RESPONSE_WAIT_TIMEOUT = 3000; // millis
+
+  // TODO: Remove this compile time flag once the VM implementation and wire protocol are final.
+  private static final boolean RENDER_CAUSAL_FRAMES = true;
 
   private final DartVmServiceDebugProcess myDebugProcess;
   private final VmService myVmService;
@@ -339,15 +343,34 @@ public class VmServiceWrapper implements Disposable {
       public void received(final Stack vmStack) {
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
           InstanceRef exceptionToAddToFrame = exception;
-          final List<XStackFrame> result = new ArrayList<>(vmStack.getFrames().size());
-          for (Frame vmFrame : vmStack.getFrames()) {
-            final DartVmServiceStackFrame stackFrame =
-              new DartVmServiceStackFrame(myDebugProcess, isolateId, vmFrame, exceptionToAddToFrame);
-            result.add(stackFrame);
 
-            if (!stackFrame.isInDartSdkPatchFile()) {
-              // exception (if any) is added to the frame where debugger stops and to the upper frames
-              exceptionToAddToFrame = null;
+          ElementList<Frame> vmFrames;
+          if (RENDER_CAUSAL_FRAMES) {
+            vmFrames = vmStack.getAsyncCausalFrames();
+            if (vmFrames == null) {
+              vmFrames = vmStack.getFrames();
+            }
+          } else {
+            vmFrames = vmStack.getFrames();
+          }
+
+          final List<XStackFrame> result = new ArrayList<>(vmFrames.size());
+          for (Frame vmFrame : vmFrames) {
+            if (vmFrame.getKind() == FrameKind.kAsyncSuspensionMarker) {
+              // Render an asynchronous gap.
+              final XStackFrame markerFrame = new DartAsyncMarkerFrame();
+              result.add(markerFrame);
+            }
+            else {
+              final DartVmServiceStackFrame stackFrame =
+                new DartVmServiceStackFrame(myDebugProcess, isolateId, vmFrame, exceptionToAddToFrame);
+
+              result.add(stackFrame);
+
+              if (!stackFrame.isInDartSdkPatchFile()) {
+                // The exception (if any) is added to the frame where debugger stops and to the upper frames.
+                exceptionToAddToFrame = null;
+              }
             }
           }
           container.addStackFrames(firstFrameIndex == 0 ? result : result.subList(firstFrameIndex, result.size()), true);

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -356,7 +356,7 @@ public class VmServiceWrapper implements Disposable {
 
           final List<XStackFrame> result = new ArrayList<>(vmFrames.size());
           for (Frame vmFrame : vmFrames) {
-            if (vmFrame.getKind() == FrameKind.kAsyncSuspensionMarker) {
+            if (vmFrame.getKind() == FrameKind.AsyncSuspensionMarker) {
               // Render an asynchronous gap.
               final XStackFrame markerFrame = new DartAsyncMarkerFrame();
               result.add(markerFrame);

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartAsyncMarkerFrame.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartAsyncMarkerFrame.java
@@ -1,0 +1,20 @@
+package com.jetbrains.lang.dart.ide.runner.server.vmService.frame;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ui.ColoredTextContainer;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.xdebugger.frame.XStackFrame;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A XStackFrame used to render a separator between two sets of async stack frames.
+ */
+public class DartAsyncMarkerFrame extends XStackFrame {
+  public DartAsyncMarkerFrame() {
+  }
+
+  public void customizePresentation(@NotNull ColoredTextContainer component) {
+    component.append("<asynchronous gap>", SimpleTextAttributes.EXCLUDED_ATTRIBUTES);
+    component.setIcon(AllIcons.General.SeparatorH);
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceStackFrame.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceStackFrame.java
@@ -56,7 +56,7 @@ public class DartVmServiceStackFrame extends XStackFrame {
   @Override
   public void customizePresentation(@NotNull final ColoredTextContainer component) {
     final String name = StringUtil.trimEnd(myVmFrame.getCode().getName(), "="); // trim setter postfix
-    final boolean causal = myVmFrame.getKind() == FrameKind.kAsyncCausal;
+    final boolean causal = myVmFrame.getKind() == FrameKind.AsyncCausal;
     component.append(name, causal ? SimpleTextAttributes.REGULAR_ITALIC_ATTRIBUTES : SimpleTextAttributes.REGULAR_ATTRIBUTES);
 
     if (mySourcePosition != null) {

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -70,7 +70,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 5;
+  public static final int versionMinor = 6;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
@@ -139,6 +139,8 @@ public class Event extends Response {
    *  - PauseBreakpoint
    */
   public ElementList<Breakpoint> getPauseBreakpoints() {
+    if (json.get("pauseBreakpoints") == null) return null;
+    
     return new ElementList<Breakpoint>(json.get("pauseBreakpoints").getAsJsonArray()) {
       @Override
       protected Breakpoint basicGet(JsonArray array, int index) {
@@ -162,6 +164,8 @@ public class Event extends Response {
    * This is provided for the TimelineEvents event.
    */
   public ElementList<TimelineEvent> getTimelineEvents() {
+    if (json.get("timelineEvents") == null) return null;
+    
     return new ElementList<TimelineEvent>(json.get("timelineEvents").getAsJsonArray()) {
       @Override
       protected TimelineEvent basicGet(JsonArray array, int index) {

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
@@ -40,6 +40,8 @@ public class Frame extends Response {
    * Note: this is not yet part of the public API and should not be considered stable.
    */
   public FrameKind getKind() {
+    if (json.get("kind") == null) return null;
+
     String name = json.get("kind").getAsString();
     try {
       return FrameKind.valueOf(name);

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
@@ -25,23 +25,20 @@ public class Frame extends Response {
   }
 
   public CodeRef getCode() {
-    return new CodeRef((JsonObject) json.get("code"));
+    return json.get("code") == null ? null : new CodeRef((JsonObject) json.get("code"));
   }
 
   public FuncRef getFunction() {
-    return new FuncRef((JsonObject) json.get("function"));
+    return json.get("function") == null ? null : new FuncRef((JsonObject) json.get("function"));
   }
 
   public int getIndex() {
     return json.get("index") == null ? -1 : json.get("index").getAsInt();
   }
 
-  /**
-   * Note: this is not yet part of the public API and should not be considered stable.
-   */
   public FrameKind getKind() {
     if (json.get("kind") == null) return null;
-
+    
     String name = json.get("kind").getAsString();
     try {
       return FrameKind.valueOf(name);

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
@@ -36,11 +36,25 @@ public class Frame extends Response {
     return json.get("index") == null ? -1 : json.get("index").getAsInt();
   }
 
+  /**
+   * Note: this is not yet part of the public API and should not be considered stable.
+   */
+  public FrameKind getKind() {
+    String name = json.get("kind").getAsString();
+    try {
+      return FrameKind.valueOf(name);
+    } catch (IllegalArgumentException e) {
+      return FrameKind.Unknown;
+    }
+  }
+
   public SourceLocation getLocation() {
-    return new SourceLocation((JsonObject) json.get("location"));
+    return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
   }
 
   public ElementList<BoundVariable> getVars() {
+    if (json.get("vars") == null) return null;
+    
     return new ElementList<BoundVariable>(json.get("vars").getAsJsonArray()) {
       @Override
       protected BoundVariable basicGet(JsonArray array, int index) {

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FrameKind.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FrameKind.java
@@ -20,11 +20,11 @@ package org.dartlang.vm.service.element;
  */
 public enum FrameKind {
 
-  kAsyncCausal,
+  AsyncCausal,
 
-  kAsyncSuspensionMarker,
+  AsyncSuspensionMarker,
 
-  kRegular,
+  Regular,
 
   /**
    * Represents a value returned by the VM but unknown to this client

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FrameKind.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FrameKind.java
@@ -15,18 +15,19 @@ package org.dartlang.vm.service.element;
 
 // This is a generated file.
 
-import com.google.gson.JsonObject;
+/**
+ * A {@link FrameKind} is used to distinguish different kinds of {@link Frame} objects.
+ */
+public enum FrameKind {
 
-public class ReloadReport extends Response {
+  kAsyncCausal,
 
-  public ReloadReport(JsonObject json) {
-    super(json);
-  }
+  kAsyncSuspensionMarker,
+
+  kRegular,
 
   /**
-   * Did the reload succeed or fail?
+   * Represents a value returned by the VM but unknown to this client
    */
-  public boolean getSuccess() {
-    return json.get("success").getAsBoolean();
-  }
+  Unknown
 }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
@@ -35,6 +35,8 @@ public class Instance extends Obj {
    *  - Map
    */
   public ElementList<MapAssociation> getAssociations() {
+    if (json.get("associations") == null) return null;
+    
     return new ElementList<MapAssociation>(json.get("associations").getAsJsonArray()) {
       @Override
       protected MapAssociation basicGet(JsonArray array, int index) {
@@ -144,6 +146,8 @@ public class Instance extends Obj {
    * @return one of <code>ElementList<InstanceRef></code> or <code>ElementList<Sentinel></code>
    */
   public ElementList<InstanceRef> getElements() {
+    if (json.get("elements") == null) return null;
+    
     return new ElementList<InstanceRef>(json.get("elements").getAsJsonArray()) {
       @Override
       protected InstanceRef basicGet(JsonArray array, int index) {
@@ -156,6 +160,8 @@ public class Instance extends Obj {
    * The fields of this Instance.
    */
   public ElementList<BoundField> getFields() {
+    if (json.get("fields") == null) return null;
+    
     return new ElementList<BoundField>(json.get("fields").getAsJsonArray()) {
       @Override
       protected BoundField basicGet(JsonArray array, int index) {

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
@@ -24,6 +24,20 @@ public class Stack extends Response {
     super(json);
   }
 
+  /**
+   * Note: this is not yet part of the public API and should not be considered stable.
+   */
+  public ElementList<Frame> getAsyncCausalFrames() {
+    if (json.get("asyncCausalFrames") == null) return null;
+    
+    return new ElementList<Frame>(json.get("asyncCausalFrames").getAsJsonArray()) {
+      @Override
+      protected Frame basicGet(JsonArray array, int index) {
+        return new Frame(array.get(index).getAsJsonObject());
+      }
+    };
+  }
+
   public ElementList<Frame> getFrames() {
     return new ElementList<Frame>(json.get("frames").getAsJsonArray()) {
       @Override

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
@@ -24,9 +24,6 @@ public class Stack extends Response {
     super(json);
   }
 
-  /**
-   * Note: this is not yet part of the public API and should not be considered stable.
-   */
   public ElementList<Frame> getAsyncCausalFrames() {
     if (json.get("asyncCausalFrames") == null) return null;
     


### PR DESCRIPTION
- display casual frames when debugging

This upgrades the service protocol lib to expose the new casual frame info, adds marker frames on the stack at async boundaries, and renders older ('casual') frames in italics - we have location info for these frames, but not variable information.

<img width="365" alt="screen shot 2017-02-12 at 3 30 52 pm" src="https://cloud.githubusercontent.com/assets/1269969/22867976/22945412-f145-11e6-8316-46451c32fa28.png">

We want a tiny bit more time for the implementation to bake - which is why there's a compile time constant to enable/disable. But I don't expect there to be any big changes.

@alexander-doroshko 