### PR TITLE
tweaks to dartdoc hover rendering

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
@@ -80,7 +80,6 @@ public class DartDocUtil {
     final StringBuilder builder = new StringBuilder();
     builder.append("<code>");
     if (signature != null) {
-      builder.append("<b>Signature:</b> ");
       if (signatureIsHtml) {
         builder.append(signature);
       }
@@ -118,14 +117,13 @@ public class DartDocUtil {
         builder.append("<br>");
       }
     }
-    builder.append("</code>");
+    builder.append("</code>\n");
     if (docText != null) {
-      builder.append("<br>");
       final MarkdownProcessor processor = new MarkdownProcessor();
-      builder.append(processor.markdown(docText));
+      builder.append(processor.markdown(docText.trim()));
     }
     // done
-    return builder.toString();
+    return builder.toString().trim();
   }
 
   @Nullable

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
@@ -16,20 +16,19 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testAbstractClassSig() throws Exception {
-    doTest("<code><b>Signature:</b> abstract class Foo extends Bar<br></code>", "abstract class <caret>Foo extends Bar { }\nclass Bar { }");
+    doTest("<code>abstract class Foo extends Bar<br></code>", "abstract class <caret>Foo extends Bar { }\nclass Bar { }");
   }
 
   public void testClassMultilineDoc1() throws Exception {
-    doTest("<code><b>Signature:</b> class A<br></code><br><pre><code>     doc1\n" +
-           "</code></pre>\n"                                                      +
-           "\n"                                                                   +
-           "<p>doc2\n"                                                            +
-           " doc3</p>\n"                                                          +
-           "\n"                                                                   +
-           "<p>   doc4</p>\n"                                                     +
-           "\n"                                                                   +
-           "<pre><code>    code\n"                                                +
-           "</code></pre>\n",
+    doTest("<code>class A<br></code>\n" +
+           "<p>doc1\n" +
+           "doc2\n" +
+           " doc3</p>\n" +
+           "\n" +
+           "<p>   doc4</p>\n" +
+           "\n" +
+           "<pre><code>    code\n" +
+           "</code></pre>",
 
            "/** 1 */\n"     +
            "/**\n"          +
@@ -46,12 +45,12 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc2() throws Exception {
-    doTest("<code><b>Signature:</b> abstract class A<br></code><br><p>doc1\n" +
+    doTest("<code>abstract class A<br></code>\n<p>doc1\n" +
            "doc2\n"                                                           +
            " doc3\n"                                                          +
            "doc4\n"                                                           +
            "doc5\n"                                                           +
-           " doc6</p>\n",
+           " doc6</p>",
 
            "@deprecated\n"  +
            "/**\n"          +
@@ -66,8 +65,8 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs1() throws Exception {
-    doTest("<code><b>Signature:</b> class A<br></code><br><p>  doc1\n" +
-           "doc2</p>\n",
+    doTest("<code>class A<br></code>\n<p>doc1\n" +
+           "doc2</p>",
 
            "// not doc \n"    +
            "///   doc1  \n"   +
@@ -78,8 +77,8 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs2() throws Exception {
-    doTest("<code><b>Signature:</b> class A<br></code><br><p>  doc1\n" +
-           "doc2</p>\n",
+    doTest("<code>class A<br></code>\n<p>doc1\n" +
+           "doc2</p>",
 
            "@deprecated"      +
            "// not doc \n"    +
@@ -91,35 +90,35 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testConstructorSig() throws Exception {
-    doTest("<code><b>Signature:</b> Z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z(); }");
+    doTest("<code>Z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z(); }");
   }
 
   public void testEnumSig() throws Exception {
-    doTest("<code><b>Signature:</b> enum Foo<br></code>", "enum <caret>Foo { BAR }");
+    doTest("<code>enum Foo<br></code>", "enum <caret>Foo { BAR }");
   }
 
   public void testFieldSig1() throws Exception {
-    doTest("<code><b>Signature:</b> int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
+    doTest("<code>int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
            "class Z { int <caret>y = 42; }");
   }
 
   public void testFieldSig2() throws Exception {
-    doTest("<code><b>Signature:</b> int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
+    doTest("<code>int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
            "class Z { int <caret>y; }");
   }
 
   public void testFunctionDoc1() throws Exception {
-    doTest("<code><b>Signature:</b> foo(int x) → void<br></code><br><p>A function on [x]s.</p>\n",
+    doTest("<code>foo(int x) → void<br></code>\n<p>A function on [x]s.</p>",
            "/// A function on [x]s.\nvoid <caret>foo(int x) { }");
   }
 
   public void testFunctionDoc2() throws Exception {
-    doTest("<code><b>Signature:</b> foo(int x) → void<br></code><br><p>Good for:</p>\n" +
+    doTest("<code>foo(int x) → void<br></code>\n<p>Good for:</p>\n" +
            "\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
            "<li>that</li>\n" +
-           "</ul>\n", "/** Good for:\n\n" +
+           "</ul>", "/** Good for:\n\n" +
                       " * * this\n" +
                       " * * that\n" +
                       "*/\n" +
@@ -127,7 +126,7 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   //public void testMetaClassSig2() throws Exception {
-  //  doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
+  //  doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
   //         "@Meta(\'foo\') class <caret>A {};\n" +
   //         "class Meta {\n" +
   //         "  final String name;\n" +
@@ -136,74 +135,73 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   //}
 
   public void testFunctionSig1() throws Exception {
-    doTest("<code><b>Signature:</b> calc(int x) → int<br></code>", "int <caret>calc(int x) => x + 42;");
+    doTest("<code>calc(int x) → int<br></code>", "int <caret>calc(int x) => x + 42;");
   }
 
   public void testFunctionSig10() throws Exception {
-    doTest("<code><b>Signature:</b> x({bool b}) → void<br></code>", "void <caret>x({bool b}){};");
+    doTest("<code>x({bool b}) → void<br></code>", "void <caret>x({bool b}){};");
   }
 
   public void testFunctionSig2() throws Exception {
-    doTest("<code><b>Signature:</b> foo([int x = 3]) → dynamic<br></code>", "<caret>foo([int x = 3]) { print(x); }");
+    doTest("<code>foo([int x = 3]) → dynamic<br></code>", "<caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig3() throws Exception {
-    doTest("<code><b>Signature:</b> foo([int x = 3]) → void<br></code>", "void <caret>foo([int x = 3]) { print(x); }");
+    doTest("<code>foo([int x = 3]) → void<br></code>", "void <caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig4() throws Exception {
-    doTest("<code><b>Signature:</b> foo(int x, {int y, int z}) → void<br></code>", "void <caret>foo(int x, {int y, int z}) { }");
+    doTest("<code>foo(int x, {int y, int z}) → void<br></code>", "void <caret>foo(int x, {int y, int z}) { }");
   }
 
   public void testFunctionSig5() throws Exception {
-    doTest("<code><b>Signature:</b> x(List&lt;dynamic&gt; e) → dynamic<br></code>", "E <caret>x(List<E> e) { }");
+    doTest("<code>x(List&lt;dynamic&gt; e) → dynamic<br></code>", "E <caret>x(List<E> e) { }");
   }
 
   public void testFunctionSig6() throws Exception {
-    doTest("<code><b>Signature:</b> calc(() → int x) → int<br></code>", "int <caret>calc(int x()) => null;");
+    doTest("<code>calc(() → int x) → int<br></code>", "int <caret>calc(int x()) => null;");
   }
 
   public void testFunctionSig7() throws Exception {
-    doTest("<code><b>Signature:</b> foo(Map&lt;int, String&gt; p) → Map&lt;String, int&gt;<br></code>",
+    doTest("<code>foo(Map&lt;int, String&gt; p) → Map&lt;String, int&gt;<br></code>",
            "Map<String, int> <caret>foo(Map<int, String> p) => null;");
   }
 
   public void testFunctionSig8() throws Exception {
-    doTest("<code><b>Signature:</b> x() → dynamic<br></code>", "<caret>x() => null;");
+    doTest("<code>x() → dynamic<br></code>", "<caret>x() => null;");
   }
 
   public void testFunctionSig9() throws Exception {
-    doTest("<code><b>Signature:</b> x({bool b: true}) → dynamic<br></code>", "<caret>x({bool b: true}){};");
+    doTest("<code>x({bool b: true}) → dynamic<br></code>", "<caret>x({bool b: true}){};");
   }
 
   public void testGetterSig() throws Exception {
-    doTest("<code><b>Signature:</b> get x → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int get <caret>x => 0; }");
+    doTest("<code>get x → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int get <caret>x => 0; }");
   }
 
   public void testImplementsSig1() throws Exception {
-    doTest("<code><b>Signature:</b> abstract class Foo implements Bar<br></code>",
+    doTest("<code>abstract class Foo implements Bar<br></code>",
            "abstract class <caret>Foo implements Bar<T> { }\nclass Bar { }");
   }
 
   public void testLibraryClassDoc() throws Exception {
-    doTest("<code><b>Signature:</b> class A<br><br><b>Containing library:</b> c.b.a<br></code>", "library c.b.a;\nclass <caret>A {}");
+    doTest("<code>class A<br><br><b>Containing library:</b> c.b.a<br></code>", "library c.b.a;\nclass <caret>A {}");
   }
 
   public void testMetaClassSig1() throws Exception {
-    doTest("<code><b>Signature:</b> class A<br></code>", " @deprecated class <caret>A {}");
+    doTest("<code>class A<br></code>", " @deprecated class <caret>A {}");
   }
 
   public void testMethodMultilineDoc() throws Exception {
-    doTest("<code><b>Signature:</b> foo() → dynamic<br><br><b>Containing class:</b> A<br></code><br><pre><code>     doc1\n" +
-           "</code></pre>\n"                                                                                                +
-           "\n"                                                                                                             +
-           "<p>doc2\n"                                                                                                      +
-           " doc3</p>\n"                                                                                                    +
-           "\n"                                                                                                             +
-           "<p>   doc4</p>\n"                                                                                               +
-           "\n"                                                                                                             +
-           "<pre><code>    code\n"                                                                                          +
-           "</code></pre>\n",
+    doTest("<code>foo() → dynamic<br><br><b>Containing class:</b> A<br></code>\n" +
+           "<p>doc1\n" +
+           "doc2\n" +
+           " doc3</p>\n" +
+           "\n" +
+           "<p>   doc4</p>\n" +
+           "\n" +
+           "<pre><code>    code\n" +
+           "</code></pre>",
 
            "class A{\n"       +
            "/** 1 */\n"       +
@@ -222,12 +220,12 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testMethodSig1() throws Exception {
-    doTest("<code><b>Signature:</b> y() → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int <caret>y() => 42; }");
+    doTest("<code>y() → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int <caret>y() => 42; }");
   }
 
   public void testMethodSingleLineDocs() throws Exception {
-    doTest("<code><b>Signature:</b> foo() → dynamic<br><br><b>Containing class:</b> A<br></code><br><p>  doc1\n" +
-           "doc2</p>\n", "class A{\n" +
+    doTest("<code>foo() → dynamic<br><br><b>Containing class:</b> A<br></code>\n<p>doc1\n" +
+           "doc2</p>", "class A{\n" +
                          "// not doc \n" +
                          "///   doc1  \n" +
                          " /* not doc */\n" +
@@ -238,78 +236,78 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testMixinSig1() throws Exception {
-    doTest("<code><b>Signature:</b> class Foo2 extends Bar1 with Baz1, Baz2<br></code>",
+    doTest("<code>class Foo2 extends Bar1 with Baz1, Baz2<br></code>",
            "class Bar1 {} class Baz1{} class Baz2 {} class <caret>Foo2 = Bar1<E> with Baz1<K>, Baz2");
   }
 
   public void testMixinSig2() throws Exception {
-    doTest("<code><b>Signature:</b> class X extends Y with Z<br></code>", "class Y {} class Z {} class <caret>X extends Y with Z { }");
+    doTest("<code>class X extends Y with Z<br></code>", "class Y {} class Z {} class <caret>X extends Y with Z { }");
   }
 
   public void testNamedConstructorSig() throws Exception {
-    doTest("<code><b>Signature:</b> Z.z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z.z(); }");
+    doTest("<code>Z.z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z.z(); }");
   }
 
   public void testParamClassSig() throws Exception {
-    doTest("<code><b>Signature:</b> class Foo&lt;T&gt;<br></code>", "class <caret>Foo<T>{ }");
+    doTest("<code>class Foo&lt;T&gt;<br></code>", "class <caret>Foo<T>{ }");
   }
 
   public void testParamClassSig2() throws Exception {
-    doTest("<code><b>Signature:</b> class Foo&lt;T, Z&gt;<br></code>", "class <caret>Foo<T,Z>{ }");
+    doTest("<code>class Foo&lt;T, Z&gt;<br></code>", "class <caret>Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() throws Exception {
-    doTest("<code><b>Signature:</b> class Foo implements Bar<br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
+    doTest("<code>class Foo implements Bar<br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() throws Exception {
-    doTest("<code><b>Signature:</b> class Foo implements Bar, Baz<br></code>",
+    doTest("<code>class Foo implements Bar, Baz<br></code>",
            "class <caret>Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
   }
 
   public void testParamClassSig5() throws Exception {
-    doTest("<code><b>Signature:</b> class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br></code>",
+    doTest("<code>class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br></code>",
            "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
   }
 
   public void testParamClassSig6() throws Exception {
-    doTest("<code><b>Signature:</b> List&lt;String&gt; ids<br><br><b>Static type:</b> List&lt;String&gt;<br></code>",
+    doTest("<code>List&lt;String&gt; ids<br><br><b>Static type:</b> List&lt;String&gt;<br></code>",
            "class A { foo() { List<String> <caret>ids; }}");
   }
 
   public void testParamClassSig7() throws Exception {
     doTest(
-      "<code><b>Signature:</b> List&lt;Map&lt;String, int&gt;&gt; ids<br><br><b>Static type:</b> List&lt;Map&lt;String, int&gt;&gt;<br></code>",
+      "<code>List&lt;Map&lt;String, int&gt;&gt; ids<br><br><b>Static type:</b> List&lt;Map&lt;String, int&gt;&gt;<br></code>",
       "class A { foo() { List<Map<String, int>> <caret>ids; }}");
   }
 
   public void testParamClassSig8() throws Exception {
-    doTest("<code><b>Signature:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; list<br><br>" +
+    doTest("<code>List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; list<br><br>" +
            "<b>Static type:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt;<br></code>",
            "class A { foo() { List<List<Map<String, List<Object>>>> <caret>list; }}");
   }
 
   public void testSetterSig() throws Exception {
-    doTest("<code><b>Signature:</b> set x(int x) → void<br><br><b>Containing class:</b> Z<br></code>",
+    doTest("<code>set x(int x) → void<br><br><b>Containing class:</b> Z<br></code>",
            "class Z { void set <caret>x(int x) { } }");
   }
 
   public void testTopLevelVarDoc1() throws Exception {
-    doTest("<code><b>Signature:</b> dynamic x<br><br><b>Containing library:</b> a.b.c<br><br>" +
-           "<b>Static type:</b> dynamic<br><b>Propagated type:</b> String<br></code><br><p>docs1\n" +
-           "docs2</p>\n", "library a.b.c;\n" +
+    doTest("<code>dynamic x<br><br><b>Containing library:</b> a.b.c<br><br>" +
+           "<b>Static type:</b> dynamic<br><b>Propagated type:</b> String<br></code>\n<p>docs1\n" +
+           "docs2</p>", "library a.b.c;\n" +
                           "/// docs1\n" +
                           "/// docs2\n" +
                           "@deprecated var <caret>x = 'foo';");
   }
 
   public void testTopLevelVarDoc2() throws Exception {
-    doTest("<code><b>Signature:</b> int x<br><br><b>Containing library:</b> a.b.c<br><br><b>Static type:</b> int<br></code>",
+    doTest("<code>int x<br><br><b>Containing library:</b> a.b.c<br><br><b>Static type:</b> int<br></code>",
            "library a.b.c;\nint <caret>x = 3;\n");
   }
 
   public void testTypedefSig() throws Exception {
-    doTest("<code><b>Signature:</b> typedef F(int x) → int<br></code>", "typedef int <caret>F(int x);");
+    doTest("<code>typedef F(int x) → int<br></code>", "typedef int <caret>F(int x);");
   }
 
   private void doTest(String expectedDoc, String fileContents) {

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
@@ -21,59 +21,59 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testAbstractClassSig() throws Exception {
-    doTest("<code><b>Signature:</b> abstract class <b>Foo</b> extends Bar<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>abstract class <b>Foo</b> extends Bar<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>abstract class Foo extends Bar { }\nclass Bar { }");
   }
 
   public void testParamClassSig() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>Foo</b>&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>Foo</b>&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo<T>{ }");
   }
 
   public void testParamClassSig2() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>Foo</b>&lt;T, Z&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>Foo</b>&lt;T, Z&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>Foo</b> implements Bar<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>Foo</b> implements Bar<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>Foo</b> implements Bar, Baz<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>Foo</b> implements Bar, Baz<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
   }
 
   public void testParamClassSig5() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>Foo</b>&lt;A, B&gt; extends Bar&lt;A,B&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>Foo</b>&lt;A, B&gt; extends Bar&lt;A,B&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
   }
 
   public void testParamClassSig6() throws Exception {
-    doTest("<code><b>Signature:</b> List&lt;String&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
+    doTest("<code>List&lt;String&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
            "class A { foo() { List<String> <caret>ids; }}");
   }
 
   public void testParamClassSig7() throws Exception {
-    doTest("<code><b>Signature:</b> List&lt;Map&lt;String, int&gt;&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
+    doTest("<code>List&lt;Map&lt;String, int&gt;&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
            "class A { foo() { List<Map<String, int>> <caret>ids; }}");
   }
 
   public void testParamClassSig8() throws Exception {
     doTest(
-      "<code><b>Signature:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; <b>list</b><br><br>" +
+      "<code>List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; <b>list</b><br><br>" +
       "<b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
       "class A { foo() { List<List<Map<String, List<Object>>>> <caret>list; }}");
   }
 
   public void testMetaClassSig1() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
            " @deprecated class <caret>A {}");
   }
 
   public void testMetaClassSig2() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
            "@Meta(\'foo\') class <caret>A {};\n" +
            "class Meta {\n" +
            "  final String name;\n" +
@@ -82,126 +82,126 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testLibraryClassDoc() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> c.b.a<br></code>",
+    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> c.b.a<br></code>",
            "library c.b.a;\nclass <caret>A {}");
   }
 
   public void testImplementsSig1() throws Exception {
-    doTest("<code><b>Signature:</b> abstract class <b>Foo</b> implements Bar&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>abstract class <b>Foo</b> implements Bar&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>abstract class Foo implements Bar<T> { }\nclass Bar { }");
   }
 
   public void testMixinSig1() throws Exception {
     doTest(
-      "<code><b>Signature:</b> class <b>Foo2</b> extends Bar1&lt;E&gt; with Baz1&lt;K&gt;, Baz2<br><br>" +
+      "<code>class <b>Foo2</b> extends Bar1&lt;E&gt; with Baz1&lt;K&gt;, Baz2<br><br>" +
       "<b>Containing library:</b> test.dart<br></code>",
       "<caret>class Foo2 = Bar1<E> with Baz1<K>, Baz2");
   }
 
   public void testMixinSig2() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>X</b> extends Y with Z<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>class <b>X</b> extends Y with Z<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>class X extends Y with Z { }");
   }
 
   public void testEnumSig() throws Exception {
-    doTest("<code><b>Signature:</b> enum <b>Foo</b><br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>enum <b>Foo</b><br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>enum Foo { BAR }");
   }
 
   public void testFunctionSig1() throws Exception {
-    doTest("<code><b>Signature:</b> <b>calc</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>calc</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>int calc(int x) => x + 42;");
   }
 
   public void testFunctionSig2() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>([int x = 3]) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig3() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>([int x = 3]) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>void foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig4() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>(int x, {int y, int z}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>foo</b>(int x, {int y, int z}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>void foo(int x, {int y, int z}) { }");
   }
 
   public void testFunctionSig5() throws Exception {
-    doTest("<code><b>Signature:</b> <b>x</b>(List&lt;E&gt; e) " + RIGHT_ARROW + " E<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>x</b>(List&lt;E&gt; e) " + RIGHT_ARROW + " E<br><br><b>Containing library:</b> test.dart<br></code>",
            "E <caret>x(List<E> e) { }");
   }
 
   public void testFunctionSig6() throws Exception {
     doTest(
-      "<code><b>Signature:</b> <b>calc</b>(x() " + RIGHT_ARROW + " int) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
+      "<code><b>calc</b>(x() " + RIGHT_ARROW + " int) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
       "<caret>int calc(int x()) => null;");
   }
 
   public void testFunctionSig7() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>(Map&lt;int, String&gt; p) " + RIGHT_ARROW + " Map&lt;String, int&gt;<br><br>" +
+    doTest("<code><b>foo</b>(Map&lt;int, String&gt; p) " + RIGHT_ARROW + " Map&lt;String, int&gt;<br><br>" +
            "<b>Containing library:</b> test.dart<br></code>",
            "Map<String, int> <caret>foo(Map<int, String> p) => null;");
   }
 
   public void testFunctionSig8() throws Exception {
-    doTest("<code><b>Signature:</b> <b>x</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>x</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>x() => null;");
   }
 
   public void testFunctionSig9() throws Exception {
-    doTest("<code><b>Signature:</b> <b>x</b>({bool b: true}) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>x</b>({bool b: true}) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>x({bool b: true}){};");
   }
 
   public void testFunctionSig10() throws Exception {
-    doTest("<code><b>Signature:</b> <b>x</b>({bool b}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>x</b>({bool b}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
            "void <caret>x({bool b}){};");
   }
 
   public void testTypedefSig() throws Exception {
-    doTest("<code><b>Signature:</b> typedef <b>a</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code>typedef <b>a</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
            "<caret>typedef int a(int x);");
   }
 
   public void testFieldSig1() throws Exception {
-    doTest("<code><b>Signature:</b> int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code>int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int y = 42; }");
   }
 
   public void testFieldSig2() throws Exception {
-    doTest("<code><b>Signature:</b> int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code>int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int y; }");
   }
 
   public void testMethodSig1() throws Exception {
-    doTest("<code><b>Signature:</b> <b>y</b>() " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>y</b>() " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int y() => 42; }");
   }
 
   public void testNamedConstructorSig() throws Exception {
-    doTest("<code><b>Signature:</b> <b>Z.</b><b>z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>Z.</b><b>z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>Z.z(); }");
   }
 
   public void testConstructorSig() throws Exception {
-    doTest("<code><b>Signature:</b> <b>Z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>Z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>Z(); }");
   }
 
   public void testGetterSig() throws Exception {
-    doTest("<code><b>Signature:</b> get <b>x</b> " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code>get <b>x</b> " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>int get x => 0; }");
   }
 
   public void testSetterSig() throws Exception {
-    doTest("<code><b>Signature:</b> set <b>x</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code>set <b>x</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
            "class Z { <caret>void set x(int x) { } }");
   }
 
   public void testTopLevelVarDoc1() throws Exception {
-    doTest("<code><b>Signature:</b> var <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code><br><p>docs1\ndocs2</p>\n",
+    doTest("<code>var <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code>\n<p>docs1\ndocs2</p>",
            "library a.b.c;\n" +
            "/// docs1\n" +
            "/// docs2\n" +
@@ -209,23 +209,23 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testTopLevelVarDoc2() throws Exception {
-    doTest("<code><b>Signature:</b> int <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code>",
+    doTest("<code>int <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code>",
            "library a.b.c;\n<caret>int x = 3;\n");
   }
 
   public void testFunctionDoc1() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br>" +
-           "<b>Containing library:</b> test.dart<br></code><br><p>A function on [x]s.</p>\n",
-           "/// A function on [x]s.\n<caret>void foo(int x) { }");
+    doTest("<code><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br>" +
+           "<b>Containing library:</b> test.dart<br></code>\n<p>A function on <code>x</code>s.</p>",
+           "/// A function on <code>x</code>s.\n<caret>void foo(int x) { }");
   }
 
   public void testFunctionDoc2() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>" +
-           "<br><p> Good for:</p>\n\n" +
+    doTest("<code><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>\n" +
+           "<p>Good for:</p>\n\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
            "<li>that</li>\n" +
-           "</ul>\n",
+           "</ul>",
            "/** Good for:\n\n" +
            " * * this\n" +
            " * * that\n" +
@@ -234,14 +234,14 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc1() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>     doc1\n" +
+    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
            "\n" +
            "<p>   doc4</p>\n" +
            "\n" +
            "<pre><code>    code\n" +
-           "</code></pre>\n",
+           "</code></pre>",
 
            "/** 1 */\n" +
            "/**\n" +
@@ -258,12 +258,12 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc2() throws Exception {
-    doTest("<code><b>Signature:</b> abstract class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>doc1\n" +
+    doTest("<code>abstract class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1\n" +
            "doc2\n" +
            " doc3\n" +
            "doc4\n" +
            "doc5\n" +
-           " doc6</p>\n",
+           " doc6</p>",
 
            "@deprecated\n" +
            "/**\n" +
@@ -278,8 +278,8 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs1() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>  doc1 <br />\n" +
-           "doc2   </p>\n",
+    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1 <br />\n" +
+           "doc2</p>",
 
            "// not doc \n"    +
            "///   doc1  \n"   +
@@ -290,8 +290,8 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs2() throws Exception {
-    doTest("<code><b>Signature:</b> class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code><br><p>  doc1 <br />\n" +
-           "doc2   </p>\n",
+    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1 <br />\n" +
+           "doc2</p>",
 
            "@deprecated"      +
            "// not doc \n"    +
@@ -303,15 +303,15 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testMethodMultilineDoc() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
-           "<b>Containing class:</b> A<br></code><br><p>     doc1\n" +
+    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
+           "<b>Containing class:</b> A<br></code>\n<p>doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
            "\n" +
            "<p>   doc4</p>\n" +
            "\n" +
            "<pre><code>    code\n" +
-           "</code></pre>\n",
+           "</code></pre>",
 
            "class A{\n" +
            "/** 1 */\n" +
@@ -330,11 +330,11 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testMethodSingleLineDocs() throws Exception {
-    doTest("<code><b>Signature:</b> <b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
-           "<b>Containing class:</b> A<br></code><br><p>  doc1  </p>\n"                                                       +
+    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
+           "<b>Containing class:</b> A<br></code>\n<p>doc1  </p>\n"                                                       +
            "\n"                                                                                                               +
            "<pre><code>    doc2\n"                                                                                            +
-           "</code></pre>\n",
+           "</code></pre>",
 
            "class A{\n"           +
            "// not doc \n"        +
@@ -347,4 +347,18 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
            "<caret>foo(){}\n"     +
            "}");
   }
+
+  public void testHyperlink() throws Exception {
+    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>\n" +
+           "<p>my <a href=\"www.cheese.com\">fancy link</a></p>",
+           "/// my [fancy link](www.cheese.com)\nvoid <caret>foo() => null;\n");
+  }
+
+  public void testHyperlinkMultiLine() throws Exception {
+    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>\n" +
+           "<p>my <a href=\"www.cheese.com\">fancy\n" +
+           "link</a></p>",
+           "/// my [fancy\n/// link](www.cheese.com)\nvoid <caret>foo() => null;\n");
+  }
+
 }


### PR DESCRIPTION
- remove double blank lines from the the dartdoc tooltip text
- remove the leading `Signature` text
- convert symbol references to markdown code format (`[foo]` ==> ``` `foo` ```)

@alexander-doroshko 

<img width="487" alt="screen shot 2017-03-29 at 1 28 56 pm" src="https://cloud.githubusercontent.com/assets/1269969/24483163/02cd6b4e-14ab-11e7-8c56-9ec85f686cfe.png">

<img width="487" alt="screen shot 2017-03-29 at 6 11 16 pm" src="https://cloud.githubusercontent.com/assets/1269969/24483184/27c22d4a-14ab-11e7-8aa2-b4d06ee9e4f6.png">
