### PR TITLE
some tweaks to the dart method refactoring dialog

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/extract/DartServerExtractMethodHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/extract/DartServerExtractMethodHandler.java
@@ -60,7 +60,10 @@ public class DartServerExtractMethodHandler implements RefactoringActionHandler 
       }
       if (initialStatus.hasError()) {
         final String title = DartBundle.message("dart.refactoring.extract.method.error");
-        CommonRefactoringUtil.showErrorHint(project, editor, initialStatus.getMessage(), title, null);
+        final String message = initialStatus.getMessage();
+        // This is not null if the status has an error.
+        assert message != null;
+        CommonRefactoringUtil.showErrorHint(project, editor, message, title, null);
         return;
       }
     }
@@ -107,16 +110,19 @@ class DartServerExtractMethodDialog extends ServerRefactoringDialog<ServerExtrac
     }
 
     if (myRefactoring.canExtractGetter()) {
-      myGetterCheckBox.setSelected(true);
-      myGetterCheckBox.addActionListener(e -> {
-        myRefactoring.setCreateGetter(myGetterCheckBox.isSelected());
-        mySignatureLabel.setText(myRefactoring.getSignature());
-      });
+      myGetterCheckBox.setSelected(false);
+      updateRefactoringPreview();
+      myGetterCheckBox.addActionListener(e -> updateRefactoringPreview());
     }
     else {
       myGetterCheckBox.setEnabled(false);
     }
 
+    mySignatureLabel.setText(myRefactoring.getSignature());
+  }
+
+  private void updateRefactoringPreview() {
+    myRefactoring.setCreateGetter(myGetterCheckBox.isSelected());
     mySignatureLabel.setText(myRefactoring.getSignature());
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/status/RefactoringStatus.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/status/RefactoringStatus.java
@@ -123,7 +123,7 @@ public class RefactoringStatus {
 
   /**
    * Return the message from the {@link RefactoringStatusEntry} with the highest severity; may be
-   * {@code null} if not entries are present.
+   * {@code null} if no entries are present.
    */
   @Nullable
   public String getMessage() {


### PR DESCRIPTION
This PR makes a small tweak to the refactor method dialog so that the `getter` option is not selected by default when entering the dialog. It's a bit confusing to users (who don't necessarily read all the options) that sometimes the dialog creates getters and sometimes not. Without the user explicitly specifying it, we now default to creating methods (not getters).

@alexander-doroshko 