### PR TITLE
badge the analysis view when the analyzer is busy

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerMessages.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerMessages.java
@@ -1,0 +1,30 @@
+package com.jetbrains.lang.dart.analyzer;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A utility class to send and receive Dart analysis busy messages on the project message bus.
+ */
+public class DartAnalysisServerMessages {
+  public static final Topic<DartAnalysisNotifier> DART_ANALYSIS_TOPIC = Topic.create("dart.analysisBusy", DartAnalysisNotifier.class);
+
+  public interface DartAnalysisNotifier {
+    void analysisStarted();
+
+    void analysisFinished();
+  }
+
+  public static void sendAnalysisStarted(@NotNull Project project, boolean isStarting) {
+    final MessageBus bus = project.getMessageBus();
+    final DartAnalysisNotifier publisher = bus.syncPublisher(DART_ANALYSIS_TOPIC);
+    if (isStarting) {
+      publisher.analysisStarted();
+    }
+    else {
+      publisher.analysisFinished();
+    }
+  }
+}


### PR DESCRIPTION
We've had some feedback that the progress view when analyzing is too noisy. This is specifically when used with the new analysis driver, which - given changes to some highly referenced libraries - can re-compute the error state for large sets of libraries. This looks to the user like making small changes in some files produces a lot of analysis.

Some tweaks to how we present status to address this:
- badge the analysis view when the analyzer is busy; this uses the same mechanism as when the `Run` or `Debug` tool windows are active
- we show the first analysis reported by the analysis server using IntelliJ's progress mechanism; later progress is ignored. We reset state every time the analysis server restarts.

<img width="141" alt="screen shot 2017-02-24 at 12 20 29 pm" src="https://cloud.githubusercontent.com/assets/1269969/23322426/b8a34ec0-fa98-11e6-902c-cde22ae6baa4.png">

@alexander-doroshko @jwren 