### PR TITLE
added wanneer as one of the dutch translations for when

### DIFF
--- a/cucumber/resources/i18n.json
+++ b/cucumber/resources/i18n.json
@@ -554,7 +554,7 @@
 	  "scenario_outline": "Abstract Scenario",
 	  "examples": "Voorbeelden",
 	  "given": "*|Gegeven|Stel",
-	  "when": "*|Als",
+	  "when": "*|Als|Wanneer",
 	  "then": "*|Dan",
 	  "and": "*|En",
 	  "but": "*|Maar"

--- a/cucumber/testData/keywords/i18n.json
+++ b/cucumber/testData/keywords/i18n.json
@@ -428,7 +428,7 @@
 	  "scenario_outline": "Abstract Scenario",
 	  "examples": "Voorbeelden",
 	  "given": "*|Gegeven|Stel",
-	  "when": "*|Als",
+	  "when": "*|Als|Wanneer",
 	  "then": "*|Dan",
 	  "and": "*|En",
 	  "but": "*|Maar"


### PR DESCRIPTION
Cucumber supports 'Wanneer' as a translation for 'When', but the Intellij cucumber plugin does not recognize 'Wanneer' as a keyword yet. I added 'Wanneer' as a Dutch translation for 'when'.