### PR TITLE
Show a tooltip w/ analysis errors on run

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -205,6 +205,7 @@
     <runConfigurationProducer implementation="com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfigurationProducer"/>
 
     <programRunner implementation="com.jetbrains.lang.dart.ide.runner.DartRunner"/>
+    <stepsBeforeRunProvider implementation="com.jetbrains.lang.dart.ide.runner.DartValidateBeforeRunTaskProvider" id="dartValidateBeforeRun" />
 
     <localInspection bundle="com.jetbrains.lang.dart.DartBundle" key="outdated.dependencies.inspection.name"
                      groupName="Dart" enabledByDefault="true" level="WARNING" language="Dart"

--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -100,6 +100,7 @@ dart.override.method=Choose method to override
 dart.implement.method=Choose method to implement
 runner.command.line.configuration.name=Dart Command Line App
 runner.command.line.configuration.description=Dart Command Line Application
+runner.validate.before.run.name=Validate Dart analysis
 remote.debug.configuration.name=Dart Remote Debug
 remote.debug.configuration.description=Debug Remote Dart Command Line Application
 dart.project.description=Create project for use with the Dart programming language

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -610,6 +610,11 @@ public class DartAnalysisServerService implements Disposable {
   }
 
   @NotNull
+  public List<DartServerData.DartError> getErrors(@NotNull final Module module) {
+    return myServerData.getErrors(module);
+  }
+
+  @NotNull
   public List<DartServerData.DartError> getErrors(@NotNull final VirtualFile file) {
     return myServerData.getErrors(file);
   }

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -6,6 +6,8 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -178,6 +180,20 @@ public class DartServerData {
     if (hasChanges) {
       forceFileAnnotation(file, false);
     }
+  }
+
+  @NotNull
+  List<DartError> getErrors(@NotNull final Module module) {
+    final List<DartError> errors = new ArrayList<>();
+
+    for (String path : myErrorData.keySet()) {
+      final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
+      if (file != null && ModuleUtilCore.moduleContainsFile(module, file, false)) {
+        errors.addAll(myErrorData.get(path));
+      }
+    }
+
+    return errors;
   }
 
   @NotNull
