### PR TITLE
finish the closing labels implementation

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -199,8 +199,11 @@
     <projectService serviceInterface="com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView"
                     serviceImplementation="com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView"/>
 
+    <applicationService serviceInterface="com.jetbrains.lang.dart.analyzer.ClosingLabelManager"
+                        serviceImplementation="com.jetbrains.lang.dart.analyzer.ClosingLabelManager"/>
     <applicationService serviceInterface="com.jetbrains.lang.dart.folding.DartCodeFoldingSettings"
                         serviceImplementation="com.jetbrains.lang.dart.folding.DartCodeFoldingSettings"/>
+
     <codeFoldingOptionsProvider instance="com.jetbrains.lang.dart.folding.DartCodeFoldingOptionsProvider"/>
     <editorNotificationProvider implementation="com.jetbrains.lang.dart.ide.actions.DartEditorNotificationsProvider"/>
     <consoleFilterProvider implementation="com.jetbrains.lang.dart.ide.runner.DartConsoleFilterProvider" order="first"/>
@@ -228,6 +231,8 @@
     <editorSmartKeysConfigurable instance="com.jetbrains.lang.dart.ide.editor.DartSmartKeysConfigurable"/>
 
     <postStartupActivity implementation="com.jetbrains.lang.dart.DartDumbAwareStartupActivity"/>
+
+    <editorAppearanceConfigurable instance="com.jetbrains.lang.dart.analyzer.DartEditorAppearanceConfigurable"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains">

--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -286,6 +286,7 @@ dart.analysis.server.error=Encountered a Dart Analysis Server error.
 dart.error.file.instructions=Please append the contents of:\n\
   file://{0}
 dart.smartKeys.insertDefaultArgValues.text=Insert default argument values in completions
