### PR TITLE
avoid an exception from a @NotNull annotation

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
@@ -377,11 +377,13 @@ public class DartVmServiceValue extends XNamedValue {
     });
   }
 
-  private void addListChildren(@NotNull final XCompositeNode node, @NotNull final ElementList<InstanceRef> listElements) {
-    final XValueChildrenList childrenList = new XValueChildrenList(listElements.size());
+  private void addListChildren(@NotNull final XCompositeNode node, @Nullable final ElementList<InstanceRef> listElements) {
+    final XValueChildrenList childrenList = new XValueChildrenList(listElements == null ? 0 : listElements.size());
     int index = myCollectionChildrenAlreadyShown.get();
-    for (InstanceRef listElement : listElements) {
-      childrenList.add(new DartVmServiceValue(myDebugProcess, myIsolateId, String.valueOf(index++), listElement, null, null, false));
+    if (listElements != null) {
+      for (InstanceRef listElement : listElements) {
+        childrenList.add(new DartVmServiceValue(myDebugProcess, myIsolateId, String.valueOf(index++), listElement, null, null, false));
+      }
     }
     node.addChildren(childrenList, true);
   }


### PR DESCRIPTION
- avoid an exception from a @NotNull annotation

While debugging, I saw this exception:

```
Argument for @NotNull parameter 'listElements' of com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.addListChildren must not be null
```

Instance.getElements() shouldn't return null, but it can in certain error circumstances. This moves the validation out of annotations.

@alexander-doroshko 