### PR TITLE
add an action to open the analysis server's diagnostic page

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -267,6 +267,9 @@ analysis.server.status.unknown.desc=Analysis server is running but has been busy
 analysis.server.status.bad.text=Analyzer: Submit Feedback (analysis process not active)
 analysis.server.status.bad.desc=Analysis server needs to be restarted
 
+analysis.server.show.diagnostics.text=View analyzer diagnostics...
+analysis.server.show.diagnostics.error=Error opening diagnostics page
+
 dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Analyzer Feedback from IntelliJ\n\n\
   ## Version information\n\n\
   - `IDEA {0}`\n\

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -926,6 +926,17 @@ public class DartAnalysisServerService implements Disposable {
     return results;
   }
 
+  public void diagnostic_getServerPort(GetServerPortConsumer consumer) {
+    final AnalysisServer server = myServer;
+    if (server == null) {
+      consumer.onError(new RequestError(ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE,
+                                        "The analysis server is not running."));
+    }
+    else {
+      server.diagnostic_getServerPort(consumer);
+    }
+  }
+
   /**
    * If server responds in less than <code>GET_FIXES_TIMEOUT</code> then this method can be considered synchronous: when exiting this method
    * <code>consumer</code> is already notified. Otherwise this method is async.

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerDiagnosticsAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerDiagnosticsAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.lang.dart.ide.errorTreeView;
+
+import com.google.dart.server.GetServerPortConsumer;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
+import org.dartlang.analysis.server.protocol.RequestError;
+
+public class AnalysisServerDiagnosticsAction extends DumbAwareAction {
+  private static final String GROUP_DISPLAY_ID = "Dart Analysis Server";
+
+  public AnalysisServerDiagnosticsAction() {
+    super(DartBundle.message("analysis.server.show.diagnostics.text"));
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final Project project = e.getProject();
+    if (project == null) return;
+
+    // Get the current analysis server.
+    DartAnalysisServerService server = DartAnalysisServerService.getInstance(project);
+
+    // Ask it for the diagnostics port.
+    server.diagnostic_getServerPort(new GetServerPortConsumer() {
+      @Override
+      public void computedServerPort(int port) {
+        // Open a new browser page.
+        final String url = "http://localhost:" + port + "/status";
+        OpenDartObservatoryUrlAction.openUrlInChromeFamilyBrowser(url);
+      }
+
+      @Override
+      public void onError(RequestError requestError) {
+        Notification notification = new Notification(
+          GROUP_DISPLAY_ID,
+          DartBundle.message("analysis.server.show.diagnostics.error"),
+          requestError.getMessage(),
+          NotificationType.ERROR);
+        Notifications.Bus.notify(notification);
+      }
+    });
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetServerPortConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetServerPortConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017, the Dart project authors.
+ * 
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server;
+
+import org.dartlang.analysis.server.protocol.ContextData;
+import org.dartlang.analysis.server.protocol.RequestError;
+
+import java.util.List;
+
+public interface GetServerPortConsumer extends Consumer {
+  public void computedServerPort(int port);
+  public void onError(RequestError requestError);
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -298,6 +298,15 @@ public interface AnalysisServer {
   public void diagnostic_getDiagnostics(GetDiagnosticsConsumer consumer);
 
   /**
+   * {@code diagnostic.getServerPort}
+   *
+   * Return the port of the diagnostic web server. If the server is not running this call will start
+   * the server. If unable to start the diagnostic web server, this call will return an error of
+   * DEBUG_PORT_COULD_NOT_BE_OPENED.
+   */
+  public void diagnostic_getServerPort(GetServerPortConsumer consumer);
+
+  /**
    * {@code edit.format}
    *
    * Format the contents of a single file. The currently selected region of text is passed in so that

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -258,6 +258,11 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     // TODO(scheglov) implement
   }
 
+  public void diagnostic_getServerPort(GetServerPortConsumer consumer) {
+    String id = generateUniqueId();
+    sendRequestToServer(id, RequestUtilities.generateDiagnosticGetServerPort(id), consumer);
+  }
+
   @Override
   public void edit_format(String file, int selectionOffset, int selectionLength, int lineLength, FormatConsumer consumer) {
     String id = generateUniqueId();
@@ -535,8 +540,10 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
       requestError = processErrorResponse(errorObject);
       listener.requestError(requestError);
     }
+
     // handle result
     JsonObject resultObject = (JsonObject)response.get("result");
+
     //
     // Analysis Domain
     //
@@ -546,7 +553,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     //
     // Completion Domain
     //
-    if (consumer instanceof GetSuggestionsConsumer) {
+    else if (consumer instanceof GetSuggestionsConsumer) {
       new CompletionIdProcessor((GetSuggestionsConsumer)consumer).process(resultObject, requestError);
     }
     //
@@ -614,6 +621,12 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
       new MapUriProcessor((MapUriConsumer)consumer).process(resultObject, requestError);
     }
     //
+    // Diagnostic Domain
+    //
+    else if (consumer instanceof GetServerPortConsumer) {
+      new GetServerPortProcessor((GetServerPortConsumer)consumer).process(resultObject, requestError);
+    }
+    //
     // Server Domain
     //
     else if (consumer instanceof GetVersionConsumer) {
@@ -622,6 +635,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     else if (consumer instanceof BasicConsumer) {
       ((BasicConsumer)consumer).received();
     }
+
     synchronized (consumerMapLock) {
       consumerMap.remove(idString);
     }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/GetServerPortProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/GetServerPortProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.CreateContextConsumer;
+import com.google.dart.server.GetServerPortConsumer;
+import com.google.gson.JsonObject;
+import org.dartlang.analysis.server.protocol.RequestError;
+
+public class GetServerPortProcessor extends ResultProcessor {
+  private GetServerPortConsumer consumer;
+
+  public GetServerPortProcessor(GetServerPortConsumer consumer) {
+    this.consumer = consumer;
+  }
+
+  public void process(JsonObject resultObject, RequestError requestError) {
+    if (resultObject != null) {
+      try {
+        int port = resultObject.get("port").getAsInt();
+        consumer.computedServerPort(port);
+      }
+      catch (Exception exception) {
+        requestError = generateRequestError(exception);
+      }
+    }
+    if (requestError != null) {
+      consumer.onError(requestError);
+    }
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -95,6 +95,9 @@ public class RequestUtilities {
   private static final String METHOD_EXECUTION_MAP_URI = "execution.mapUri";
   private static final String METHOD_EXECUTION_SET_SUBSCRIPTIONS = "execution.setSubscriptions";
 
+  // Diagnostic domain
+  private static final String METHOD_DIAGNOSTIC_GET_SERVER_PORT = "diagnostic.getServerPort";
+
   /**
    * Flag indicating whether requests should include the time at which the request is made.
    */
