### PR TITLE
initial plumbing for closing labels support

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -224,6 +224,11 @@ public class DartAnalysisServerService implements Disposable {
     }
 
     @Override
+    public void computedClosingLabels(@NotNull final String filePath, List<ClosingLabel> labels) {
+      myServerData.computedClosingLabels(FileUtil.toSystemIndependentName(filePath), labels);
+    }
+
+    @Override
     public void computedImplemented(String _filePath,
                                     List<ImplementedClass> implementedClasses,
                                     List<ImplementedMember> implementedMembers) {
@@ -1491,6 +1496,9 @@ public class DartAnalysisServerService implements Disposable {
       subscriptions.put(AnalysisService.OVERRIDES, myVisibleFiles);
       if (StringUtil.compareVersionNumbers(mySdkVersion, "1.13") >= 0) {
         subscriptions.put(AnalysisService.IMPLEMENTED, myVisibleFiles);
+      }
+      if (StringUtil.compareVersionNumbers(mySdkVersion, "1.25.0") >= 0) {
+        subscriptions.put(AnalysisService.CLOSING_LABELS, myVisibleFiles);
       }
 
       if (LOG.isDebugEnabled()) {

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -76,6 +76,13 @@ public class DartServerData {
     return true;
   }
 
+  void computedClosingLabels(@NotNull final String filePath, @NotNull final List<ClosingLabel> labels) {
+    if (myFilePathsWithUnsentChanges.contains(filePath)) return;
+
+    // TODO(devoncarew): implement
+
+  }
+
   void computedHighlights(@NotNull final String filePath, @NotNull final List<HighlightRegion> regions) {
     if (myFilePathsWithUnsentChanges.contains(filePath)) return;
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -16,19 +16,7 @@ package com.google.dart.server;
 import com.google.dart.server.generated.AnalysisServer;
 import com.google.dart.server.internal.remote.utilities.ResponseUtilities;
 
-import org.dartlang.analysis.server.protocol.AnalysisError;
-import org.dartlang.analysis.server.protocol.AnalysisStatus;
-import org.dartlang.analysis.server.protocol.CompletionSuggestion;
-import org.dartlang.analysis.server.protocol.HighlightRegion;
-import org.dartlang.analysis.server.protocol.ImplementedClass;
-import org.dartlang.analysis.server.protocol.ImplementedMember;
-import org.dartlang.analysis.server.protocol.NavigationRegion;
-import org.dartlang.analysis.server.protocol.Occurrences;
-import org.dartlang.analysis.server.protocol.Outline;
-import org.dartlang.analysis.server.protocol.OverrideMember;
-import org.dartlang.analysis.server.protocol.PubStatus;
-import org.dartlang.analysis.server.protocol.RequestError;
-import org.dartlang.analysis.server.protocol.SearchResult;
+import org.dartlang.analysis.server.protocol.*;
 
 import java.util.List;
 
@@ -143,6 +131,8 @@ public interface AnalysisServerListener {
    * @param overrides the overrides associated with the file
    */
   public void computedOverrides(String file, List<OverrideMember> overrides);
+
+  public void computedClosingLabels(String file, List<ClosingLabel> labels);
 
   /**
    * A new collection of search results have been computed for the given completion id.

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -13,19 +13,7 @@
  */
 package com.google.dart.server;
 
-import org.dartlang.analysis.server.protocol.AnalysisError;
-import org.dartlang.analysis.server.protocol.AnalysisStatus;
-import org.dartlang.analysis.server.protocol.CompletionSuggestion;
-import org.dartlang.analysis.server.protocol.HighlightRegion;
-import org.dartlang.analysis.server.protocol.ImplementedClass;
-import org.dartlang.analysis.server.protocol.ImplementedMember;
-import org.dartlang.analysis.server.protocol.NavigationRegion;
-import org.dartlang.analysis.server.protocol.Occurrences;
-import org.dartlang.analysis.server.protocol.Outline;
-import org.dartlang.analysis.server.protocol.OverrideMember;
-import org.dartlang.analysis.server.protocol.PubStatus;
-import org.dartlang.analysis.server.protocol.RequestError;
-import org.dartlang.analysis.server.protocol.SearchResult;
+import org.dartlang.analysis.server.protocol.*;
 
 import java.util.List;
 
@@ -75,6 +63,10 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
 
   @Override
   public void computedOverrides(String file, List<OverrideMember> overrides) {
+  }
+
+  @Override
+  public void computedClosingLabels(String file, List<ClosingLabel> labels) {
   }
 
   @Override

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -16,20 +16,7 @@ package com.google.dart.server.internal;
 
 import com.google.common.collect.Lists;
 import com.google.dart.server.AnalysisServerListener;
-
-import org.dartlang.analysis.server.protocol.AnalysisError;
-import org.dartlang.analysis.server.protocol.AnalysisStatus;
-import org.dartlang.analysis.server.protocol.CompletionSuggestion;
-import org.dartlang.analysis.server.protocol.HighlightRegion;
-import org.dartlang.analysis.server.protocol.ImplementedClass;
-import org.dartlang.analysis.server.protocol.ImplementedMember;
-import org.dartlang.analysis.server.protocol.NavigationRegion;
-import org.dartlang.analysis.server.protocol.Occurrences;
-import org.dartlang.analysis.server.protocol.Outline;
-import org.dartlang.analysis.server.protocol.OverrideMember;
-import org.dartlang.analysis.server.protocol.PubStatus;
-import org.dartlang.analysis.server.protocol.RequestError;
-import org.dartlang.analysis.server.protocol.SearchResult;
+import org.dartlang.analysis.server.protocol.*;
 
 import java.util.List;
 
@@ -131,6 +118,13 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
   public void computedOverrides(String file, List<OverrideMember> overrides) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.computedOverrides(file, overrides);
+    }
+  }
+
+  @Override
+  public void computedClosingLabels(String file, List<ClosingLabel> labels) {
+    for (AnalysisServerListener listener : getListeners()) {
+      listener.computedClosingLabels(file, labels);
     }
   }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -74,6 +74,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   private static final String ANALYSIS_NOTIFICATION_OCCURRENCES = "analysis.occurrences";
   private static final String ANALYSIS_NOTIFICATION_OUTLINE = "analysis.outline";
   private static final String ANALYSIS_NOTIFICATION_OVERRIDES = "analysis.overrides";
+  private static final String ANALYSIS_NOTIFICATION_CLOSING_LABELS = "analysis.closingLabels";
 
   // Code Completion domain
   private static final String COMPLETION_NOTIFICATION_RESULTS = "completion.results";
@@ -520,6 +521,10 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     else if (event.equals(ANALYSIS_NOTIFICATION_OVERRIDES)) {
       // analysis.overrides
       new NotificationAnalysisOverridesProcessor(listener).process(response);
+    }
+    else if (event.equals(ANALYSIS_NOTIFICATION_CLOSING_LABELS)) {
+      // analysis.closingLabels
+      new NotificationAnalysisClosingLabelsProcessor(listener).process(response);
     }
     else if (event.equals(ANALYSIS_NOTIFICATION_ANALYZED_FILES)) {
       // analysis.errors

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationAnalysisClosingLabelsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationAnalysisClosingLabelsProcessor.java
@@ -1,0 +1,23 @@
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.AnalysisServerListener;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.dartlang.analysis.server.protocol.ClosingLabel;
+
+/**
+ * Processor for "analysis.closingLabels" notification.
+ */
+public class NotificationAnalysisClosingLabelsProcessor extends NotificationProcessor {
+  public NotificationAnalysisClosingLabelsProcessor(AnalysisServerListener listener) {
+    super(listener);
+  }
+
+  @Override
+  public void process(JsonObject response) throws Exception {
+    JsonObject paramsObject = response.get("params").getAsJsonObject();
+    String file = paramsObject.get("file").getAsString();
+    JsonArray labelsJsonArray = paramsObject.get("labels").getAsJsonArray();
+    getListener().computedClosingLabels(file, ClosingLabel.fromJsonArray(labelsJsonArray));
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AnalysisService.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AnalysisService.java
@@ -44,4 +44,5 @@ public class AnalysisService {
 
   public static final String OVERRIDES = "OVERRIDES";
 
+  public static final String CLOSING_LABELS = "CLOSING_LABELS";
 }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ClosingLabel.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ClosingLabel.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * This file has been automatically generated.  Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A label that is associated with a range of code that may be useful to render at the end of the
+ * range to aid code readability. For example, a constructor call that spans multiple lines may
+ * result in a closing label to allow the constructor type/name to be rendered alongside the
+ * closing parenthesis.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class ClosingLabel {
+
+  public static final ClosingLabel[] EMPTY_ARRAY = new ClosingLabel[0];
+
+  public static final List<ClosingLabel> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The offset of the construct being labelled.
+   */
+  private final int offset;
+
+  /**
+   * The length of the whole construct to be labelled.
+   */
+  private final int length;
+
+  /**
+   * The label associated with this range that should be displayed to the user.
+   */
+  private final String label;
+
+  /**
+   * Constructor for {@link ClosingLabel}.
+   */
+  public ClosingLabel(int offset, int length, String label) {
+    this.offset = offset;
+    this.length = length;
+    this.label = label;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof ClosingLabel) {
+      ClosingLabel other = (ClosingLabel) obj;
+      return
+        other.offset == offset &&
+        other.length == length &&
+        ObjectUtilities.equals(other.label, label);
+    }
+    return false;
+  }
+
+  public static ClosingLabel fromJson(JsonObject jsonObject) {
+    int offset = jsonObject.get("offset").getAsInt();
+    int length = jsonObject.get("length").getAsInt();
+    String label = jsonObject.get("label").getAsString();
+    return new ClosingLabel(offset, length, label);
+  }
+
+  public static List<ClosingLabel> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<ClosingLabel> list = new ArrayList<ClosingLabel>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The label associated with this range that should be displayed to the user.
+   */
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * The length of the whole construct to be labelled.
+   */
+  public int getLength() {
+    return length;
+  }
+
+  /**
+   * The offset of the construct being labelled.
+   */
+  public int getOffset() {
+    return offset;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(offset);
+    builder.append(length);
+    builder.append(label);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("offset", offset);
+    jsonObject.addProperty("length", length);
+    jsonObject.addProperty("label", label);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("offset=");
+    builder.append(offset + ", ");
+    builder.append("length=");
+    builder.append(length + ", ");
+    builder.append("label=");
+    builder.append(label);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}


### PR DESCRIPTION
@alexander-doroshko, this is some initial plumbing for 'closing labels' support. These are labels displayed inline into the editor which, for code like Flutter's build() method, can help users match the final line of a nested constructor call with the starting line. More info in https://github.com/flutter/flutter-intellij/issues/1252 and related.

We have a bit more work on the analysis server side in terms of:
- making the notifications less noisy (code changes can produce more of these notification than is absolutely necessary)
- and producing fewer notifications - we create more in a build() method than we probably should

But for the IntelliJ side, I could use some advice for this PR. It looks like in order to produce an Inlay, you start with an Editor instance, call `InlayModel getInlayModel()`, and use that returned object to create `Inlay`s. Where would be a good place in the Dart plugin to look for where I should be getting the Editor instances?

