### PR TITLE
fix a race condition in the dart debugger against --preview-dart-2 vms

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceListener.java
@@ -99,6 +99,10 @@ public class DartVmServiceListener implements VmServiceListener {
         break;
       case ServiceExtensionAdded:
         break;
+      case ServiceRegistered:
+        break;
+      case ServiceUnregistered:
+        break;
       case VMUpdate:
         break;
       case WriteEvent:

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -110,6 +110,12 @@ public class VmServiceWrapper implements Disposable {
                       final Event event = isolate.getPauseEvent();
                       final EventKind eventKind = event.getKind();
 
+                      // Ignore isolates that are very early in their lifecycle. You can't set breakpoints on them
+                      // yet, and we'll get lifecycle events for them later.
+                      if (eventKind == EventKind.None) {
+                        return;
+                      }
+
                       // if event is not PauseStart it means that PauseStart event will follow later and will be handled by listener
                       handleIsolate(isolateRef, eventKind == EventKind.PauseStart);
 
@@ -351,7 +357,7 @@ public class VmServiceWrapper implements Disposable {
         @Override
         public void onError(RPCError error) {
           myDebugProcess.getSession().getConsoleView()
-            .print("Error from drop frame: " + error.getMessage() + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+                        .print("Error from drop frame: " + error.getMessage() + "\n", ConsoleViewContentType.ERROR_OUTPUT);
         }
 
         @Override


### PR DESCRIPTION
We 're seeing a race condition when debugging against the dart vm when it's run with `--preview-dart-2`. The main isolate takes much longer to start up now - it's compiling the user's app with the common front end. We request isolates from the VM at startup, but now the main isolate is often in a pre-runnable state, where trying to set a breakpoint will fail.

To repro, create a command-line app, set a breakpoint, and hit run. The app will never auto-resume from start.

This fix:
- addresses an existing issue where the data in the `myIsolateIdToInfoMap` map would be replaced - we call `IsolatesInfo.addIsolate()` twice, and the 2nd time the info was being replaced.
- we do not try and set breakpoints on isolates that are not yet runnable. Those breakpoint attempts would fail; we instead wait for later lifecycle events (like runnable)

@alexander-doroshko 