### PR TITLE
upgrade the service protocol library to 3.10

### DIFF
--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -77,7 +77,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 9;
+  public static final int versionMinor = 12;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
@@ -270,6 +270,19 @@ public class VmService extends VmServiceBase {
   }
 
   /**
+   * Returns a ServiceObject (a specialization of an ObjRef).
+   *
+   * @undocumented
+   */
+  public void getInstances(String isolateId, String classId, int limit, ObjRefConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    params.addProperty("classId", classId);
+    params.addProperty("limit", limit);
+    request("_getInstances", params, consumer);
+  }
+
+  /**
    * The [getIsolate] RPC is used to lookup an [Isolate] object by its [id].
    */
   public void getIsolate(String isolateId, GetIsolateConsumer consumer) {
@@ -300,6 +313,16 @@ public class VmService extends VmServiceBase {
     if (offset != null) params.addProperty("offset", offset);
     if (count != null) params.addProperty("count", count);
     request("getObject", params, consumer);
+  }
+
+  /**
+   * The [getScripts] RPC is used to retrieve a [ScriptList] containing all scripts for an isolate
+   * based on the isolate's [isolateId].
+   */
+  public void getScripts(String isolateId, ScriptListConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    request("getScripts", params, consumer);
   }
 
   /**
@@ -723,6 +746,60 @@ public class VmService extends VmServiceBase {
         return;
       }
     }
+    if (consumer instanceof ObjRefConsumer) {
+      if (responseType.equals("@Class")) {
+        ((ObjRefConsumer) consumer).received(new ClassRef(json));
+        return;
+      }
+      if (responseType.equals("Code")) {
+        ((ObjRefConsumer) consumer).received(new Code(json));
+        return;
+      }
+      if (responseType.equals("@Code")) {
+        ((ObjRefConsumer) consumer).received(new CodeRef(json));
+        return;
+      }
+      if (responseType.equals("@Context")) {
+        ((ObjRefConsumer) consumer).received(new ContextRef(json));
+        return;
+      }
+      if (responseType.equals("@Error")) {
+        ((ObjRefConsumer) consumer).received(new ErrorRef(json));
+        return;
+      }
+      if (responseType.equals("@Field")) {
+        ((ObjRefConsumer) consumer).received(new FieldRef(json));
+        return;
+      }
+      if (responseType.equals("@Function")) {
+        ((ObjRefConsumer) consumer).received(new FuncRef(json));
+        return;
+      }
+      if (responseType.equals("@Instance")) {
+        ((ObjRefConsumer) consumer).received(new InstanceRef(json));
+        return;
+      }
+      if (responseType.equals("@Library")) {
+        ((ObjRefConsumer) consumer).received(new LibraryRef(json));
+        return;
+      }
+      if (responseType.equals("@Null")) {
+        ((ObjRefConsumer) consumer).received(new NullRef(json));
+        return;
+      }
+      if (responseType.equals("@Object")) {
+        ((ObjRefConsumer) consumer).received(new ObjRef(json));
+        return;
+      }
+      if (responseType.equals("@Script")) {
+        ((ObjRefConsumer) consumer).received(new ScriptRef(json));
+        return;
+      }
+      if (responseType.equals("@TypeArguments")) {
+        ((ObjRefConsumer) consumer).received(new TypeArgumentsRef(json));
+        return;
+      }
+    }
     if (consumer instanceof ReloadReportConsumer) {
       if (responseType.equals("ReloadReport")) {
         ((ReloadReportConsumer) consumer).received(new ReloadReport(json));
@@ -866,6 +943,10 @@ public class VmService extends VmServiceBase {
         ((ResponseConsumer) consumer).received(new Script(json));
         return;
       }
+      if (responseType.equals("ScriptList")) {
+        ((ResponseConsumer) consumer).received(new ScriptList(json));
+        return;
+      }
       if (responseType.equals("@Script")) {
         ((ResponseConsumer) consumer).received(new ScriptRef(json));
         return;
@@ -916,6 +997,12 @@ public class VmService extends VmServiceBase {
       }
       if (responseType.equals("_CpuProfile")) {
         ((ResponseConsumer) consumer).received(new CpuProfile(json));
+        return;
+      }
+    }
+    if (consumer instanceof ScriptListConsumer) {
+      if (responseType.equals("ScriptList")) {
+        ((ScriptListConsumer) consumer).received(new ScriptList(json));
         return;
       }
     }

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/consumer/ObjRefConsumer.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/consumer/ObjRefConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.ObjRef;
+
+@SuppressWarnings({"WeakerAccess", "unused", "UnnecessaryInterfaceModifier"})
+public interface ObjRefConsumer extends Consumer {
+
+  public void received(ObjRef response);
+}

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/consumer/ScriptListConsumer.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/consumer/ScriptListConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.ScriptList;
+
+@SuppressWarnings({"WeakerAccess", "unused", "UnnecessaryInterfaceModifier"})
+public interface ScriptListConsumer extends Consumer {
+
+  public void received(ScriptList response);
+}

--- a/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/ScriptList.java
+++ b/Dart/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/element/ScriptList.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+@SuppressWarnings({"WeakerAccess", "unused", "UnnecessaryInterfaceModifier"})
+public class ScriptList extends Response {
+
+  public ScriptList(JsonObject json) {
+    super(json);
+  }
+
+  public ElementList<ScriptRef> getScripts() {
+    return new ElementList<ScriptRef>(json.get("scripts").getAsJsonArray()) {
+      @Override
+      protected ScriptRef basicGet(JsonArray array, int index) {
+        return new ScriptRef(array.get(index).getAsJsonObject());
+      }
+    };
+  }
+}


### PR DESCRIPTION
- upgrade the service protocol library to 3.10

This exposes the new `isolate.getScripts()` call (not yet available in shipping Dart SDKs).

@jwren @alexander-doroshko 