### PR TITLE
In the Dart Plugin, add AnalysisError.correction information into the tooltip of the Dart Analysis errors and warnings

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.registry.Registry;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -36,6 +37,11 @@ public class DartProblem {
   @NotNull
   public String getErrorMessage() {
     return myAnalysisError.getMessage();
+  }
+
+  @NotNull
+  String getCorrectionMessage() {
+    return StringUtil.notNullize(myAnalysisError.getCorrection());
   }
 
   public String getSeverity() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsTableModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsTableModel.java
@@ -31,6 +31,8 @@ class DartProblemsTableModel extends ListTableModel<DartProblem> {
       final DartProblem problem = (DartProblem)value;
       setText(problem.getErrorMessage());
 
+      setToolTipText(generateToolTipText(problem.getErrorMessage(), problem.getCorrectionMessage()));
+
       final String severity = problem.getSeverity();
       setIcon(AnalysisErrorSeverity.ERROR.equals(severity)
               ? AllIcons.General.Error
@@ -41,6 +43,13 @@ class DartProblemsTableModel extends ListTableModel<DartProblem> {
       return label;
     }
   };
+
+  @NotNull
+  private static String generateToolTipText(@Nullable final String message, @Nullable final String correction) {
+    String messageSanitized = StringUtil.notNullize(message).replaceAll("\\\\n", "\n");
+    String correctionSanitized = StringUtil.notNullize(correction).replaceAll("\\\\n", "\n");
+    return correctionSanitized.isEmpty() ? messageSanitized : messageSanitized + "\n\n" + correctionSanitized;
+  }
 
   private static final TableCellRenderer LOCATION_RENDERER = new DefaultTableCellRenderer() {
     @Override


### PR DESCRIPTION
I made an attempt at adding the information into the tooltips in the DartAnnotator, but the AnnotationHolderImpl makes a call to XmlStringUtil.escapeString(message) which removes any added '/n' or '\<br/\>'.

![two](https://cloud.githubusercontent.com/assets/1533520/24378879/6b4655f4-12f9-11e7-80c7-1c1ffc06c7ce.png)
