### PR TITLE
use session.areBreakpointsMuted to help determine the break on exceptions mode

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartExceptionBreakpointHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartExceptionBreakpointHandler.java
@@ -1,6 +1,7 @@
 package com.jetbrains.lang.dart.ide.runner.server.vmService;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.intellij.xdebugger.breakpoints.XBreakpoint;
 import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
@@ -31,7 +32,11 @@ public class DartExceptionBreakpointHandler extends XBreakpointHandler<XBreakpoi
   }
 
   @NotNull
-  public static ExceptionPauseMode getBreakOnExceptionMode(@Nullable final XBreakpoint<DartExceptionBreakpointProperties> bp) {
+  public static ExceptionPauseMode getBreakOnExceptionMode(@NotNull XDebugSession session,
+                                                           @Nullable final XBreakpoint<DartExceptionBreakpointProperties> bp) {
+    if (session.areBreakpointsMuted()) {
+      return ExceptionPauseMode.None;
+    }
     if (bp == null) return ExceptionPauseMode.Unhandled; // Default to breaking on unhandled exceptions.
     if (!bp.isEnabled()) return ExceptionPauseMode.None;
     return bp.getProperties().isBreakOnAllExceptions() ? ExceptionPauseMode.All : ExceptionPauseMode.Unhandled;
@@ -41,7 +46,7 @@ public class DartExceptionBreakpointHandler extends XBreakpointHandler<XBreakpoi
   public void registerBreakpoint(@NotNull final XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
     final VmServiceWrapper vmServiceWrapper = myDebugProcess.getVmServiceWrapper();
     if (vmServiceWrapper != null) {
-      vmServiceWrapper.setExceptionPauseMode(getBreakOnExceptionMode(breakpoint));
+      vmServiceWrapper.setExceptionPauseMode(getBreakOnExceptionMode(myDebugProcess.getSession(), breakpoint));
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -167,7 +167,8 @@ public class VmServiceWrapper implements Disposable {
     // Just to make sure that the main isolate is not handled twice, both from handleDebuggerConnected() and DartVmServiceListener.received(PauseStart)
     if (newIsolate) {
       final ExceptionPauseMode mode = DartExceptionBreakpointHandler
-        .getBreakOnExceptionMode(DartExceptionBreakpointHandler.getDefaultExceptionBreakpoint(myDebugProcess.getSession().getProject()));
+        .getBreakOnExceptionMode(myDebugProcess.getSession(),
+                                 DartExceptionBreakpointHandler.getDefaultExceptionBreakpoint(myDebugProcess.getSession().getProject()));
       addRequest(() -> myVmService.setExceptionPauseMode(isolateRef.getId(),
                                                          mode,
                                                          new VmServiceConsumers.SuccessConsumerWrapper() {


### PR DESCRIPTION
- use session.areBreakpointsMuted to help determine the break on exceptions mode

This does address https://github.com/flutter/flutter-intellij/issues/1164, but will only help users of the Flutter plugin who have a version of the Dart plugin with this fix.

@alexander-doroshko 