@@ -806,6 +809,10 @@ public class RequestUtilities {
    */
   public static JsonObject generateServerShutdown(String idValue) {
     return buildJsonObjectRequest(idValue, METHOD_SERVER_SHUTDOWN);
+  }
+
+  public static JsonObject generateDiagnosticGetServerPort(String idValue) {
+    return buildJsonObjectRequest(idValue, METHOD_DIAGNOSTIC_GET_SERVER_PORT);
   }
 
   /**

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/HoverInformation.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/HoverInformation.java
@@ -95,6 +95,11 @@ public class HoverInformation {
   private final String elementKind;
 
   /**
+   * True if the referenced element is deprecated.
+   */
+  private final Boolean isDeprecated;
+
+  /**
    * A human-readable description of the parameter corresponding to the expression being hovered
    * over. This data is omitted if the location is not in an argument to a function.
    */
@@ -115,7 +120,7 @@ public class HoverInformation {
   /**
    * Constructor for {@link HoverInformation}.
    */
-  public HoverInformation(int offset, int length, String containingLibraryPath, String containingLibraryName, String containingClassDescription, String dartdoc, String elementDescription, String elementKind, String parameter, String propagatedType, String staticType) {
+  public HoverInformation(int offset, int length, String containingLibraryPath, String containingLibraryName, String containingClassDescription, String dartdoc, String elementDescription, String elementKind, Boolean isDeprecated, String parameter, String propagatedType, String staticType) {
     this.offset = offset;
     this.length = length;
     this.containingLibraryPath = containingLibraryPath;
@@ -124,6 +129,7 @@ public class HoverInformation {
     this.dartdoc = dartdoc;
     this.elementDescription = elementDescription;
     this.elementKind = elementKind;
+    this.isDeprecated = isDeprecated;
     this.parameter = parameter;
     this.propagatedType = propagatedType;
     this.staticType = staticType;
@@ -142,6 +148,7 @@ public class HoverInformation {
         ObjectUtilities.equals(other.dartdoc, dartdoc) &&
         ObjectUtilities.equals(other.elementDescription, elementDescription) &&
         ObjectUtilities.equals(other.elementKind, elementKind) &&
+        ObjectUtilities.equals(other.isDeprecated, isDeprecated) &&
         ObjectUtilities.equals(other.parameter, parameter) &&
         ObjectUtilities.equals(other.propagatedType, propagatedType) &&
         ObjectUtilities.equals(other.staticType, staticType);
@@ -158,10 +165,11 @@ public class HoverInformation {
     String dartdoc = jsonObject.get("dartdoc") == null ? null : jsonObject.get("dartdoc").getAsString();
     String elementDescription = jsonObject.get("elementDescription") == null ? null : jsonObject.get("elementDescription").getAsString();
     String elementKind = jsonObject.get("elementKind") == null ? null : jsonObject.get("elementKind").getAsString();
+    Boolean isDeprecated = jsonObject.get("isDeprecated") == null ? null : jsonObject.get("isDeprecated").getAsBoolean();
     String parameter = jsonObject.get("parameter") == null ? null : jsonObject.get("parameter").getAsString();
     String propagatedType = jsonObject.get("propagatedType") == null ? null : jsonObject.get("propagatedType").getAsString();
     String staticType = jsonObject.get("staticType") == null ? null : jsonObject.get("staticType").getAsString();
-    return new HoverInformation(offset, length, containingLibraryPath, containingLibraryName, containingClassDescription, dartdoc, elementDescription, elementKind, parameter, propagatedType, staticType);
+    return new HoverInformation(offset, length, containingLibraryPath, containingLibraryName, containingClassDescription, dartdoc, elementDescription, elementKind, isDeprecated, parameter, propagatedType, staticType);
   }
 
   public static List<HoverInformation> fromJsonArray(JsonArray jsonArray) {
@@ -228,6 +236,13 @@ public class HoverInformation {
   }
 
   /**
+   * True if the referenced element is deprecated.
+   */
+  public Boolean getIsDeprecated() {
+    return isDeprecated;
+  }
+
+  /**
    * The length of the range of characters that encompasses the cursor position and has the same
    * hover information as the cursor position.
    */
@@ -278,6 +293,7 @@ public class HoverInformation {
     builder.append(dartdoc);
     builder.append(elementDescription);
     builder.append(elementKind);
+    builder.append(isDeprecated);
     builder.append(parameter);
     builder.append(propagatedType);
     builder.append(staticType);
@@ -305,6 +321,9 @@ public class HoverInformation {
     }
     if (elementKind != null) {
       jsonObject.addProperty("elementKind", elementKind);
+    }
+    if (isDeprecated != null) {
+      jsonObject.addProperty("isDeprecated", isDeprecated);
     }
     if (parameter != null) {
       jsonObject.addProperty("parameter", parameter);
@@ -338,6 +357,8 @@ public class HoverInformation {
     builder.append(elementDescription + ", ");
     builder.append("elementKind=");
     builder.append(elementKind + ", ");
+    builder.append("isDeprecated=");
+    builder.append(isDeprecated + ", ");
     builder.append("parameter=");
     builder.append(parameter + ", ");
     builder.append("propagatedType=");

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/NavigationTarget.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/NavigationTarget.java
@@ -54,12 +54,12 @@ public class NavigationTarget {
   private final int fileIndex;
 
   /**
-   * The offset of the region from which the user can navigate.
+   * The offset of the region to which the user can navigate.
    */
   private final int offset;
 
   /**
-   * The length of the region from which the user can navigate.
+   * The length of the region to which the user can navigate.
    */
   private final int length;
 
@@ -143,14 +143,14 @@ public class NavigationTarget {
   }
 
   /**
-   * The length of the region from which the user can navigate.
+   * The length of the region to which the user can navigate.
    */
   public int getLength() {
     return length;
   }
 
   /**
-   * The offset of the region from which the user can navigate.
+   * The offset of the region to which the user can navigate.
    */
   public int getOffset() {
     return offset;

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RefactoringProblemSeverity.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RefactoringProblemSeverity.java
@@ -23,12 +23,33 @@ package org.dartlang.analysis.server.protocol;
  */
 public class RefactoringProblemSeverity {
 
+  /**
+   * A minor code problem. No example, because it is not used yet.
+   */
   public static final String INFO = "INFO";
 
+  /**
+   * A minor code problem. For example names of local variables should be camel case and start with a
+   * lower case letter. Staring the name of a variable with an upper case is OK from the language
+   * point of view, but it is nice to warn the user.
+   */
   public static final String WARNING = "WARNING";
 
+  /**
+   * The refactoring technically can be performed, but there is a logical problem. For example the
+   * name of a local variable being extracted conflicts with another name in the scope, or duplicate
+   * parameter names in the method being extracted, or a conflict between a parameter name and a
+   * local variable, etc. In some cases the location of the problem is also provided, so the IDE can
+   * show user the location and the problem, and let the user decide whether she wants to perform the
+   * refactoring. For example the name conflict might be expected, and the user wants to fix it
+   * afterwards.
+   */
   public static final String ERROR = "ERROR";
 
+  /**
+   * A fatal error, which prevents performing the refactoring. For example the name of a local
+   * variable being extracted is not a valid identifier, or selection is not a valid expression.
+   */
   public static final String FATAL = "FATAL";
 
 }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RequestError.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RequestError.java
@@ -61,6 +61,13 @@ public class RequestError {
   /**
    * Constructor for {@link RequestError}.
    */
+  public RequestError(String code, String message) {
+    this(code, message, null);
+  }
+
+  /**
+   * Constructor for {@link RequestError}.
+   */
   public RequestError(String code, String message, String stackTrace) {
     this.code = code;
     this.message = message;

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RequestErrorCode.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RequestErrorCode.java
@@ -30,6 +30,11 @@ public class RequestErrorCode {
   public static final String CONTENT_MODIFIED = "CONTENT_MODIFIED";
 
   /**
+   * The server was unable to open a port for the diagnostic server.
+   */
+  public static final String DEBUG_PORT_COULD_NOT_BE_OPENED = "DEBUG_PORT_COULD_NOT_BE_OPENED";
+
+  /**
    * A request specified a FilePath which does not match a file in an analysis root, or the requested
    * operation is not available for the file.
    */


### PR DESCRIPTION
Add an action to open the analysis server's diagnostic page:
- rev the analysis server protocol library to the latest version
- add a gear action to the Dart Analysis view to open the analysis server's diagnostic page
- in the action, query the analysis server for its diagnostic server port; on the response, open a browser

<img width="253" alt="screen shot 2017-02-20 at 2 56 54 pm" src="https://cloud.githubusercontent.com/assets/1269969/23144621/b1e70324-f77d-11e6-9164-681a431bddfc.png">

@alexander-doroshko 