### PR TITLE
Use already known step annotation when extracting regex pattern 

### DIFF
--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/CucumberJavaExtension.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/CucumberJavaExtension.java
@@ -52,7 +52,7 @@ public class CucumberJavaExtension extends AbstractCucumberJavaExtension {
       if (annotationClass.isAnnotationType()) {
         final Query<PsiMethod> javaStepDefinitions = AnnotatedElementsSearch.searchPsiMethods(annotationClass, dependenciesScope);
         for (PsiMethod stepDefMethod : javaStepDefinitions) {
-          result.add(new JavaStepDefinition(stepDefMethod));
+          result.add(new JavaStepDefinition(stepDefMethod, annotationClass));
         }
       }
     }

--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/steps/JavaStepDefinition.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/steps/JavaStepDefinition.java
@@ -13,8 +13,17 @@ import java.util.regex.Matcher;
 import java.util.regex.PatternSyntaxException;
 
 public class JavaStepDefinition extends AbstractStepDefinition {
+  @Nullable
+  private final PsiClass annotationClass;
+
   public JavaStepDefinition(PsiElement stepDef) {
     super(stepDef);
+    this.annotationClass = null;
+  }
+
+  public JavaStepDefinition(PsiElement stepDef, @Nullable PsiClass annotationClass) {
+    super(stepDef);
+    this.annotationClass = annotationClass;
   }
 
   @Override
@@ -34,8 +43,12 @@ public class JavaStepDefinition extends AbstractStepDefinition {
   @Nullable
   @Override
   protected String getCucumberRegexFromElement(PsiElement element) {
-    if (element instanceof PsiMethod) {
-      final PsiAnnotation stepAnnotation = CucumberJavaUtil.getCucumberStepAnnotation((PsiMethod)element);
+    if (element instanceof PsiMethod && annotationClass != null) {
+      final String annotationName = annotationClass.getQualifiedName();
+      if (annotationName == null) {
+        return null;
+      }
+      final PsiAnnotation stepAnnotation = ((PsiMethod) element).getModifierList().findAnnotation(annotationName);
       if (stepAnnotation == null) {
         return null;
       }


### PR DESCRIPTION
...instead of relying on cucumber package names

**As** the creator of an alternative cucumber implementation
**I want** my implementation to be supported by intellij
**So that** my users are happy

The cucumber-java plugin currently uses two different ways to identify annotated step definitions:

 - In `CucumberJavaExtension` it correctly uses the `StepDefAnnotation` meta-annotation to find all annotated methods
 - For matching steps against patterns, `CucumberJavaUtil` relies on the package name of the methods annotation

I would like the plugin to support additional annotations, which are still annotated by `StepDefAnnotation`, but reside in a different package than the cucumber ones. The PR solves this by reusing the discovered annotation class from the step definition.

Please note that this is the first time I'm touching an IntelliJ plugin and I'm still struggling with running the unit tests.

There are also still several usages of the package-based logic, which I was not able to replace yet. 