### PR TITLE
Modify the Dart Analysis Server rename test to make it not blink.

### DIFF
--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerRenameTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerRenameTest.java
@@ -176,7 +176,7 @@ public class DartServerRenameTest extends CodeInsightFixtureTestCase {
 
   public void testFileRename() {
     final PsiFile barFile = myFixture.addFileToProject("src/bar.dart", "");
-    final PsiFile fooFile = myFixture.addFileToProject("foo.dart", "import  r'''src/bar.dart ''' ;");
+    final PsiFile fooFile = myFixture.addFileToProject("foo.dart", "import  r'''src/bar.dart''' ;");
     final PsiFile bazFile = myFixture.addFileToProject("src/baz.dart", "export  'bar.dart';");
     myFixture.openFileInEditor(barFile.getVirtualFile());
     myFixture.doHighlighting(); // warm up


### PR DESCRIPTION
@alexander-doroshko 