### PR TITLE
Changes to error reporting

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -276,11 +276,11 @@ analysis.server.show.diagnostics.text=View analyzer diagnostics...
 analysis.server.show.diagnostics.error=Error opening Dart Analysis Server diagnostics page
 
 dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Analyzer Feedback from IntelliJ\n\n\
-  ## Version information\n\n\
+  # Version information\n\n\
   - `IDEA {0}`\n\
   - `{1}`\n\
   - `{2}`\n\n\
-  ## Exception
+  # Exception
 dart.analysis.server.error=Encountered a Dart Analysis Server error.
 dart.error.file.instructions=Please append the contents of:\n\
   file://{0}

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
@@ -26,7 +26,7 @@ import javax.swing.event.HyperlinkEvent;
  * send issues to the flutter project on github.
  */
 public abstract class DartFeedbackBuilder {
-  public static final int MAX_URL_LENGTH = 4000;
+  public static final int MAX_URL_LENGTH = 1900;
 
   // NOTIFICATION_GROUP is used to add an error to Event Log tool window. Red balloon is shown separately, like for IDE fatal errors.
   // We do not show standard balloon using this NOTIFICATION_GROUP because it is not red enough.

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 public class DefaultDartFeedbackBuilder extends DartFeedbackBuilder {
 
   public String prompt() {
-    return "Create an issue on GitHub?";
+    return "Open issue submission form";
   }
 
   public void sendFeedback(@NotNull Project project, @Nullable String errorMessage, @Nullable String serverLog) {


### PR DESCRIPTION
@alexander-doroshko This fixes a few things with server error reporting.

- Use top-level headers
- Limit URL length to something acceptable to all browsers
- Change the balloon label to be consistent with IntelliJ