### PR TITLE
expression eval can return sentinels

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -466,6 +466,11 @@ public class VmServiceWrapper implements Disposable {
       }
 
       @Override
+      public void received(Sentinel sentinel) {
+        callback.errorOccurred(sentinel.getValueAsString());
+      }
+
+      @Override
       public void received(ErrorRef errorRef) {
         callback.errorOccurred(DartVmServiceEvaluator.getPresentableError(errorRef.getMessage()));
       }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -18,9 +18,10 @@ package org.dartlang.vm.service;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import java.util.Map;
 import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
+
+import java.util.Map;
 
 /**
  * {@link VmService} allows control of and access to information in a running
@@ -479,6 +480,10 @@ public class VmService extends VmServiceBase {
       }
       if (responseType.equals("@Null")) {
         ((EvaluateInFrameConsumer) consumer).received(new NullRef(json));
+        return;
+      }
+      if (responseType.equals("Sentinel")) {
+        ((EvaluateInFrameConsumer) consumer).received(new Sentinel(json));
         return;
       }
     }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/consumer/EvaluateInFrameConsumer.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/consumer/EvaluateInFrameConsumer.java
@@ -17,6 +17,7 @@ package org.dartlang.vm.service.consumer;
 
 import org.dartlang.vm.service.element.ErrorRef;
 import org.dartlang.vm.service.element.InstanceRef;
+import org.dartlang.vm.service.element.Sentinel;
 
 @SuppressWarnings({"WeakerAccess", "unused", "UnnecessaryInterfaceModifier"})
 public interface EvaluateInFrameConsumer extends Consumer {
@@ -24,4 +25,6 @@ public interface EvaluateInFrameConsumer extends Consumer {
   public void received(ErrorRef response);
 
   public void received(InstanceRef response);
+
+  public void received(Sentinel response);
 }


### PR DESCRIPTION
- fix an issue where the debugger library (and originally, the debugger spec) didn't correctly handle sentinels coming back from `evaluateInFrame()`; the regular `evaluate()` call had correctly been marked as returning sentinels

@alexander-doroshko 