### PR TITLE
add support for awaiter frame traces

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -37,9 +37,6 @@ public class VmServiceWrapper implements Disposable {
   public static final Logger LOG = Logger.getInstance(VmServiceWrapper.class.getName());
   private static final long RESPONSE_WAIT_TIMEOUT = 3000; // millis
 
-  // TODO: Remove this compile time flag once the VM implementation and wire protocol are final.
-  private static final boolean RENDER_CAUSAL_FRAMES = true;
-
   private final DartVmServiceDebugProcess myDebugProcess;
   private final VmService myVmService;
   private final DartVmServiceListener myVmServiceListener;
@@ -369,15 +366,12 @@ public class VmServiceWrapper implements Disposable {
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
           InstanceRef exceptionToAddToFrame = exception;
 
-          ElementList<Frame> elementList;
-          if (RENDER_CAUSAL_FRAMES) {
+          ElementList<Frame> elementList = vmStack.getAwaiterFrames();
+          if (elementList == null) {
             elementList = vmStack.getAsyncCausalFrames();
             if (elementList == null) {
               elementList = vmStack.getFrames();
             }
-          }
-          else {
-            elementList = vmStack.getFrames();
           }
 
           final List<Frame> vmFrames = Lists.newArrayList(elementList);

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -366,6 +366,8 @@ public class VmServiceWrapper implements Disposable {
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
           InstanceRef exceptionToAddToFrame = exception;
 
+          // Check to see if the VM passing in awaiter frames; if so, use them. Else check
+          // for async causal frames. Finally, fall back to using regular sync frames.
           ElementList<Frame> elementList = vmStack.getAwaiterFrames();
           if (elementList == null) {
             elementList = vmStack.getAsyncCausalFrames();

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FrameKind.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/FrameKind.java
@@ -20,6 +20,8 @@ package org.dartlang.vm.service.element;
  */
 public enum FrameKind {
 
+  AsyncActivation,
+
   AsyncCausal,
 
   AsyncSuspensionMarker,

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
@@ -35,6 +35,17 @@ public class Stack extends Response {
     };
   }
 
+  public ElementList<Frame> getAwaiterFrames() {
+    if (json.get("awaiterFrames") == null) return null;
+
+    return new ElementList<Frame>(json.get("awaiterFrames").getAsJsonArray()) {
+      @Override
+      protected Frame basicGet(JsonArray array, int index) {
+        return new Frame(array.get(index).getAsJsonObject());
+      }
+    };
+  }
+
   public ElementList<Frame> getFrames() {
     return new ElementList<Frame>(json.get("frames").getAsJsonArray()) {
       @Override


### PR DESCRIPTION
- add support for awaiter frame traces
- prefer displaying awaiter traces if available; then prefer a sync causal traces, else show regular vm (sync) traces

