### PR TITLE
url encode analyzer bug reports

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -266,15 +266,20 @@ analysis.server.status.good.text=Submit Analyzer Feedback...
 analysis.server.show.diagnostics.text=View analyzer diagnostics...
 analysis.server.show.diagnostics.error=Error opening Dart Analysis Server diagnostics page
 
-dart.feedback.url.template=https://github.com/dart-lang/sdk/issues/new?body=Analyzer Feedback from IntelliJ\n\n\
-  # Version information\n\n\
+dart.feedback.url=https://github.com/dart-lang/sdk/issues/new?body=
+dart.feedback.template=Analyzer Feedback from IntelliJ\n\n\
+  ## Version information\n\n\
   - `IDEA {0}`\n\
   - `{1}`\n\
-  - `{2}`\n\n\
-  # Exception
+  - `{2}`
+dart.feedback.error=\n\n## Exception\n\
+  ```\n\
+  {0}\n\
+  ```
+dart.feedback.file=\n\nFor additional log information, please append the contents of\n\
+  file://{0}.
+
 dart.analysis.server.error=Encountered a Dart Analysis Server error.
-dart.error.file.instructions=Please append the contents of:\n\
-  file://{0}
 dart.smartKeys.insertDefaultArgValues.text=Insert default argument values in completions
 dart.editor.showClosingLabels.text=Show closing labels in Dart source code
 dialog.paste.on.import.title=Update Imports on Paste

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartFeedbackBuilder.java
@@ -19,8 +19,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.MessageDialogBuilder;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.wm.IdeFrame;
@@ -39,8 +37,6 @@ import javax.swing.event.HyperlinkEvent;
  * send issues to the flutter project on github.
  */
 public abstract class DartFeedbackBuilder {
-  public static final int MAX_URL_LENGTH = 1900;
-
   // NOTIFICATION_GROUP is used to add an error to Event Log tool window. Red balloon is shown separately, like for IDE fatal errors.
   // We do not show standard balloon using this NOTIFICATION_GROUP because it is not red enough.
   private static final NotificationGroup NOTIFICATION_GROUP =

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DefaultDartFeedbackBuilder.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 public class DefaultDartFeedbackBuilder extends DartFeedbackBuilder {
@@ -62,8 +63,7 @@ public class DefaultDartFeedbackBuilder extends DartFeedbackBuilder {
       }
     }
 
-    //noinspection deprecation
-    openBrowserOnFeedbackForm(url + URLEncoder.encode(body), project);
+    openBrowserOnFeedbackForm(url + urlEncode(body), project);
   }
 
   public static void openBrowserOnFeedbackForm(@NotNull String urlTemplate, @Nullable Project project) {
@@ -73,5 +73,15 @@ public class DefaultDartFeedbackBuilder extends DartFeedbackBuilder {
   protected String getSdkVersion(@NotNull Project project) {
     DartSdk sdk = DartSdk.getDartSdk(project);
     return sdk == null ? "<NO SDK>" : sdk.getVersion();
+  }
+
+  private static String urlEncode(String input) {
+    try {
+      return URLEncoder.encode(input, "UTF-8");
+    }
+    catch (UnsupportedEncodingException e) {
+      // Unreachable - UTF-8 is always supported.
+      return input;
+    }
   }
 }


### PR DESCRIPTION
This url encodes the data we use to create a url for analyzer issue reports. This should hopefully address problems we've seen with analyzer bug reports without exception information.

- fix https://github.com/flutter/flutter-intellij/issues/2611

@alexander-doroshko 
