### PR TITLE
some cleanup to the run notification

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExecutionHelper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/DartExecutionHelper.java
@@ -16,7 +16,6 @@
 package com.jetbrains.lang.dart.ide.runner;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
@@ -72,34 +71,13 @@ public class DartExecutionHelper {
     clearIssueNotifications(project);
 
     List<DartServerData.DartError> errors = getIssues(project, launchFile);
-
     if (errors.isEmpty()) {
       return;
     }
 
-    final DartProblemsView problemsView = DartProblemsView.getInstance(project);
-
-    final String content;
-    if (errors.size() == 1) {
-      content = errors.get(0).getMessage();
-    }
-    else {
-      content = errors.size() + " " + StringUtil.pluralize("issue", errors.size()) + " found.";
-    }
-
     // Show a notification on the dart analysis tool window.
-    problemsView.showErrorNotification(launchTitle, content, icon);
-
-    // Jump to and highlight the first error (order unspecified) in the editor.
-    /*
-    DartServerData.DartError error = errors.get(0);
-    final VirtualFile errorFile = LocalFileSystem.getInstance().findFileByPath(error.getAnalysisErrorFileSD());
-    if (errorFile != null) {
-      final OpenFileDescriptor descriptor = new OpenFileDescriptor(project, errorFile, error.getOffset());
-      descriptor.setScrollType(ScrollType.MAKE_VISIBLE);
-      descriptor.navigate(true);
-    }
-    */
+    final DartProblemsView problemsView = DartProblemsView.getInstance(project);
+    problemsView.showErrorNotification(launchTitle, null, icon);
   }
 
   public static void clearIssueNotifications(@NotNull final Project project) {


### PR DESCRIPTION
- fix https://youtrack.jetbrains.com/issue/WEB-26864
- remove the ability to jump to an error on run
- add a `don't show again` link
- make the `open view` link not show if the Dart Analysis view is already open
- do not show the number of issues in the notification (this could be inconsistent w/ the filter in the analysis view)

@alexander-doroshko 
