### PR TITLE
Add support for edit.getStatementCompletion

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -949,6 +949,29 @@ public class DartAnalysisServerService implements Disposable {
     return results;
   }
 
+  public SourceChange edit_getStatementCompletion(@NotNull final VirtualFile file, final int _offset) {
+    final String filePath = FileUtil.toSystemDependentName(file.getPath());
+
+    final AnalysisServer server = myServer;
+    if (server == null) {
+      return null;
+    }
+
+    SourceChange[] results = new SourceChange[1];
+    final CountDownLatch latch = new CountDownLatch(1);
+    final int offset = getOriginalOffset(file, _offset);
+    server.edit_getStatementCompletion(filePath, offset, new GetStatementCompletionConsumer() {
+      @Override
+      public void computedSourceChange(SourceChange sourceChange) {
+        results[0] = sourceChange;
+        latch.countDown();
+      }
+    });
+
+    awaitForLatchCheckingCanceled(server, latch, GET_ASSISTS_TIMEOUT, false);
+    return results[0];
+  }
+
   public void diagnostic_getServerPort(GetServerPortConsumer consumer) {
     final AnalysisServer server = myServer;
     if (server == null) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerStatementCompletionProcessor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerStatementCompletionProcessor.java
@@ -1,0 +1,36 @@
+package com.jetbrains.lang.dart.ide.completion;
+
+import com.intellij.CommonBundle;
+import com.intellij.codeInsight.editorActions.smartEnter.SmartEnterProcessor;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.refactoring.util.CommonRefactoringUtil;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+public class DartServerStatementCompletionProcessor extends SmartEnterProcessor {
+
+  @Override
+  public boolean process(@NotNull Project project, @NotNull Editor editor, @NotNull PsiFile psiFile) {
+    final Caret currentCaret = editor.getCaretModel().getPrimaryCaret();
+    final int offset = currentCaret.getSelectionStart();
+    final DartAnalysisServerService service = DartAnalysisServerService.getInstance(psiFile.getProject());
+    service.updateFilesContent();
+    SourceChange sourceChange = service.edit_getStatementCompletion(psiFile.getVirtualFile(), offset);
+    if (sourceChange != null) {
+      try {
+        AssistUtils.applySourceChange(project, sourceChange, true);
+      }
+      catch (DartSourceEditException e) {
+        CommonRefactoringUtil.showErrorHint(project, editor, e.getMessage(), CommonBundle.getErrorTitle(), null);
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetStatementCompletionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetStatementCompletionConsumer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server;
+
+import org.dartlang.analysis.server.protocol.SourceChange;
+
+/**
+ * The interface {@code GetStatementCompletionConsumer} defines the behavior of objects that consume a statement completion
+ * {@link SourceChange}.
+ *
+ * @coverage dart.server
+ */
+public interface GetStatementCompletionConsumer extends Consumer {
+
+  public void computedSourceChange(SourceChange sourceChange);
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -387,6 +387,20 @@ public interface AnalysisServer {
   public void edit_getRefactoring(String kind, String file, int offset, int length, boolean validateOnly, RefactoringOptions options, GetRefactoringConsumer consumer);
 
   /**
+   * {@code edit.getStatementCompletion}
+   *
+   * Get the changes required to convert the partial statement at the given location into a
+   * syntactically valid statement. If the current statement is already valid the change will insert
+   * a newline plus appropriate indentation at the end of the line containing the offset. If a change
+   * that makes the statement valid cannot be determined (perhaps because it has not yet been
+   * implemented) the statement will be considered already valid and the appropriate change returned.
+   *
+   * @param file The file containing the statement to be completed.
+   * @param offset The offset used to identify the statement to be completed.
+   */
+  public void edit_getStatementCompletion(String file, int offset, GetStatementCompletionConsumer consumer);
+
+  /**
    * {@code edit.organizeDirectives}
    *
    * Organizes all of the directives - removes unused imports and sorts directives of the given Dart

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -301,6 +301,12 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   }
 
   @Override
+  public void edit_getStatementCompletion(String file, int offset, GetStatementCompletionConsumer consumer) {
+    String id = generateUniqueId();
+    sendRequestToServer(id, RequestUtilities.generateEditStatementCompletion(id, file, offset), consumer);
+  }
+
+  @Override
   public void edit_organizeDirectives(String file, OrganizeDirectivesConsumer consumer) {
     String id = generateUniqueId();
     sendRequestToServer(id, RequestUtilities.generateEditOrganizeDirectives(id, file), consumer);
@@ -592,6 +598,9 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     }
     else if (consumer instanceof GetFixesConsumer) {
       new FixesProcessor((GetFixesConsumer)consumer).process(resultObject, requestError);
+    }
+    else if (consumer instanceof GetStatementCompletionConsumer) {
+      new StatementCompletionProcessor((GetStatementCompletionConsumer)consumer).process(resultObject, requestError);
     }
     else if (consumer instanceof GetLibraryDependenciesConsumer) {
       new LibraryDependenciesProcessor((GetLibraryDependenciesConsumer)consumer).process(resultObject, requestError);

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/StatementCompletionProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/StatementCompletionProcessor.java
@@ -1,0 +1,29 @@
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.GetStatementCompletionConsumer;
+import com.google.gson.JsonObject;
+import org.dartlang.analysis.server.protocol.AnalysisErrorFixes;
+import org.dartlang.analysis.server.protocol.RequestError;
+import org.dartlang.analysis.server.protocol.SourceChange;
+
+import java.util.List;
+
+public class StatementCompletionProcessor extends ResultProcessor {
+  private final GetStatementCompletionConsumer consumer;
+
+  public StatementCompletionProcessor(GetStatementCompletionConsumer consumer) {
+    this.consumer = consumer;
+  }
+
+  public void process(JsonObject resultObject, RequestError requestError) {
+    if (resultObject != null) {
+      try {
+        SourceChange sourceChange = SourceChange.fromJson(resultObject.get("change").getAsJsonObject());
+        consumer.computedSourceChange(sourceChange);
+      } catch (Exception exception) {
+        // catch any exceptions in the formatting of this response
+        requestError = generateRequestError(exception);
+      }
+    }
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -76,6 +76,7 @@ public class RequestUtilities {
   private static final String METHOD_EDIT_GET_AVAILABLE_REFACTORING = "edit.getAvailableRefactorings";
   private static final String METHOD_EDIT_GET_FIXES = "edit.getFixes";
   private static final String METHOD_EDIT_GET_REFACTORING = "edit.getRefactoring";
+  private static final String METHOD_EDIT_GET_STATEMENT_COMPLETION = "edit.getStatementCompletion";
   private static final String METHOD_EDIT_ORGANIZE_DIRECTIVES = "edit.organizeDirectives";
   private static final String METHOD_EDIT_SORT_MEMBERS = "edit.sortMembers";
 
@@ -528,6 +529,13 @@ public class RequestUtilities {
       params.add("options", options.toJson());
     }
     return buildJsonObjectRequest(idValue, METHOD_EDIT_GET_REFACTORING, params);
+  }
+
+  public static JsonObject generateEditStatementCompletion(String idValue, String file, int offset) {
+    JsonObject params = new JsonObject();
+    params.addProperty(FILE, file);
+    params.addProperty(OFFSET, offset);
+    return buildJsonObjectRequest(idValue, METHOD_EDIT_GET_STATEMENT_COMPLETION, params);
   }
 
   /**


### PR DESCRIPTION
@alexander-doroshko This is the beginning of the Complete Statement work. The server modifications are pretty straight-forward. I would appreciate you verifying that the call to `awaitForLatchCheckingCanceled()` is correct. I'm just guessing that the last argument (`false`) is needed to stop error checking. The editor hook-up is basic at this point. No support for identifier completion terminated with statement completion has been defined yet. However, we already know one case where that would be useful, so I'm planning to do that eventually.

This line needs to be added to plugin.xml to make it work:
```xml
    <lang.smartEnterProcessor language="Dart"
                              implementationClass="com.jetbrains.lang.dart.ide.completion.DartServerStatementCompletionProcessor"/>
```

I have not committed the DAS code to do recognize the edit.getStatementCompletion request yet.

I have tested that the round-trip works, using a fixed response from the server.