### PR TITLE
trim text from VM stack names

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceStackFrame.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceStackFrame.java
@@ -76,7 +76,11 @@ public class DartVmServiceStackFrame extends XStackFrame {
 
   @Override
   public void customizePresentation(@NotNull final ColoredTextContainer component) {
-    final String name = StringUtil.trimEnd(myVmFrame.getCode().getName(), "="); // trim setter postfix
+    final String unoptimizedPrefix = "[Unoptimized] ";
+
+    String name = StringUtil.trimEnd(myVmFrame.getCode().getName(), "="); // trim setter postfix
+    name = StringUtil.trimStart(name, unoptimizedPrefix);
+
     final boolean causal = myVmFrame.getKind() == FrameKind.AsyncCausal;
     component.append(name, causal ? SimpleTextAttributes.REGULAR_ITALIC_ATTRIBUTES : SimpleTextAttributes.REGULAR_ATTRIBUTES);
 


### PR DESCRIPTION
- trim some undesired text from the front of VM stack frames

<img width="418" alt="screen shot 2018-12-11 at 10 46 21 am" src="https://user-images.githubusercontent.com/1269969/49839536-4e7a6080-fd64-11e8-9507-8aab3858034a.png">

@alexander-doroshko 