### PR TITLE
work to support configuring exception breakpoints

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -203,6 +203,7 @@
     <console.folding implementation="com.jetbrains.lang.dart.ide.runner.server.DartConsoleFolding"/>
 
     <xdebugger.breakpointType implementation="com.jetbrains.lang.dart.ide.runner.DartLineBreakpointType"/>
+    <xdebugger.breakpointType implementation="com.jetbrains.lang.dart.ide.runner.DartExceptionBreakpointType"/>
 
     <configurationType implementation="com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunConfigurationType"/>
     <runConfigurationProducer implementation="com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRuntimeConfigurationProducer"/>

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExceptionBreakpointProperties.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExceptionBreakpointProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.lang.dart.ide.runner;
+
+import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
+import org.jetbrains.annotations.Nullable;
+
+public class DartExceptionBreakpointProperties extends XBreakpointProperties<DartExceptionBreakpointProperties> {
+  public boolean myBreakOnAllExceptions;
+
+  public DartExceptionBreakpointProperties() {
+  }
+
+  @Nullable
+  @Override
+  public DartExceptionBreakpointProperties getState() {
+    return this;
+  }
+
+  @Override
+  public void loadState(DartExceptionBreakpointProperties state) {
+    myBreakOnAllExceptions = state.myBreakOnAllExceptions;
+  }
+
+  public void setBreakOnAllExceptions(boolean value) {
+    myBreakOnAllExceptions = value;
+  }
+
+  public boolean breakOnAllExceptions() {
+    return myBreakOnAllExceptions;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExceptionBreakpointType.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExceptionBreakpointType.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2000-2017 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.lang.dart.ide.runner;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.components.JBRadioButton;
+import com.intellij.xdebugger.breakpoints.XBreakpoint;
+import com.intellij.xdebugger.breakpoints.XBreakpointType;
+import com.intellij.xdebugger.breakpoints.ui.XBreakpointCustomPropertiesPanel;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class DartExceptionBreakpointType
+  extends XBreakpointType<XBreakpoint<DartExceptionBreakpointProperties>, DartExceptionBreakpointProperties> {
+
+  @SuppressWarnings("StaticNonFinalField")
+  public static DartExceptionBreakpointType INSTANCE;
+
+  public DartExceptionBreakpointType() {
+    super("dart-exception", "Dart Exception Breakpoint");
+
+    //noinspection AssignmentToStaticFieldFromInstanceMethod
+    INSTANCE = this;
+  }
+
+  @NotNull
+  @Override
+  public Icon getEnabledIcon() {
+    return AllIcons.Debugger.Db_exception_breakpoint;
+  }
+
+  @NotNull
+  @Override
+  public Icon getDisabledIcon() {
+    return AllIcons.Debugger.Db_disabled_exception_breakpoint;
+  }
+
+  @Override
+  public DartExceptionBreakpointProperties createProperties() {
+    return new DartExceptionBreakpointProperties();
+  }
+
+  @Override
+  public boolean isAddBreakpointButtonVisible() {
+    return false;
+  }
+
+  @Override
+  public XBreakpoint<DartExceptionBreakpointProperties> addBreakpoint(final Project project, JComponent parentComponent) {
+    return null;
+  }
+
+  @Override
+  public String getBreakpointsDialogHelpTopic() {
+    return "reference.dialogs.breakpoints";
+  }
+
+  @Override
+  public String getDisplayText(XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
+    return "Break on exceptions";
+  }
+
+  @Override
+  public XBreakpoint<DartExceptionBreakpointProperties> createDefaultBreakpoint(@NotNull XBreakpointCreator<DartExceptionBreakpointProperties> creator) {
+    final XBreakpoint<DartExceptionBreakpointProperties> breakpoint = creator.createBreakpoint(createDefaultBreakpointProperties());
+    breakpoint.setEnabled(true);
+    return breakpoint;
+  }
+
+  private static DartExceptionBreakpointProperties createDefaultBreakpointProperties() {
+    DartExceptionBreakpointProperties properties = new DartExceptionBreakpointProperties();
+    properties.setBreakOnAllExceptions(false);
+    return properties;
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public XBreakpointCustomPropertiesPanel<XBreakpoint<DartExceptionBreakpointProperties>> createCustomPropertiesPanel() {
+    return new DartExceptionBreakpointPropertiesPanel();
+  }
+
+  private static class DartExceptionBreakpointPropertiesPanel
+    extends XBreakpointCustomPropertiesPanel<XBreakpoint<DartExceptionBreakpointProperties>> {
+    private JBRadioButton myBreakOnUncaughtExceptions;
+    private JBRadioButton myBreakOnAllExceptions;
+
+    @NotNull
+    @Override
+    public JComponent getComponent() {
+      myBreakOnUncaughtExceptions = new JBRadioButton("Break on uncaught exceptions");
+      myBreakOnAllExceptions = new JBRadioButton("Break on all exceptions");
+
+      ButtonGroup group = new ButtonGroup();
+      group.add(myBreakOnUncaughtExceptions);
+      group.add(myBreakOnAllExceptions);
+
+      JPanel panel = new JPanel(new BorderLayout());
+      panel.add(myBreakOnUncaughtExceptions, BorderLayout.NORTH);
+      panel.add(myBreakOnAllExceptions, BorderLayout.SOUTH);
+      panel.setBorder(IdeBorderFactory.createTitledBorder("Breaking policy", true));
+
+      return panel;
+    }
+
+    @Override
+    public void saveTo(@NotNull XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
+      breakpoint.getProperties().setBreakOnAllExceptions(myBreakOnAllExceptions.isSelected());
+    }
+
+    @Override
+    public void loadFrom(@NotNull XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
+      if (breakpoint.getProperties().breakOnAllExceptions()) {
+        myBreakOnAllExceptions.setSelected(true);
+      }
+      else {
+        myBreakOnUncaughtExceptions.setSelected(true);
+      }
+    }
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandler.java
@@ -1,12 +1,17 @@
 package com.jetbrains.lang.dart.ide.runner.server.vmService;
 
-import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
-import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
-import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.Computable;
+import com.intellij.xdebugger.XDebuggerManager;
+import com.intellij.xdebugger.breakpoints.*;
+import com.jetbrains.lang.dart.ide.runner.DartExceptionBreakpointProperties;
+import com.jetbrains.lang.dart.ide.runner.DartExceptionBreakpointType;
 import com.jetbrains.lang.dart.ide.runner.DartLineBreakpointType;
 import gnu.trove.THashMap;
 import gnu.trove.THashSet;
 import org.dartlang.vm.service.element.Breakpoint;
+import org.dartlang.vm.service.element.ExceptionPauseMode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -14,16 +19,37 @@ import java.util.*;
 import static com.intellij.icons.AllIcons.Debugger.Db_invalid_breakpoint;
 import static com.intellij.icons.AllIcons.Debugger.Db_verified_breakpoint;
 
-public class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<XBreakpointProperties>> {
-
+public class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<XBreakpointProperties>> implements Disposable {
   private final DartVmServiceDebugProcess myDebugProcess;
   private final Set<XLineBreakpoint<XBreakpointProperties>> myXBreakpoints = new THashSet<>();
   private final Map<String, IsolateBreakpointInfo> myIsolateInfo = new THashMap<>();
   private final Map<String, XLineBreakpoint<XBreakpointProperties>> myVmBreakpointIdToXBreakpointMap = new THashMap<>();
+  private ExceptionPauseMode myExceptionPauseMode;
 
   public DartVmServiceBreakpointHandler(@NotNull final DartVmServiceDebugProcess debugProcess) {
     super(DartLineBreakpointType.class);
     myDebugProcess = debugProcess;
+
+    getDebuggerManager().getBreakpointManager().addBreakpointListener(
+      DartExceptionBreakpointType.INSTANCE,
+      new XBreakpointListener<XBreakpoint<DartExceptionBreakpointProperties>>() {
+        @Override
+        public void breakpointAdded(@NotNull XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
+          fireOnExceptionModeChange();
+        }
+
+        @Override
+        public void breakpointChanged(@NotNull XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
+          fireOnExceptionModeChange();
+        }
+
+        @Override
+        public void breakpointRemoved(@NotNull XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
+          fireOnExceptionModeChange();
+        }
+      }, this);
+
+    myExceptionPauseMode = getBreakOnExceptionsMode();
   }
 
   @Override
@@ -86,6 +112,10 @@ public class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLineBrea
     return info;
   }
 
+  private XDebuggerManager getDebuggerManager() {
+    return XDebuggerManager.getInstance(myDebugProcess.getSession().getProject());
+  }
+
   public void breakpointResolved(@NotNull final Breakpoint vmBreakpoint) {
     final XLineBreakpoint<XBreakpointProperties> xBreakpoint = myVmBreakpointIdToXBreakpointMap.get(vmBreakpoint.getId());
 
@@ -102,6 +132,50 @@ public class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLineBrea
 
   public XLineBreakpoint<XBreakpointProperties> getXBreakpoint(@NotNull final Breakpoint vmBreakpoint) {
     return myVmBreakpointIdToXBreakpointMap.get(vmBreakpoint.getId());
+  }
+
+  public ExceptionPauseMode getBreakOnExceptionsMode() {
+    XBreakpoint<DartExceptionBreakpointProperties> bp = getExceptionBreakpoint();
+
+    if (bp == null) {
+      // Default to breaking on unhandled exceptions.
+      return ExceptionPauseMode.Unhandled;
+    }
+
+    if (!bp.isEnabled()) {
+      return ExceptionPauseMode.None;
+    }
+    else if (bp.getProperties().breakOnAllExceptions()) {
+      return ExceptionPauseMode.All;
+    }
+    else {
+      return ExceptionPauseMode.Unhandled;
+    }
+  }
+
+  private XBreakpoint<DartExceptionBreakpointProperties> getExceptionBreakpoint() {
+    return ApplicationManager.getApplication().runReadAction((Computable<XBreakpoint<DartExceptionBreakpointProperties>>)() -> {
+      Collection<? extends XBreakpoint<DartExceptionBreakpointProperties>>
+        exceptionBreakpoints =
+        getDebuggerManager().getBreakpointManager().getBreakpoints(DartExceptionBreakpointType.class);
+      return exceptionBreakpoints.isEmpty() ? null : exceptionBreakpoints.iterator().next();
+    });
+  }
+
+  @Override
+  public void dispose() {
+    // This class implements Disposable in order to be able to pass itself into
+    // BreakpointManager.addBreakpointListener() as the parentDisposable.
+  }
+
+  private void fireOnExceptionModeChange() {
+    ExceptionPauseMode newMode = getBreakOnExceptionsMode();
+
+    if (newMode != myExceptionPauseMode) {
+      myExceptionPauseMode = newMode;
+
+      myDebugProcess.setExceptionPauseMode(newMode);
+    }
   }
 }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -7,6 +7,7 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.execution.ui.ExecutionConsole;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
@@ -358,6 +359,12 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       }
 
       Disposer.dispose(myVmServiceWrapper);
+
+      for (XBreakpointHandler handler : myBreakpointHandlers) {
+        if (handler instanceof Disposable) {
+          Disposer.dispose((Disposable)handler);
+        }
+      }
     }
   }
 
@@ -413,6 +420,15 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
     if (isolateRef.getId().equals(myLatestCurrentIsolateId)) {
       resume(getSession().getSuspendContext()); // otherwise no way no resume them from UI
+    }
+  }
+
+  /**
+   * Set the exception pause mode for all current isolates.
+   */
+  public void setExceptionPauseMode(ExceptionPauseMode mode) {
+    for (IsolatesInfo.IsolateInfo isolateInfo : myIsolatesInfo.getIsolateInfos()) {
+      myVmServiceWrapper.setExceptionPauseMode(isolateInfo.getIsolateId(), mode);
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -166,14 +166,15 @@ public class VmServiceWrapper implements Disposable {
 
     // Just to make sure that the main isolate is not handled twice, both from handleDebuggerConnected() and DartVmServiceListener.received(PauseStart)
     if (newIsolate) {
-      addRequest(() -> myVmService.setExceptionPauseMode(isolateRef.getId(),
-                                                         ExceptionPauseMode.Unhandled,
-                                                         new VmServiceConsumers.SuccessConsumerWrapper() {
-                                                           @Override
-                                                           public void received(Success response) {
-                                                             setInitialBreakpointsAndResume(isolateRef);
-                                                           }
-                                                         }));
+      addRequest(() -> myVmService.setExceptionPauseMode(
+        isolateRef.getId(),
+        myBreakpointHandler.getBreakOnExceptionsMode(),
+        new VmServiceConsumers.SuccessConsumerWrapper() {
+          @Override
+          public void received(Success response) {
+            setInitialBreakpointsAndResume(isolateRef);
+          }
+        }));
     }
     else {
       checkInitialResume(isolateRef);
@@ -327,6 +328,13 @@ public class VmServiceWrapper implements Disposable {
       myLatestStep = stepOption;
       myVmService.resume(isolateId, stepOption, null, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
     });
+  }
+
+  public void setExceptionPauseMode(@NotNull final String isolateId, @NotNull ExceptionPauseMode mode) {
+    addRequest(() -> myVmService.setExceptionPauseMode(
+      isolateId,
+      mode,
+      VmServiceConsumers.EMPTY_SUCCESS_CONSUMER));
   }
 
   /**


### PR DESCRIPTION
Work to support configuring exception breakpoints:

- add a new breakpoint type, `DartExceptionBreakpointType`; this shows up in the breakpoints dialog
- have the UI for it allow two settings, `break on uncaught` and `break on all` exceptions
- plumb the UI info through to vm service calls, including listening for changes to the setting while the app is running

@alexander-doroshko 

I do see issues where changing the value from `break on uncaught` to `break on all` and back doesn't kick out an event. Changing the breakpoint state from enabled to disabled does fire events.
