### PR TITLE
show errors when running a Dart app

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -189,6 +189,8 @@
                     serviceImplementation="com.jetbrains.lang.dart.pubServer.PubServerManager"/>
     <projectService serviceInterface="com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView"
                     serviceImplementation="com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView"/>
+    <projectService serviceInterface="com.jetbrains.lang.dart.ide.runner.DartExecutionHelper"
+                    serviceImplementation="com.jetbrains.lang.dart.ide.runner.DartExecutionHelper"/>
 
     <applicationService serviceInterface="com.jetbrains.lang.dart.folding.DartCodeFoldingSettings"
                         serviceImplementation="com.jetbrains.lang.dart.folding.DartCodeFoldingSettings"/>

--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -189,8 +189,6 @@
                     serviceImplementation="com.jetbrains.lang.dart.pubServer.PubServerManager"/>
     <projectService serviceInterface="com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView"
                     serviceImplementation="com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView"/>
-    <projectService serviceInterface="com.jetbrains.lang.dart.ide.runner.DartExecutionHelper"
-                    serviceImplementation="com.jetbrains.lang.dart.ide.runner.DartExecutionHelper"/>
 
     <applicationService serviceInterface="com.jetbrains.lang.dart.folding.DartCodeFoldingSettings"
                         serviceImplementation="com.jetbrains.lang.dart.folding.DartCodeFoldingSettings"/>

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -45,6 +45,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFileSystemItem;
 import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.SearchScope;
 import com.intellij.util.Alarm;
 import com.intellij.util.Consumer;
 import com.intellij.util.PathUtil;
