### PR TITLE
DartServerRootsHandler- have the resulting set from getExcludedPackageSymlinkUrls(module) be included in the excluded roots List.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -92,6 +92,10 @@ public class DartServerRootsHandler {
                 newExcludedRoots.add(FileUtil.toSystemDependentName(VfsUtilCore.urlToPath(excludedUrl)));
               }
             }
+
+            for (String excludedPackageSymlinkUrl : excludedPackageSymlinkUrls) {
+              newExcludedRoots.add(FileUtil.toSystemDependentName(VfsUtilCore.urlToPath(excludedPackageSymlinkUrl)));
+            }
           }
         }
       }


### PR DESCRIPTION
@alexander-doroshko 