### PR TITLE
[WEB-23645] Show package info in Dart code completion

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -322,8 +322,9 @@ public class DartServerCompletionContributor extends CompletionContributor {
     final String lookupString = suggestion.getCompletion();
     LookupElementBuilder lookup = LookupElementBuilder.create(lookupObject, lookupString);
 
-    if (suggestion.getDisplayText() != null) {
-      lookup = lookup.withPresentableText(suggestion.getDisplayText());
+    String displayText = suggestion.getDisplayText();
+    if (displayText != null) {
+      lookup = lookup.withPresentableText(displayText);
     }
 
     // keywords are bold
@@ -448,6 +449,11 @@ public class DartServerCompletionContributor extends CompletionContributor {
           });
         }
       }
+    }
+
+    // If this is a class, try to show which package it's coming from.
+    if (element != null && element.getKind().equals(ElementKind.CLASS) && suggestion.getElementUri() != null) {
+      lookup = lookup.appendTailText(" (" + suggestion.getElementUri() + ")", true /* grayed */);
     }
 
     // Use selection offset / length.

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionSuggestion.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionSuggestion.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
  * for details. All rights reserved. Use of this source code is governed by a
  * BSD-style license that can be found in the LICENSE file.
  *
- * This file has been automatically generated.  Please do not edit it manually.
+ * This file has been automatically generated. Please do not edit it manually.
  * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
  */
 package org.dartlang.analysis.server.protocol;
@@ -58,6 +58,12 @@ public class CompletionSuggestion {
    * displayed text should be different than the completion. Otherwise it is omitted.
    */
   private final String displayText;
+
+  /**
+   * The URI of the element corresponding to this suggestion. It will be set whenever analysis server
+   * is able to compute it.
+   */
+  private final String elementUri;
 
   /**
    * The offset, relative to the beginning of the completion, of where the selection should be placed
@@ -169,11 +175,12 @@ public class CompletionSuggestion {
   /**
    * Constructor for {@link CompletionSuggestion}.
    */
-  public CompletionSuggestion(String kind, int relevance, String completion, String displayText, int selectionOffset, int selectionLength, boolean isDeprecated, boolean isPotential, String docSummary, String docComplete, String declaringType, String defaultArgumentListString, int[] defaultArgumentListTextRanges, Element element, String returnType, List<String> parameterNames, List<String> parameterTypes, Integer requiredParameterCount, Boolean hasNamedParameters, String parameterName, String parameterType, String importUri) {
+  public CompletionSuggestion(String kind, int relevance, String completion, String displayText, String elementUri, int selectionOffset, int selectionLength, boolean isDeprecated, boolean isPotential, String docSummary, String docComplete, String declaringType, String defaultArgumentListString, int[] defaultArgumentListTextRanges, Element element, String returnType, List<String> parameterNames, List<String> parameterTypes, Integer requiredParameterCount, Boolean hasNamedParameters, String parameterName, String parameterType, String importUri) {
     this.kind = kind;
     this.relevance = relevance;
     this.completion = completion;
     this.displayText = displayText;
+    this.elementUri = elementUri;
     this.selectionOffset = selectionOffset;
     this.selectionLength = selectionLength;
     this.isDeprecated = isDeprecated;
@@ -203,6 +210,7 @@ public class CompletionSuggestion {
         other.relevance == relevance &&
         ObjectUtilities.equals(other.completion, completion) &&
         ObjectUtilities.equals(other.displayText, displayText) &&
+        ObjectUtilities.equals(other.elementUri, elementUri) &&
         other.selectionOffset == selectionOffset &&
         other.selectionLength == selectionLength &&
         other.isDeprecated == isDeprecated &&
@@ -230,6 +238,7 @@ public class CompletionSuggestion {
     int relevance = jsonObject.get("relevance").getAsInt();
     String completion = jsonObject.get("completion").getAsString();
     String displayText = jsonObject.get("displayText") == null ? null : jsonObject.get("displayText").getAsString();
+    String elementUri = jsonObject.get("elementUri") == null ? null : jsonObject.get("elementUri").getAsString();
     int selectionOffset = jsonObject.get("selectionOffset").getAsInt();
     int selectionLength = jsonObject.get("selectionLength").getAsInt();
     boolean isDeprecated = jsonObject.get("isDeprecated").getAsBoolean();
@@ -248,7 +257,7 @@ public class CompletionSuggestion {
     String parameterName = jsonObject.get("parameterName") == null ? null : jsonObject.get("parameterName").getAsString();
     String parameterType = jsonObject.get("parameterType") == null ? null : jsonObject.get("parameterType").getAsString();
     String importUri = jsonObject.get("importUri") == null ? null : jsonObject.get("importUri").getAsString();
-    return new CompletionSuggestion(kind, relevance, completion, displayText, selectionOffset, selectionLength, isDeprecated, isPotential, docSummary, docComplete, declaringType, defaultArgumentListString, defaultArgumentListTextRanges, element, returnType, parameterNames, parameterTypes, requiredParameterCount, hasNamedParameters, parameterName, parameterType, importUri);
+    return new CompletionSuggestion(kind, relevance, completion, displayText, elementUri, selectionOffset, selectionLength, isDeprecated, isPotential, docSummary, docComplete, declaringType, defaultArgumentListString, defaultArgumentListTextRanges, element, returnType, parameterNames, parameterTypes, requiredParameterCount, hasNamedParameters, parameterName, parameterType, importUri);
   }
 
   public static List<CompletionSuggestion> fromJsonArray(JsonArray jsonArray) {
@@ -327,6 +336,14 @@ public class CompletionSuggestion {
    */
   public Element getElement() {
     return element;
+  }
+
+  /**
+   * The URI of the element corresponding to this suggestion. It will be set whenever analysis server
+   * is able to compute it.
+   */
+  public String getElementUri() {
+    return elementUri;
   }
 
   /**
@@ -444,6 +461,7 @@ public class CompletionSuggestion {
     builder.append(relevance);
     builder.append(completion);
     builder.append(displayText);
+    builder.append(elementUri);
     builder.append(selectionOffset);
     builder.append(selectionLength);
     builder.append(isDeprecated);
@@ -472,6 +490,9 @@ public class CompletionSuggestion {
     jsonObject.addProperty("completion", completion);
     if (displayText != null) {
       jsonObject.addProperty("displayText", displayText);
+    }
+    if (elementUri != null) {
+      jsonObject.addProperty("elementUri", elementUri);
     }
     jsonObject.addProperty("selectionOffset", selectionOffset);
     jsonObject.addProperty("selectionLength", selectionLength);
@@ -546,6 +567,8 @@ public class CompletionSuggestion {
     builder.append(completion + ", ");
     builder.append("displayText=");
     builder.append(displayText + ", ");
+    builder.append("elementUri=");
+    builder.append(elementUri + ", ");
     builder.append("selectionOffset=");
     builder.append(selectionOffset + ", ");
     builder.append("selectionLength=");


### PR DESCRIPTION
This patch updates the Dart plugin to use CompletionSuggestion#elementUri,
added to analysis server in https://dart-review.googlesource.com/c/sdk/+/88744
and https://dart-review.googlesource.com/c/sdk/+/89441, to provide class
package info whenever a class is being suggested and the elementUri is available.

![6lvcsg5a504](https://user-images.githubusercontent.com/535859/51277466-98bab700-198c-11e9-820b-d08f91e3fcaa.png)

/cc @alexander-doroshko @jwren