@@ -612,6 +613,14 @@ public class DartAnalysisServerService implements Disposable {
   @NotNull
   public List<DartServerData.DartError> getErrors(@NotNull final VirtualFile file) {
     return myServerData.getErrors(file);
+  }
+
+  public List<DartServerData.DartError> getErrors(@NotNull final Module module) {
+    return myServerData.getErrors(module);
+  }
+
+  public List<DartServerData.DartError> getErrors(@NotNull final SearchScope scope) {
+    return myServerData.getErrors(scope);
   }
 
   @NotNull

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExecutionHelper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExecutionHelper.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.lang.dart.ide.runner;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.editor.ScrollType;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.analyzer.DartServerData;
+import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
+import com.jetbrains.lang.dart.resolve.DartResolveScopeProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DartExecutionHelper {
+
+  public static DartExecutionHelper getInstance(@NotNull final Project project) {
+    return ServiceManager.getService(project, DartExecutionHelper.class);
+  }
+
+  private @NotNull final Project myProject;
+
+  DartExecutionHelper(@NotNull final Project project) {
+    myProject = project;
+  }
+
+  @SuppressWarnings("unused")
+  public boolean hasIssues(@NotNull VirtualFile launchFile) {
+    return !getIssues(launchFile).isEmpty();
+  }
+
+  public List<DartServerData.DartError> getIssues(@NotNull VirtualFile launchFile) {
+    return getIssues(launchFile, true);
+  }
+
+  public List<DartServerData.DartError> getIssues(@NotNull VirtualFile launchFile, boolean onlyErrors) {
+    GlobalSearchScope scope = DartResolveScopeProvider.getDartScope(myProject, launchFile, true);
+    if (scope == null) {
+      return Collections.emptyList();
+    }
+
+    // Collect errors.
+    final DartAnalysisServerService analysisServerService = DartAnalysisServerService.getInstance(myProject);
+    List<DartServerData.DartError> errors = analysisServerService.getErrors(scope);
+    if (onlyErrors) {
+      errors = errors.stream().filter(DartServerData.DartError::isError).collect(Collectors.toList());
+    }
+
+    return errors;
+  }
+
+  @SuppressWarnings("unused")
+  public void displayIssues(@NotNull VirtualFile launchFile) {
+    displayIssues(launchFile, "Error launching app", null);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  public void displayIssues(@NotNull VirtualFile launchFile, @NotNull String launchTitle, @Nullable Icon icon) {
+    clearIssueNotifications();
+
+    List<DartServerData.DartError> errors = getIssues(launchFile);
+
+    if (errors.isEmpty()) {
+      return;
+    }
+
+    final DartProblemsView problemsView = DartProblemsView.getInstance(myProject);
+
+    final String content;
+    if (errors.size() == 1) {
+      content = errors.get(0).getMessage() + " (<a href=\"issues\">show</a>)";
+    }
+    else {
+      content = errors.size() + " analysis " + StringUtil.pluralize("issue", errors.size()) + " found. (<a href=\"issues\">show</a>)";
+      problemsView.showErrorNotification(myProject, launchTitle, content, icon);
+    }
+
+    // Show a notification on the dart analysis tool window.
+    problemsView.showErrorNotification(myProject, launchTitle, content, icon);
+
+    // Jump to and highlight the first error (order unspecified) in the editor.
+    DartServerData.DartError error = errors.get(0);
+    final VirtualFile errorFile = LocalFileSystem.getInstance().findFileByPath(error.getAnalysisErrorFileSD());
+    if (errorFile != null) {
+      final OpenFileDescriptor descriptor = new OpenFileDescriptor(myProject, errorFile, error.getOffset());
+      descriptor.setScrollType(ScrollType.MAKE_VISIBLE);
+      descriptor.navigate(true);
+    }
+  }
+
+  public void clearIssueNotifications() {
+    final DartProblemsView problemsView = DartProblemsView.getInstance(myProject);
+    problemsView.clearNotifications();
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExecutionHelper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExecutionHelper.java
@@ -92,7 +92,6 @@ public class DartExecutionHelper {
     }
     else {
       content = errors.size() + " " + StringUtil.pluralize("issue", errors.size()) + " found. (<a href=\"issues\">show</a>)";
-      problemsView.showErrorNotification(project, launchTitle, content, icon);
     }
 
     // Show a notification on the dart analysis tool window.

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
@@ -1,6 +1,9 @@
 package com.jetbrains.lang.dart.ide.runner.server;
 
 import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
@@ -149,6 +152,22 @@ public class DartCommandLineRunnerParameters implements Cloneable {
     }
 
     return dartFile;
+  }
+
+  @Nullable
+  public Module getModule(@NotNull Project project) {
+    try {
+      final VirtualFile file = getDartFileOrDirectory();
+      return ModuleUtilCore.findModuleForFile(file, project);
+    }
+    catch (RuntimeConfigurationError ignore) {
+      final Module[] modules = ModuleManager.getInstance(project).getModules();
+      if (modules.length == 1) {
+        return modules[0];
+      }
+    }
+
+    return null;
   }
 
   public void check(final @NotNull Project project) throws RuntimeConfigurationError {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -26,6 +26,7 @@ import com.intellij.util.net.NetUtils;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.coverage.DartCoverageProgramRunner;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.DartExecutionHelper;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.client.DartiumUtil;
@@ -34,11 +35,11 @@ import com.jetbrains.lang.dart.sdk.DartSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
 import java.io.IOException;
 import java.util.*;
 
 public class DartCommandLineRunningState extends CommandLineState {
-
   protected final @NotNull DartCommandLineRunnerParameters myRunnerParameters;
   private int myObservatoryPort = -1;
   private Collection<Consumer<String>> myObservatoryUrlConsumers = new ArrayList<>();
@@ -76,7 +77,7 @@ public class DartCommandLineRunningState extends CommandLineState {
   @Override
   protected AnAction[] createActions(final ConsoleView console, final ProcessHandler processHandler, final Executor executor) {
     // These actions are effectively added only to the Run tool window. For Debug see DartCommandLineDebugProcess.registerAdditionalActions()
-    final List<AnAction> actions = new ArrayList(Arrays.asList(super.createActions(console, processHandler, executor)));
+    final List<AnAction> actions = new ArrayList<>(Arrays.asList(super.createActions(console, processHandler, executor)));
     addObservatoryActions(actions, processHandler);
     return actions.toArray(new AnAction[actions.size()]);
   }
@@ -126,7 +127,27 @@ public class DartCommandLineRunningState extends CommandLineState {
       }
     });
 
+    // Check for and display any analysis errors when we launch a Dart app.
+    final Project project = getEnvironment().getProject();
+    try {
+      final DartRunConfiguration dartRunConfiguration = (DartRunConfiguration)getEnvironment().getRunProfile();
+      final VirtualFile launchFile = dartRunConfiguration.getRunnerParameters().getDartFileOrDirectory();
+
+      if (getEnvironment().getRunnerAndConfigurationSettings() == null) {
+        DartExecutionHelper.getInstance(project).displayIssues(launchFile);
+      }
+      else {
+        String launchTitle = "Error launching " + getEnvironment().getRunnerAndConfigurationSettings().getName();
+        Icon icon = getEnvironment().getRunnerAndConfigurationSettings().getConfiguration().getIcon();
+        DartExecutionHelper.getInstance(project).displayIssues(launchFile, launchTitle, icon);
+      }
+    }
+    catch (RuntimeConfigurationError error) {
+      DartExecutionHelper.getInstance(project).clearIssueNotifications();
+    }
+
     ProcessTerminatedListener.attach(processHandler, getEnvironment().getProject());
+
     return processHandler;
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -134,16 +134,16 @@ public class DartCommandLineRunningState extends CommandLineState {
       final VirtualFile launchFile = dartRunConfiguration.getRunnerParameters().getDartFileOrDirectory();
 
       if (getEnvironment().getRunnerAndConfigurationSettings() == null) {
-        DartExecutionHelper.getInstance(project).displayIssues(launchFile);
+        DartExecutionHelper.displayIssues(project, launchFile);
       }
       else {
-        String launchTitle = "Error launching " + getEnvironment().getRunnerAndConfigurationSettings().getName();
+        String launchTitle = "Analysis issues with " + getEnvironment().getRunnerAndConfigurationSettings().getName();
         Icon icon = getEnvironment().getRunnerAndConfigurationSettings().getConfiguration().getIcon();
-        DartExecutionHelper.getInstance(project).displayIssues(launchFile, launchTitle, icon);
+        DartExecutionHelper.displayIssues(project, launchFile, launchTitle, icon);
       }
     }
     catch (RuntimeConfigurationError error) {
-      DartExecutionHelper.getInstance(project).clearIssueNotifications();
+      DartExecutionHelper.clearIssueNotifications(project);
     }
 
     ProcessTerminatedListener.attach(processHandler, getEnvironment().getProject());


### PR DESCRIPTION
Show errors when running a Dart app:

- add functionality to Dart launches to display errors on run. We display tool window notifications on the Dart Analysis view and focus an error in the editor
- the user can set an option in the preferences to not show these notifications
- the code is written in such a way that the general API is available to other plugins (are there errors for a launch / display the errors for a launch)

<img width="259" alt="screen shot 2017-04-18 at 11 59 17 am" src="https://cloud.githubusercontent.com/assets/1269969/25148393/a033b058-242f-11e7-92a8-9975c28d6e0b.png">

<img width="868" alt="screen shot 2017-04-18 at 11 51 34 am" src="https://cloud.githubusercontent.com/assets/1269969/25148401/a996bbfe-242f-11e7-929f-7bf45eca83c6.png">

@alexander-doroshko 
