### PR TITLE
Bump Error Prone library to 2.3.2

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
-  <artifact version="2.3.1" name="error-prone" urlPrefix="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_ant/2.3.1/">
-    <item url="error_prone_ant-2.3.1.jar"/>
+  <artifact version="2.3.2" name="error-prone" urlPrefix="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_ant/2.3.2/">
+    <item url="error_prone_ant-2.3.2.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
Please note that this PR should not be merged until the 2.3.2 ant
library has been uploaded to maven; for some reason this particular
integration was skipped.

Please see [here](https://repo1.maven.org/maven2/com/google/errorprone/error_prone_ant/) for determining whether 2.3.2 has been released.