### PR TITLE
Add request listener methods to AnalysisServer interface.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1803,7 +1803,7 @@ public class DartAnalysisServerService implements Disposable {
           startedServer.addAnalysisServerListener(listener);
         }
         for (RequestListener listener : myRequestListeners) {
-          startedServer.addRequestListeners(listener);
+          startedServer.addRequestListener(listener);
         }
         for (ResponseListener listener : myResponseListeners) {
           startedServer.addResponseListener(listener);

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -172,6 +172,7 @@ public class DartAnalysisServerService implements Disposable {
   }
 
   @NotNull private final List<AnalysisServerListener> myAdditionalServerListeners = new SmartList<>();
+  @NotNull private final List<RequestListener> myRequestListeners = new SmartList<>();
   @NotNull private final List<ResponseListener> myResponseListeners = new SmartList<>();
 
   private static final String ENABLE_ANALYZED_FILES_SUBSCRIPTION_KEY =
@@ -552,6 +553,24 @@ public class DartAnalysisServerService implements Disposable {
     myAdditionalServerListeners.remove(serverListener);
     if (myServer != null) {
       myServer.removeAnalysisServerListener(serverListener);
+    }
+  }
+
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void addRequestListener(@NotNull final RequestListener requestListener) {
+    if (!myRequestListeners.contains(requestListener)) {
+      myRequestListeners.add(requestListener);
+      if (myServer != null && isServerProcessActive()) {
+        myServer.addRequestListener(requestListener);
+      }
+    }
+  }
+
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void removeRequestListener(@NotNull final RequestListener requestListener) {
+    myRequestListeners.remove(requestListener);
+    if (myServer != null) {
+      myServer.removeRequestListener(requestListener);
     }
   }
 
@@ -1783,6 +1802,9 @@ public class DartAnalysisServerService implements Disposable {
         for (AnalysisServerListener listener : myAdditionalServerListeners) {
           startedServer.addAnalysisServerListener(listener);
         }
+        for (RequestListener listener : myRequestListeners) {
+          startedServer.addRequestListeners(listener);
+        }
         for (ResponseListener listener : myResponseListeners) {
           startedServer.addResponseListener(listener);
         }
@@ -1879,6 +1901,9 @@ public class DartAnalysisServerService implements Disposable {
         myServer.removeAnalysisServerListener(myAnalysisServerListener);
         for (AnalysisServerListener listener : myAdditionalServerListeners) {
           myServer.removeAnalysisServerListener(listener);
+        }
+        for (RequestListener listener : myRequestListeners) {
+          myServer.removeRequestListener(listener);
         }
         for (ResponseListener listener : myResponseListeners) {
           myServer.removeResponseListener(listener);

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/RequestListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/RequestListener.java
@@ -1,0 +1,10 @@
+package com.google.dart.server;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Listener for arbitrary requests sent from the analysis server.
+ */
+public interface RequestListener {
+  void onRequest(JsonObject json);
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -40,6 +40,12 @@ public interface AnalysisServer {
   public void addAnalysisServerListener(AnalysisServerListener listener);
 
   /**
+   * Add the given listener to the list of listeners that will receive notification when
+   * requests are made by an analysis server client.
+   */
+  public void addRequestListener(RequestListener listener);
+
+  /**
    * Add the given listener to the list of listeners that will receive every response from
    * the analysis server.
    */
@@ -685,6 +691,12 @@ public interface AnalysisServer {
    * @param listener the listener to be removed
    */
   public void removeAnalysisServerListener(AnalysisServerListener listener);
+
+  /**
+   * Remove the given listener from the list of listeners that will receive notification when
+   * requests are made by an analysis server client.
+   */
+  public void removeRequestListener(RequestListener listener);
 
   /**
    * Remove the given listener from the list of listeners that will receive every response from

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -454,7 +454,6 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   }
 
   @Override
-  @Override
   public void removeResponseListener(ResponseListener listener) {
     synchronized (responseListenerList) {
       responseListenerList.remove(listener);


### PR DESCRIPTION
This patch builds on the work in d6a6512b6ea0f1faee3cebd6c05271bed9369b99
which added a mechanism to subscribe to notifications whenever the Dart
analysis server client receives a response. Here we're adding the
symmetric capability for subscribers to be notified whenever a request
will be issued. This new hook allows tools interfacing with the Dart
plugin (like Flutter) to do things like measure roundtrip times to the
Dart analysis server.

Note that the upstream changes were merged in https://dart-review.googlesource.com/c/sdk/+/86583.

/cc @alexander-doroshko @jwren @scheglov