### PR TITLE
enhance the copy action on the dart problems view

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -44,6 +44,11 @@ public class DartProblem {
     return StringUtil.notNullize(myAnalysisError.getCorrection());
   }
 
+  @NotNull
+  public String getCode() {
+    return StringUtil.notNullize(myAnalysisError.getCode());
+  }
+
   public String getSeverity() {
     return myAnalysisError.getSeverity();
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -276,11 +276,11 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Data
   @Override
   public void performCopy(@NotNull DataContext dataContext) {
     final List<DartProblem> selectedObjects = myTable.getSelectedObjects();
-    final String s = StringUtil.join(selectedObjects, problem -> problem.getSeverity() +
+    final String s = StringUtil.join(selectedObjects, problem -> problem.getSeverity().toLowerCase() +
                                                                  ": " +
                                                                  problem.getErrorMessage() +
                                                                  " (" +
-                                                                 problem.getPresentableLocation() +
+                                                                 problem.getCode() + " at " + problem.getPresentableLocation() +
                                                                  ")", "\n");
 
     if (!s.isEmpty()) {


### PR DESCRIPTION
Some slight tweaks to the copy action on the problems view - add the `code` info. Before:

```
INFO: 'previousToken' is deprecated and shouldn't be used. ([analyzer] lib/src/fasta/token_utils.dart:251)
```

after:

```
info: 'EmbedderUriResolver' is deprecated and shouldn't be used. (deprecated_member_use at [dartdoc] lib/dartdoc.dart:202)
info: The value of the local variable 'foo' isn't used. (unused_local_variable at [dartdoc] test/compare_output_test.dart:51)
```
