### PR TITLE
General cleanup in Dart plugin test package com.jetbrains.dart.analysisServer

### DIFF
--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import static com.jetbrains.lang.dart.DartTokenTypes.CALL_EXPRESSION;
 
 public class DartCallHierarchyTest extends HierarchyViewTestBase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -36,18 +35,19 @@ public class DartCallHierarchyTest extends HierarchyViewTestBase {
   }
 
   @Override
-  protected VirtualFile configureByFiles(@Nullable final File rawProjectRoot, @NotNull final VirtualFile... vFiles) throws IOException {
-    VirtualFile root = super.configureByFiles(rawProjectRoot, vFiles);
-    return DartTestUtils.configureNavigation(this, root, vFiles);
-  }
-
-  @Override
   protected String getBasePath() {
     return "analysisServer/callHierarchy/" + getTestName(false);
   }
 
+  @Override
   protected String getTestDataPath() {
     return DartTestUtils.BASE_TEST_DATA_PATH;
+  }
+
+  @Override
+  protected VirtualFile configureByFiles(@Nullable final File rawProjectRoot, @NotNull final VirtualFile... vFiles) throws IOException {
+    VirtualFile root = super.configureByFiles(rawProjectRoot, vFiles);
+    return DartTestUtils.configureNavigation(this, root, vFiles);
   }
 
   private void doCallHierarchyTest(final String className,

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartExtractLocalVariableRefactoringTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartExtractLocalVariableRefactoringTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.openapi.application.ApplicationManager;
@@ -33,15 +18,16 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 public class DartExtractLocalVariableRefactoringTest extends CodeInsightFixtureTestCase {
-  protected String getBasePath() {
-    return "/analysisServer/refactoring/extract/localVariable";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/extract/localVariable";
   }
 
   public void testExpressionAll() throws Throwable {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartExtractMethodRefactoringTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartExtractMethodRefactoringTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.openapi.application.ApplicationManager;
@@ -29,15 +14,16 @@ import org.dartlang.analysis.server.protocol.SourceChange;
 import org.jetbrains.annotations.NotNull;
 
 public class DartExtractMethodRefactoringTest extends CodeInsightFixtureTestCase {
-  protected String getBasePath() {
-    return "/analysisServer/refactoring/extract/method";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/extract/method";
   }
 
   public void testFunctionAll() throws Throwable {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartInlineLocalRefactoringTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartInlineLocalRefactoringTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.openapi.application.ApplicationManager;
@@ -28,15 +13,16 @@ import org.dartlang.analysis.server.protocol.SourceChange;
 import org.jetbrains.annotations.NotNull;
 
 public class DartInlineLocalRefactoringTest extends CodeInsightFixtureTestCase {
-  protected String getBasePath() {
-    return "/analysisServer/refactoring/inline/local";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/inline/local";
   }
 
   public void testTest() throws Throwable {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartInlineMethodRefactoringTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartInlineMethodRefactoringTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.openapi.application.ApplicationManager;
@@ -28,15 +13,16 @@ import org.dartlang.analysis.server.protocol.SourceChange;
 import org.jetbrains.annotations.NotNull;
 
 public class DartInlineMethodRefactoringTest extends CodeInsightFixtureTestCase {
-  protected String getBasePath() {
-    return "/analysisServer/refactoring/inline/method";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/inline/method";
   }
 
   public void testFunctionSingle() throws Throwable {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartMethodHierarchyTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartMethodHierarchyTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import static com.jetbrains.dart.analysisServer.DartCallHierarchyTest.findReference;
 
 public class DartMethodHierarchyTest extends HierarchyViewTestBase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -35,18 +34,19 @@ public class DartMethodHierarchyTest extends HierarchyViewTestBase {
   }
 
   @Override
-  protected VirtualFile configureByFiles(@Nullable final File rawProjectRoot, @NotNull final VirtualFile... vFiles) throws IOException {
-    VirtualFile root = super.configureByFiles(rawProjectRoot, vFiles);
-    return DartTestUtils.configureNavigation(this, root, vFiles);
-  }
-
-  @Override
   protected String getBasePath() {
     return "analysisServer/methodHierarchy/" + getTestName(false);
   }
 
+  @Override
   protected String getTestDataPath() {
     return DartTestUtils.BASE_TEST_DATA_PATH;
+  }
+
+  @Override
+  protected VirtualFile configureByFiles(@Nullable final File rawProjectRoot, @NotNull final VirtualFile... vFiles) throws IOException {
+    VirtualFile root = super.configureByFiles(rawProjectRoot, vFiles);
+    return DartTestUtils.configureNavigation(this, root, vFiles);
   }
 
   private void doMethodHierarchyTest(final String className,

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartOptimizeImportsTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartOptimizeImportsTest.java
@@ -7,7 +7,6 @@ import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
 public class DartOptimizeImportsTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -15,6 +14,7 @@ public class DartOptimizeImportsTest extends CodeInsightFixtureTestCase {
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
   }
 
+  @Override
   protected String getBasePath() {
     return "/analysisServer/optimizeImports";
   }
@@ -29,6 +29,6 @@ public class DartOptimizeImportsTest extends CodeInsightFixtureTestCase {
 
   public void testOptimizeImports() throws Throwable {
     final String testName = getTestName(false);
-    doTest(testName+ ".dart", testName + "_other1.dart", testName + "_other2.dart");
+    doTest(testName + ".dart", testName + "_other1.dart", testName + "_other2.dart");
   }
 }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartParameterInfoTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartParameterInfoTest.java
@@ -20,6 +20,7 @@ public class DartParameterInfoTest extends CodeInsightFixtureTestCase {
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
   }
 
+  @Override
   protected String getBasePath() {
     return "/paramInfo";
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -26,6 +25,7 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
   }
 
+  @Override
   protected String getBasePath() {
     return "/analysisServer/completion";
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.psi.PsiFile;
@@ -23,7 +8,6 @@ import com.jetbrains.lang.dart.util.DartTestUtils;
 import org.dartlang.analysis.server.protocol.HoverInformation;
 
 public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerFindUsagesTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerFindUsagesTest.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 public class DartServerFindUsagesTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerGotoSuperHandlerTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerGotoSuperHandlerTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.codeInsight.CodeInsightActionHandler;
@@ -23,16 +8,16 @@ import com.jetbrains.lang.dart.DartLanguage;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
 public class DartServerGotoSuperHandlerTest extends CodeInsightFixtureTestCase {
-
-  protected String getBasePath() {
-    return "/analysisServer/gotoSuper";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/gotoSuper";
   }
 
   public void testSuperClass() throws Throwable {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java
@@ -33,6 +33,7 @@ public class DartServerHighlightingTest extends CodeInsightFixtureTestCase {
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
   }
 
+  @Override
   protected String getBasePath() {
     return "/analysisServer/highlighting";
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerImplementationsMarkerProviderTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerImplementationsMarkerProviderTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.codeInsight.daemon.GutterMark;
@@ -27,17 +12,17 @@ import javax.swing.*;
 import java.util.List;
 
 public class DartServerImplementationsMarkerProviderTest extends CodeInsightFixtureTestCase {
-
-  protected String getBasePath() {
-    return "/analysisServer/implementationsMarker";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/implementationsMarker";
   }
 
   private void checkHasGutterAtCaret(final String expectedText, final Icon expectedIcon) {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerIntentionsTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerIntentionsTest.java
@@ -8,7 +8,6 @@ import com.jetbrains.lang.dart.util.DartTestUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class DartServerIntentionsTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -17,6 +16,7 @@ public class DartServerIntentionsTest extends CodeInsightFixtureTestCase {
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
   }
 
+  @Override
   protected String getBasePath() {
     return "/analysisServer/intentions";
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerOverrideMarkerProviderTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerOverrideMarkerProviderTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.google.common.collect.Lists;
@@ -27,17 +12,17 @@ import javax.swing.*;
 import java.util.List;
 
 public class DartServerOverrideMarkerProviderTest extends CodeInsightFixtureTestCase {
-
-  protected String getBasePath() {
-    return "/analysisServer/overrideMarker";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/overrideMarker";
   }
 
   private void doTest(final String expectedText, final Icon expectedIcon) {

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerQuickFixTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerQuickFixTest.java
@@ -13,7 +13,6 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 
 public class DartServerQuickFixTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -22,6 +21,7 @@ public class DartServerQuickFixTest extends CodeInsightFixtureTestCase {
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
   }
 
+  @Override
   protected String getBasePath() {
     return "/analysisServer/quickfix";
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerRenameTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerRenameTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2000-2015 JetBrains s.r.o.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.jetbrains.dart.analysisServer;
 
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -64,10 +49,6 @@ public class DartServerRenameTest extends CodeInsightFixtureTestCase {
     }
   }
 
-  protected String getBasePath() {
-    return "/analysisServer/refactoring/rename";
-  }
-
   @Override
   public void setUp() throws Exception {
     super.setUp();
@@ -75,6 +56,12 @@ public class DartServerRenameTest extends CodeInsightFixtureTestCase {
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
   }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/rename";
+  }
+
 
   private void doTest(@NotNull final String newName) {
     final ServerRenameRefactoring refactoring = createRenameRefactoring();

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerResolverTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerResolverTest.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class DartServerResolverTest extends CodeInsightFixtureTestCase {
-
   @Override
   public void setUp() throws Exception {
     super.setUp();

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartTypeHierarchyTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartTypeHierarchyTest.java
@@ -28,6 +28,7 @@ public class DartTypeHierarchyTest extends HierarchyViewTestBase {
     return "analysisServer/typeHierarchy/" + getTestName(false);
   }
 
+  @Override
   protected String getTestDataPath() {
     return DartTestUtils.BASE_TEST_DATA_PATH;
   }


### PR DESCRIPTION
Add missing overrides in com.jetbrains.dart.analysisServer, move setUp(), getBasePath() and getTestDataPath() to top of classes, and in that order.