### PR TITLE
Add surround-with-brackets for named args (to support Flutter)

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/surroundWith/DartExpressionSurroundDescriptor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/surroundWith/DartExpressionSurroundDescriptor.java
@@ -4,6 +4,7 @@ import com.intellij.lang.surroundWith.SurroundDescriptor;
 import com.intellij.lang.surroundWith.Surrounder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.ide.surroundWith.expression.DartWithBracketsExpressionSurrounder;
 import com.jetbrains.lang.dart.ide.surroundWith.expression.DartWithNotParenthesisExpressionSurrounder;
 import com.jetbrains.lang.dart.ide.surroundWith.expression.DartWithParenthesisExpressionSurrounder;
 import com.jetbrains.lang.dart.psi.DartExpression;
@@ -26,7 +27,8 @@ public class DartExpressionSurroundDescriptor implements SurroundDescriptor {
   public Surrounder[] getSurrounders() {
     return new Surrounder[]{
       new DartWithParenthesisExpressionSurrounder(),
-      new DartWithNotParenthesisExpressionSurrounder()
+      new DartWithNotParenthesisExpressionSurrounder(),
+      new DartWithBracketsExpressionSurrounder(),
     };
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/surroundWith/expression/DartWithBracketsExpressionSurrounder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/surroundWith/expression/DartWithBracketsExpressionSurrounder.java
@@ -1,0 +1,33 @@
+package com.jetbrains.lang.dart.ide.surroundWith.expression;
+
+import com.intellij.psi.PsiElement;
+import com.jetbrains.lang.dart.psi.DartNamedArgument;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DartWithBracketsExpressionSurrounder extends DartWithExpressionSurrounder {
+
+  public boolean isApplicable(@NotNull PsiElement[] elements) {
+    // Limit this to named arguments; the intent is to convert a Flutter child: param to children:, which may involve creating red code.
+    return super.isApplicable(elements) && elements[0].getParent() instanceof DartNamedArgument;
+  }
+
+  @Override
+  public String getTemplateDescription() {
+    return "[expr]";
+  }
+
+  @Override
+  protected String getTemplateText(PsiElement expr) {
+    String text = expr.getText();
+    int nlIndex = text.lastIndexOf('\n');
+    if (nlIndex < 0) {
+      return "[" + expr.getText() + "]";
+    }
+    Matcher matcher = Pattern.compile("\\n", Pattern.MULTILINE).matcher(text);
+    String newText = matcher.replaceAll("\n  ");
+    return "[\n" + newText + ",]\n";
+  }
+}

--- a/Dart/testData/surroundWith/Brackets1.after.dart
+++ b/Dart/testData/surroundWith/Brackets1.after.dart
@@ -1,0 +1,13 @@
+class FX {
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      body: new Center(
+        child: [
+          new Text(
+            'Button tapped $_counter time${ _counter == 1 ? '' : 's' }.',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/Dart/testData/surroundWith/Brackets1.dart
+++ b/Dart/testData/surroundWith/Brackets1.dart
@@ -1,0 +1,11 @@
+class FX {
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      body: new Center(
+        child: <selection>new Text(
+          'Button tapped $_counter time${ _counter == 1 ? '' : 's' }.',
+        )</selection>,
+      ),
+    );
+  }
+}

--- a/Dart/testData/surroundWith/Brackets2.after.dart
+++ b/Dart/testData/surroundWith/Brackets2.after.dart
@@ -1,0 +1,9 @@
+class FX {
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      body: new Center(
+        child: [new Text('Got $_counter time${ _counter == 1 ? '' : 's' }.',)],
+      ),
+    );
+  }
+}

--- a/Dart/testData/surroundWith/Brackets2.dart
+++ b/Dart/testData/surroundWith/Brackets2.dart
@@ -1,0 +1,9 @@
+class FX {
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      body: new Center(
+        child: <selection>new Text('Got $_counter time${ _counter == 1 ? '' : 's' }.',)</selection>,
+      ),
+    );
+  }
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/DartSurroundWithTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/DartSurroundWithTest.java
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.generation.surroundWith.SurroundWithHandler;
 import com.intellij.lang.surroundWith.Surrounder;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.testFramework.LightPlatformCodeInsightTestCase;
+import com.jetbrains.lang.dart.ide.surroundWith.expression.DartWithBracketsExpressionSurrounder;
 import com.jetbrains.lang.dart.ide.surroundWith.expression.DartWithNotParenthesisExpressionSurrounder;
 import com.jetbrains.lang.dart.ide.surroundWith.expression.DartWithParenthesisExpressionSurrounder;
 import com.jetbrains.lang.dart.ide.surroundWith.statement.*;
@@ -90,5 +91,13 @@ public class DartSurroundWithTest extends LightPlatformCodeInsightTestCase {
 
   public void testWhile2() throws Throwable {
     doTest(new DartWithWhileSurrounder());
+  }
+
+  public void testBrackets1() throws Throwable {
+    doTest(new DartWithBracketsExpressionSurrounder());
+  }
+
+  public void testBrackets2() throws Throwable {
+    doTest(new DartWithBracketsExpressionSurrounder());
   }
 }


### PR DESCRIPTION
@alexander-doroshko I limited this to only being available when the selected expression is a named argument. It *will* make code red, unless it is already red because the user changed `child:` to `children:` first. And yes, we could be even more specific and check the name of the argument but I don't want to be too restrictive -- I don't have enough Flutter expertise to know if it could be useful for other arguments.

The one thing I don't like about this currently is that it adds bracket-surrounding at position #3 (for me). I'd prefer it at the bottom so it doesn't change the existing order.

/cc @devoncarew @pq 