### PR TITLE
update to the latest vm service library

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/imports/DartImportOptimizer.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/imports/DartImportOptimizer.java
@@ -48,7 +48,7 @@ public class DartImportOptimizer implements ImportOptimizer {
               myFileChanged = true;
               final Document document = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
               if (document != null) {
-                // Tricky story. Committing a document here is required in oder to guarantee that DartPostFormatProcessor.processText() is called afterwards.
+                // Tricky story. Committing a document here is required in order to guarantee that DartPostFormatProcessor.processText() is called afterwards.
                 PsiDocumentManager.getInstance(file.getProject()).commitDocument(document);
               }
             }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -77,7 +77,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 6;
+  public static final int versionMinor = 8;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
@@ -467,6 +467,17 @@ public class VmService extends VmServiceBase {
     params.addProperty("isolateId", isolateId);
     params.addProperty("mode", mode.name());
     request("setExceptionPauseMode", params, consumer);
+  }
+
+  /**
+   * The [setFlag] RPC is used to set a VM flag at runtime. Returns an error if the named flag does
+   * not exist, the flag may not be set at runtime, or the value is of the wrong type for the flag.
+   */
+  public void setFlag(String name, String value, SuccessConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("name", name);
+    params.addProperty("value", value);
+    request("setFlag", params, consumer);
   }
 
   /**

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -117,9 +117,14 @@ abstract class VmServiceBase implements VmServiceConst {
     });
 
     // Establish WebSocket Connection
+    //noinspection TryWithIdenticalCatches
     try {
       webSocket.connect();
     } catch (WebSocketException e) {
+      throw new IOException("Failed to connect: " + url, e);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // The weberknecht can occasionally throw an array index exception if a connect terminates on initial connect
+      // (de.roderick.weberknecht.WebSocket.connect, WebSocket.java:126).
       throw new IOException("Failed to connect: " + url, e);
     }
     vmService.requestSink = new WebSocketRequestSink(webSocket);

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
@@ -212,8 +212,8 @@ public class Event extends Response {
    * pause events, the timestamp is from when the isolate was paused. For other events, the
    * timestamp is from when the event was created.
    */
-  public int getTimestamp() {
-    return json.get("timestamp") == null ? -1 : json.get("timestamp").getAsInt();
+  public long getTimestamp() {
+    return json.get("timestamp") == null ? -1 : json.get("timestamp").getAsLong();
   }
 
   /**


### PR DESCRIPTION
update to the latest vm service library:
- have Event.timestamp return a long (instead of an int)
- work around a (rare) issue with the weberknecht library

@alexander-doroshko 