### PR TITLE
make the errors/warnings/hints display more consistent

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
+++ b/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
@@ -91,9 +91,9 @@ public class DartSyntaxHighlighterColors {
   public static final TextAttributesKey ERROR =
     createTextAttributesKey(DART_ERROR, CodeInsightColors.ERRORS_ATTRIBUTES);
   public static final TextAttributesKey WARNING =
-    createTextAttributesKey(DART_WARNING, CodeInsightColors.WEAK_WARNING_ATTRIBUTES);
+    createTextAttributesKey(DART_WARNING, CodeInsightColors.WARNINGS_ATTRIBUTES);
   public static final TextAttributesKey HINT =
-    createTextAttributesKey(DART_HINT, CodeInsightColors.NOT_USED_ELEMENT_ATTRIBUTES);
+    createTextAttributesKey(DART_HINT, CodeInsightColors.WEAK_WARNING_ATTRIBUTES);
 
   public static final TextAttributesKey BLOCK_COMMENT =
     createTextAttributesKey(DART_BLOCK_COMMENT, DefaultLanguageHighlighterColors.BLOCK_COMMENT);

--- a/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
+++ b/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
@@ -91,9 +91,9 @@ public class DartSyntaxHighlighterColors {
   public static final TextAttributesKey ERROR =
     createTextAttributesKey(DART_ERROR, CodeInsightColors.ERRORS_ATTRIBUTES);
   public static final TextAttributesKey WARNING =
-    createTextAttributesKey(DART_WARNING, CodeInsightColors.ERRORS_ATTRIBUTES);
+    createTextAttributesKey(DART_WARNING, CodeInsightColors.WEAK_WARNING_ATTRIBUTES);
   public static final TextAttributesKey HINT =
-    createTextAttributesKey(DART_HINT, CodeInsightColors.WARNINGS_ATTRIBUTES);
+    createTextAttributesKey(DART_HINT, CodeInsightColors.NOT_USED_ELEMENT_ATTRIBUTES);
 
   public static final TextAttributesKey BLOCK_COMMENT =
     createTextAttributesKey(DART_BLOCK_COMMENT, DefaultLanguageHighlighterColors.BLOCK_COMMENT);


### PR DESCRIPTION
- make the errors/warnings/hints display more consistent

before (error / warning / hint):

<img width="234" alt="screen shot 2017-03-22 at 12 40 30 pm" src="https://cloud.githubusercontent.com/assets/1269969/24217675/e46c4696-0efd-11e7-8428-7f6b7c5c1540.png">

after:

<img width="223" alt="screen shot 2017-03-22 at 12 39 36 pm" src="https://cloud.githubusercontent.com/assets/1269969/24217683/ea79f70e-0efd-11e7-8690-b7e4026d1053.png">

- we now show warnings with a yellow underline
- hints have a similar presentation to dart errors and warnings (an underline, no background color changes)

@alexander-doroshko 