### PR TITLE
adjust the Dart analysis server crash report template

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -266,7 +266,7 @@ analysis.server.status.good.text=Submit Analyzer Feedback...
 analysis.server.show.diagnostics.text=View analyzer diagnostics...
 analysis.server.show.diagnostics.error=Error opening Dart Analysis Server diagnostics page
 
-dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Analyzer Feedback from IntelliJ\n\n\
+dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?labels=area-analyzer,analyzer-crash-report&body=Analyzer Feedback from IntelliJ\n\n\
   # Version information\n\n\
   - `IDEA {0}`\n\
   - `{1}`\n\


### PR DESCRIPTION
- this updates the Dart crash report template slightly - it'll automatically apply the `area-analyzer` and `analyzer-crash-report` labels

@stereotype441, @alexander-doroshko, @jwren 