+dart.editor.showClosingLabels.text=Show closing labels in Dart source code
 dialog.paste.on.import.title=Update Imports on Paste
 dialog.paste.on.import.text=<html>The code fragment which you have pasted uses libraries that are not accessible by imports in the new context.<br/><br/>Update imports in the new file?</html>
 always.update.imports.do.not.ask.again=Always &update, don't ask again

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/ClosingLabelManager.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/ClosingLabelManager.java
@@ -1,0 +1,191 @@
+package com.jetbrains.lang.dart.analyzer;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.editor.*;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
+import com.intellij.openapi.editor.colors.FontPreferences;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.editor.impl.ComplementaryFontsRegistry;
+import com.intellij.openapi.editor.impl.FontInfo;
+import com.intellij.openapi.editor.markup.TextAttributes;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.ui.UIUtil;
+import com.jetbrains.lang.dart.ide.codeInsight.DartCodeInsightSettings;
+import org.dartlang.analysis.server.protocol.ClosingLabel;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ClosingLabelManager {
+  public static ClosingLabelManager getInstance() {
+    return ServiceManager.getService(ClosingLabelManager.class);
+  }
+
+  private List<PreferenceChangeListener> listeners = new ArrayList<>();
+
+  interface PreferenceChangeListener {
+    void closingLabelPreferenceChanged();
+  }
+
+  public ClosingLabelManager() {
+    addListener(new PreferenceChangeListener() {
+      @Override
+      public void closingLabelPreferenceChanged() {
+        if (!getShowClosingLabels()) {
+          UIUtil.invokeLaterIfNeeded(() -> clearAllInlays());
+        }
+      }
+    });
+  }
+
+  public void setShowClosingLabels(boolean value) {
+    DartCodeInsightSettings.getInstance().SHOW_CLOSING_LABELS = value;
+
+    notifyPreferenceChanged();
+  }
+
+  public boolean getShowClosingLabels() {
+    return DartCodeInsightSettings.getInstance().SHOW_CLOSING_LABELS;
+  }
+
+  public void addListener(PreferenceChangeListener listener) {
+    listeners.add(listener);
+  }
+
+  public void removeListener(PreferenceChangeListener listener) {
+    listeners.remove(listener);
+  }
+
+  void computedClosingLabels(@NotNull Project project, @NotNull final String filePath, @NotNull final List<ClosingLabel> labels) {
+    if (!getShowClosingLabels()) {
+      return;
+    }
+
+    final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath);
+    if (file == null) {
+      return;
+    }
+
+    UIUtil.invokeLaterIfNeeded(() -> {
+      for (final FileEditor fileEditor : FileEditorManager.getInstance(project).getEditors(file)) {
+        if (!(fileEditor instanceof TextEditor)) {
+          continue;
+        }
+
+        final TextEditor textEditor = (TextEditor)fileEditor;
+        final Editor editor = textEditor.getEditor();
+        final InlayModel inlayModel = editor.getInlayModel();
+
+        clearEditorInlays(editor);
+
+        // Display combined labels as `// Foo, Bar`, not `// Foo // Bar`.
+
+        // sort the new inlays by starting offset, reversed order
+        labels.sort((label1, label2) -> label2.getOffset() - label1.getOffset());
+
+        // create the inlay text for each line
+        Map<Integer, String> lineText = new HashMap<>();
+        for (ClosingLabel label : labels) {
+          final int offset = label.getOffset() + label.getLength();
+          final Integer line = editor.getDocument().getLineNumber(offset);
+
+          if (lineText.containsKey(line)) {
+            lineText.put(line, lineText.get(line) + ", " + label.getLabel());
+          }
+          else {
+            lineText.put(line, "// " + label.getLabel());
+          }
+        }
+
+        // build inlays from the line labels
+        for (Integer line : lineText.keySet()) {
+          inlayModel.addInlineElement(
+            editor.getDocument().getLineEndOffset(line), true, new TextLabelCustomElementRenderer(lineText.get(line)));
+        }
+      }
+    });
+  }
+
+  private static void clearEditorInlays(@NotNull Editor editor) {
+    List<Inlay> existingInlays = editor.getInlayModel().getInlineElementsInRange(0, editor.getDocument().getTextLength());
+    for (Inlay inlay : existingInlays) {
+      if (inlay.getRenderer() instanceof TextLabelCustomElementRenderer) {
+        Disposer.dispose(inlay);
+      }
+    }
+  }
+
+  private static void clearAllInlays() {
+    for (Project project : ProjectManager.getInstance().getOpenProjects()) {
+      final FileEditor[] editors = FileEditorManager.getInstance(project).getAllEditors();
+
+      for (FileEditor fileEditor : editors) {
+        if (fileEditor instanceof TextEditor) {
+          Editor editor = ((TextEditor)fileEditor).getEditor();
+          List<Inlay> existingInlays = editor.getInlayModel().getInlineElementsInRange(0, editor.getDocument().getTextLength());
+          for (Inlay inlay : existingInlays) {
+            if (inlay.getRenderer() instanceof TextLabelCustomElementRenderer) {
+              Disposer.dispose(inlay);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private void notifyPreferenceChanged() {
+    for (PreferenceChangeListener listener : listeners) {
+      listener.closingLabelPreferenceChanged();
+    }
+  }
+}
+
+class TextLabelCustomElementRenderer implements EditorCustomElementRenderer {
+  private static TextAttributesKey TEXT_ATTRIBUTES = DefaultLanguageHighlighterColors.LINE_COMMENT;
+
+  private final String label;
+
+  TextLabelCustomElementRenderer(@NotNull String label) {
+    this.label = " " + label;
+  }
+
+  private static FontInfo getFontInfo(@NotNull Editor editor) {
+    EditorColorsScheme colorsScheme = editor.getColorsScheme();
+    FontPreferences fontPreferences = colorsScheme.getFontPreferences();
+    TextAttributes attributes = editor.getColorsScheme().getAttributes(TEXT_ATTRIBUTES);
+    int fontStyle = attributes == null ? Font.PLAIN : attributes.getFontType();
+    return ComplementaryFontsRegistry.getFontAbleToDisplay(
+      'a', fontStyle, fontPreferences,
+      FontInfo.getFontRenderContext(editor.getContentComponent()));
+  }
+
+  @Override
+  public int calcWidthInPixels(@NotNull Editor editor) {
+    FontInfo fontInfo = getFontInfo(editor);
+    return fontInfo.fontMetrics().stringWidth(label);
+  }
+
+  @Override
+  public void paint(@NotNull Editor editor, @NotNull Graphics g, @NotNull Rectangle r, @NotNull TextAttributes textAttributes) {
+    TextAttributes attributes = editor.getColorsScheme().getAttributes(TEXT_ATTRIBUTES);
+    if (attributes == null) return;
+    Color fgColor = attributes.getForegroundColor();
+    if (fgColor == null) return;
+    g.setColor(fgColor);
+    FontInfo fontInfo = getFontInfo(editor);
+    g.setFont(fontInfo.getFont());
+    FontMetrics metrics = fontInfo.fontMetrics();
+    g.drawString(label, r.x, r.y + metrics.getAscent());
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartEditorAppearanceConfigurable.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartEditorAppearanceConfigurable.java
@@ -1,0 +1,28 @@
+package com.jetbrains.lang.dart.analyzer;
+
+import com.intellij.openapi.options.BeanConfigurable;
+import com.intellij.openapi.options.UnnamedConfigurable;
+import com.intellij.ui.IdeBorderFactory;
+import com.jetbrains.lang.dart.DartBundle;
+
+import javax.swing.*;
+
+public class DartEditorAppearanceConfigurable extends BeanConfigurable<ClosingLabelManager> implements UnnamedConfigurable {
+  public DartEditorAppearanceConfigurable() {
+    super(ClosingLabelManager.getInstance());
+
+    ClosingLabelManager closingLabelManager = getInstance();
+    checkBox(
+      DartBundle.message("dart.editor.showClosingLabels.text"),
+      () -> closingLabelManager.getShowClosingLabels(),
+      v -> closingLabelManager.setShowClosingLabels(v));
+  }
+
+  @Override
+  public JComponent createComponent() {
+    JComponent result = super.createComponent();
+    assert result != null;
+    result.setBorder(IdeBorderFactory.createTitledBorder("Dart")); //$NON-NLS-1$
+    return result;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -77,10 +77,12 @@ public class DartServerData {
   }
 
   void computedClosingLabels(@NotNull final String filePath, @NotNull final List<ClosingLabel> labels) {
-    if (myFilePathsWithUnsentChanges.contains(filePath)) return;
+    if (myFilePathsWithUnsentChanges.contains(filePath)) {
+      return;
+    }
 
-    // TODO(devoncarew): implement
-
+    ClosingLabelManager.getInstance().computedClosingLabels(
+      myService.getProject(), FileUtil.toSystemIndependentName(filePath), labels);
   }
 
   void computedHighlights(@NotNull final String filePath, @NotNull final List<HighlightRegion> regions) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/codeInsight/DartCodeInsightSettings.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/codeInsight/DartCodeInsightSettings.java
@@ -33,9 +33,10 @@ public class DartCodeInsightSettings implements PersistentStateComponent<DartCod
 
   public boolean INSERT_DEFAULT_ARG_VALUES = true;
 
+  public boolean SHOW_CLOSING_LABELS = true;
+
   @MagicConstant(intValues = {YES, NO, ASK})
   public int ADD_IMPORTS_ON_PASTE = ASK;
-
 
   @Override
   public DartCodeInsightSettings getState() {


### PR DESCRIPTION
Follow up to https://github.com/JetBrains/intellij-plugins/pull/549, finish the closing labels implementation.
- show a preference toggle in the Editor > General > Appearance page
- listen for preference changes, and enable / disable labels as appropriate
- listen for closing label events from the analysis server, and render Inlays in the appropriate editors

@alexander-doroshko 

<img width="440" alt="screen shot 2017-09-26 at 4 23 46 pm" src="https://user-images.githubusercontent.com/1269969/30889812-ca0c2284-a2dd-11e7-8dbf-b4da096933e2.png">

<img width="503" alt="screen shot 2017-09-26 at 5 13 19 pm" src="https://user-images.githubusercontent.com/1269969/30889861-0dd2f768-a2de-11e7-8c78-b833914b67b9.png">

