### PR TITLE
increase the height of the table header

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.table.JTableHeader;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.KeyAdapter;
@@ -131,6 +132,9 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Data
     table.setShowHorizontalLines(false);
     table.setStriped(true);
     table.setRowHeight(table.getRowHeight() + JBUI.scale(4));
+
+    JTableHeader tableHeader = table.getTableHeader();
+    tableHeader.setPreferredSize(new Dimension(0, table.getRowHeight()));
 
     return table;
   }


### PR DESCRIPTION
- increase the height of the table header in the dart analysis tool window

from:

<img width="439" alt="screen shot 2017-02-28 at 6 10 32 pm" src="https://cloud.githubusercontent.com/assets/1269969/23443152/af9d9e9c-fde1-11e6-980c-10cf050eb3ed.png">

to:

<img width="531" alt="screen shot 2017-02-28 at 6 05 59 pm" src="https://cloud.githubusercontent.com/assets/1269969/23443151/af9ae210-fde1-11e6-88e1-88c1b52f2c52.png">

@alexander-doroshko 