### PR TITLE
update the icons we use for test outline elements

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewElement.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewElement.java
@@ -1,5 +1,6 @@
 package com.jetbrains.lang.dart.ide.structure;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.ide.structureView.StructureViewTreeElement;
 import com.intellij.ide.util.treeView.NodeDescriptorProvidingKey;
 import com.intellij.navigation.ItemPresentation;
@@ -148,14 +149,13 @@ public class DartStructureViewElement implements StructureViewTreeElement, ItemP
       case ElementKind.PARAMETER:
       case ElementKind.PREFIX:
       case ElementKind.TYPE_PARAMETER:
+      case ElementKind.UNIT_TEST_GROUP:
+        return AllIcons.RunConfigurations.Junit;
+      case ElementKind.UNIT_TEST_TEST:
+        return DartIcons.TestNode;
       case ElementKind.UNKNOWN:
         return null; // unexpected
       default:
-        final String name = myOutline.getElement().getName();
-        if (name.startsWith("test ") || name.startsWith("group ")) {
-          return DartIcons.TestNode;
-        }
-
         return null;
     }
   }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ElementKind.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ElementKind.java
@@ -63,14 +63,8 @@ public class ElementKind {
 
   public static final String TYPE_PARAMETER = "TYPE_PARAMETER";
 
-  /**
-   * Deprecated: support for tests was removed.
-   */
   public static final String UNIT_TEST_GROUP = "UNIT_TEST_GROUP";
 
-  /**
-   * Deprecated: support for tests was removed.
-   */
   public static final String UNIT_TEST_TEST = "UNIT_TEST_TEST";
 
   public static final String UNKNOWN = "UNKNOWN";


### PR DESCRIPTION
@alexander-doroshko, this updates how we determine want icons to use for `group` and `test` items in the outline view (it uses newly undeprecated element kinds), and switches the icons that we use. Here's the latest:

<img width="352" alt="screen shot 2017-10-10 at 2 25 12 pm" src="https://user-images.githubusercontent.com/1269969/31411979-4173d278-adc8-11e7-8531-eccad1dc134c.png">

This depends on some soon-to-land changes in the analysis server (https://dart-review.googlesource.com/c/sdk/+/12841).