@@ -460,6 +476,10 @@ public class DartServerData {
 
     public String getSeverity() {
       return mySeverity;
+    }
+
+    public boolean isError() {
+      return mySeverity == "ERROR";
     }
 
     @Nullable

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsView.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsView.java
@@ -19,6 +19,10 @@ import com.intellij.execution.runners.ExecutionUtil;
 import com.intellij.ide.projectView.ProjectView;
 import com.intellij.ide.projectView.impl.ProjectViewPane;
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.application.ApplicationManager;
@@ -45,6 +49,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +60,9 @@ import java.util.Map;
 )
 public class DartProblemsView implements PersistentStateComponent<DartProblemsViewSettings> {
   public static final String TOOLWINDOW_ID = DartBundle.message("dart.analysis.tool.window");
+
+  private static final NotificationGroup NOTIFICATION_GROUP =
+    NotificationGroup.toolWindowGroup(TOOLWINDOW_ID, TOOLWINDOW_ID, false);
 
   private static final int TABLE_REFRESH_PERIOD = 300;
 
@@ -72,6 +80,7 @@ public class DartProblemsView implements PersistentStateComponent<DartProblemsVi
   private boolean myAnalysisIsBusy;
 
   private int myFilesWithErrorsHash;
+  private Notification myNotification;
 
   private final Runnable myUpdateRunnable = new Runnable() {
     @Override
@@ -170,6 +179,29 @@ public class DartProblemsView implements PersistentStateComponent<DartProblemsVi
 
   public static DartProblemsView getInstance(@NotNull final Project project) {
     return ServiceManager.getService(project, DartProblemsView.class);
+  }
+
+  public void clearNotifications() {
+    if (myNotification != null) {
+      myNotification.expire();
+      myNotification = null;
+    }
+  }
+
+  public void showWarningNotification(@NotNull Project project, @NotNull String title, @NotNull String htmlContent, @Nullable Icon icon) {
+    clearNotifications();
+
+    myNotification = NOTIFICATION_GROUP.createNotification(
+      title, htmlContent, NotificationType.WARNING, new NotificationListener.Adapter() {
+        @Override
+        protected void hyperlinkActivated(@NotNull final Notification notification, @NotNull final HyperlinkEvent e) {
+          notification.expire();
+          ToolWindowManager.getInstance(project).getToolWindow(TOOLWINDOW_ID).activate(null);
+        }
+      }
+    );
+    myNotification.setIcon(icon);
+    myNotification.notify(project);
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartValidateBeforeRunTaskProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartValidateBeforeRunTaskProvider.java
@@ -1,0 +1,135 @@
+package com.jetbrains.lang.dart.ide.runner;
+
+import com.intellij.execution.BeforeRunTask;
+import com.intellij.execution.BeforeRunTaskProvider;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.analyzer.DartServerData;
+import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
+import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
+import com.jetbrains.lang.dart.ide.runner.base.DartRunConfigurationBase;
+import icons.DartIcons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DartValidateBeforeRunTaskProvider extends BeforeRunTaskProvider<DartValidateBeforeRunTaskProvider.DartValidateBeforeRunTask> {
+  public static final Key<DartValidateBeforeRunTask> ID = Key.create("DartValidate");
+
+  @SuppressWarnings({"unused", "FieldCanBeLocal"})
+  @NotNull private final Project myProject;
+
+  public DartValidateBeforeRunTaskProvider(@NotNull Project project) {
+    myProject = project;
+  }
+
+  @Override
+  public Key<DartValidateBeforeRunTask> getId() {
+    return ID;
+  }
+
+  @Override
+  public String getName() {
+    return DartBundle.message("runner.validate.before.run.name");
+  }
+
+  @Override
+  public String getDescription(DartValidateBeforeRunTask task) {
+    return DartBundle.message("runner.validate.before.run.name");
+  }
+
+  @Override
+  public Icon getIcon() {
+    return DartIcons.Dart_16;
+  }
+
+  @Override
+  public Icon getTaskIcon(DartValidateBeforeRunTask task) {
+    return DartIcons.Dart_16;
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public DartValidateBeforeRunTask createTask(RunConfiguration runConfiguration) {
+    // Only show for Dart run configurations.
+    if (!(runConfiguration instanceof DartRunConfigurationBase)) {
+      return null;
+    }
+
+    DartValidateBeforeRunTask task = new DartValidateBeforeRunTask();
+    task.setEnabled(true);
+    return task;
+  }
+
+  @Override
+  public boolean configureTask(RunConfiguration runConfiguration, DartValidateBeforeRunTask task) {
+    return false;
+  }
+
+  @Override
+  public boolean canExecuteTask(RunConfiguration configuration, DartValidateBeforeRunTask task) {
+    return true;
+  }
+
+  @Override
+  public boolean executeTask(DataContext context,
+                             RunConfiguration configuration,
+                             ExecutionEnvironment env,
+                             DartValidateBeforeRunTask task) {
+    if (!(configuration instanceof DartRunConfiguration)) {
+      return false;
+    }
+
+    final Project project = env.getProject();
+
+    final DartProblemsView problemsView = DartProblemsView.getInstance(project);
+    problemsView.clearNotifications();
+
+    final DartRunConfiguration dartRunConfiguration = (DartRunConfiguration)configuration;
+    final Module module = dartRunConfiguration.getRunnerParameters().getModule(project);
+    final String launchTitle = env.getRunnerAndConfigurationSettings() == null
+                               ? "Launching app"
+                               : "Launching " + env.getRunnerAndConfigurationSettings().getName();
+
+    if (module == null) {
+      return true;
+    }
+
+    // Collect module errors.
+    final DartAnalysisServerService analysisServerService = DartAnalysisServerService.getInstance(project);
+    List<DartServerData.DartError> errors = analysisServerService.getErrors(module);
+    errors = errors.stream().filter(DartServerData.DartError::isError).collect(Collectors.toList());
+
+    // If there are no 'error' level issues then exit.
+    if (errors.isEmpty()) {
+      return true;
+    }
+
+    final String content =
+      errors.size() + " analysis <a href=\"issues\">" + StringUtil.pluralize("issue", errors.size()) + "</a> found.";
+    problemsView.showWarningNotification(project, launchTitle, content, dartRunConfiguration.getIcon());
+
+    return true;
+  }
+
+  public static class DartValidateBeforeRunTask extends BeforeRunTask<DartValidateBeforeRunTask> {
+    public DartValidateBeforeRunTask() {
+      super(ID);
+    }
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
@@ -1,6 +1,9 @@
 package com.jetbrains.lang.dart.ide.runner.server;
 
 import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
@@ -149,6 +152,22 @@ public class DartCommandLineRunnerParameters implements Cloneable {
     }
 
     return dartFile;
+  }
+
+  @Nullable
+  public Module getModule(@NotNull Project project) {
+    try {
+      final VirtualFile file = getDartFileOrDirectory();
+      return ModuleUtilCore.findModuleForFile(file, project);
+    }
+    catch (RuntimeConfigurationError ignore) {
+      final Module[] modules = ModuleManager.getInstance(project).getModules();
+      if (modules.length == 1) {
+        return modules[0];
+      }
+    }
+
+    return null;
   }
 
   public void check(final @NotNull Project project) throws RuntimeConfigurationError {


### PR DESCRIPTION
When running a Dart app, if there are analysis errors in the containing module, show a tooltip on the Dart Analysis view telling the users about the issues.

<img width="240" alt="screen shot 2017-02-26 at 8 43 30 pm" src="https://cloud.githubusercontent.com/assets/1269969/23349027/87a3a518-fc64-11e6-9d68-230013650809.png">

The user can enable / disable this by adding or removing the Validate Dart analysis pre-launch task:

<img width="435" alt="screen shot 2017-02-26 at 8 43 05 pm" src="https://cloud.githubusercontent.com/assets/1269969/23349046/994fd57a-fc64-11e6-8eaf-4791b86a3503.png">
