### PR TITLE
Don't select the current line in 'Extract Method' when selection is empty.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/extract/DartServerExtractMethodHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/extract/DartServerExtractMethodHandler.java
@@ -46,7 +46,6 @@ public class DartServerExtractMethodHandler implements RefactoringActionHandler 
   @Override
   public void invoke(@NotNull Project project, Editor editor, PsiFile file, DataContext dataContext) {
     final SelectionModel selectionModel = editor.getSelectionModel();
-    if (!selectionModel.hasSelection()) selectionModel.selectLineAtCaret();
 
     final int offset = selectionModel.getSelectionStart();
     final int length = selectionModel.getSelectionEnd() - offset;


### PR DESCRIPTION
Instead Dart Analysis Server [was enhanced](https://dart-review.googlesource.com/c/sdk/+/41520) to extract the smallest extractable expression that covers the caret.