### PR TITLE
Fix for Dart/Flutter plugin issue https://github.com/flutter/flutter-intellij/issues/1449

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartEditorNotificationsProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartEditorNotificationsProvider.java
@@ -53,12 +53,14 @@ public class DartEditorNotificationsProvider extends EditorNotifications.Provide
       return null;
     }
 
-    if (PubspecYamlUtil.PUBSPEC_YAML.equalsIgnoreCase(vFile.getName())) {
+    boolean isPubspecFile = PubspecYamlUtil.isPubspecFile(vFile);
+
+    if (isPubspecFile) {
       final Module module = ModuleUtilCore.findModuleForFile(vFile, myProject);
       if (module == null) return null;
 
       // Defer to the Flutter plugin for package management and SDK configuration if appropriate.
-      if (FlutterUtil.isFlutterPluginInstalled() && FlutterUtil.isFlutterModule(module)) return null;
+      if (FlutterUtil.isFlutterPluginInstalled() && FlutterUtil.isPubspecDeclaringFlutter(vFile)) return null;
 
       final DartSdk sdk = DartSdk.getDartSdk(myProject);
       if (sdk != null && DartSdkLibUtil.isDartSdkEnabled(module)) {
@@ -66,7 +68,7 @@ public class DartEditorNotificationsProvider extends EditorNotifications.Provide
       }
     }
 
-    if (PubspecYamlUtil.PUBSPEC_YAML.equalsIgnoreCase(vFile.getName()) || vFile.getFileType() == DartFileType.INSTANCE) {
+    if (isPubspecFile || vFile.getFileType() == DartFileType.INSTANCE) {
       final DartSdk sdk = DartSdk.getDartSdk(myProject);
 
       final PsiFile psiFile = PsiManager.getInstance(myProject).findFile(vFile);

--- a/Dart/src/com/jetbrains/lang/dart/util/PubspecYamlUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/PubspecYamlUtil.java
@@ -38,6 +38,11 @@ public class PubspecYamlUtil {
 
   private static final Key<Pair<Long, Map<String, Object>>> MOD_STAMP_TO_PUBSPEC_NAME = Key.create("MOD_STAMP_TO_PUBSPEC_NAME");
 
+  public static boolean isPubspecFile(@NotNull final VirtualFile file) {
+    // https://www.dartlang.org/tools/pub/pubspec
+    return !file.isDirectory() && file.getName().equals(PUBSPEC_YAML);
+  }
+
   @Nullable
   public static VirtualFile findPubspecYamlFile(@NotNull final Project project, @NotNull final VirtualFile contextFile) {
     final ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter-intellij/issues/1449, and a change to the Dart Plugin and Flutter Plugin to check for the flutteriness of a pubspec.  We now look to see if the individual pubspec declares flutter when determining if a notification should appear for a pubspec, _instead_ of asking the module if some pubspec.yaml declares flutter.

Nit: when comparing a file name to "pubspec.yaml" the two plugins are not consistent in _not_ ignoring the case of the filename.

Corresponding PR: https://github.com/flutter/flutter-intellij/pull/1468