### PR TITLE
Issue 35680 - Dart code completion suggestions from not yet imported libs

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -2,7 +2,9 @@
 package com.jetbrains.lang.dart.analyzer;
 
 import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.dart.server.*;
 import com.google.dart.server.generated.AnalysisServer;
@@ -186,6 +188,11 @@ public class DartAnalysisServerService implements Disposable {
     }
 
     @Override
+    public void computedAvailableSuggestions(@NotNull List<AvailableSuggestionSet> changed, @NotNull int[] removed) {
+      myServerData.computedAvailableSuggestions(changed, removed);
+    }
+
+    @Override
     public void computedErrors(@NotNull final String filePathSD, @NotNull final List<AnalysisError> errors) {
       final String fileName = PathUtil.getFileName(filePathSD);
 
@@ -275,9 +282,13 @@ public class DartAnalysisServerService implements Disposable {
                                    final int replacementOffset,
                                    final int replacementLength,
                                    @NotNull final List<CompletionSuggestion> completions,
+                                   @NotNull final List<IncludedSuggestionSet> includedSuggestionSets,
+                                   @NotNull final List<String> includedSuggestionKinds,
                                    final boolean isLast) {
       synchronized (myCompletionInfos) {
-        myCompletionInfos.add(new CompletionInfo(completionId, replacementOffset, replacementLength, completions, isLast));
+        myCompletionInfos.add(
+          new CompletionInfo(completionId, replacementOffset, replacementLength, completions, includedSuggestionSets,
+                             includedSuggestionKinds, isLast));
         myCompletionInfos.notifyAll();
       }
     }
@@ -441,7 +452,8 @@ public class DartAnalysisServerService implements Disposable {
 
   public void addCompletions(@NotNull final VirtualFile file,
                              @NotNull final String completionId,
-                             @NotNull final CompletionSuggestionConsumer consumer) {
+                             @NotNull final CompletionSuggestionConsumer consumer,
+                             @NotNull final CompletionLibraryRefConsumer libraryRefConsumer) {
     while (true) {
       ProgressManager.checkCanceled();
 
@@ -455,6 +467,11 @@ public class DartAnalysisServerService implements Disposable {
             final int convertedReplacementOffset = getConvertedOffset(file, completionInfo.myOriginalReplacementOffset);
             final int convertedReplacementLength = getConvertedOffset(file, completionInfo.myOriginalReplacementLength);
             consumer.consumeCompletionSuggestion(convertedReplacementOffset, convertedReplacementLength, completion);
+          }
+
+          final Set<String> includedKinds = Sets.newHashSet(completionInfo.myIncludedSuggestionKinds);
+          for (final IncludedSuggestionSet includedSet : completionInfo.myIncludedSuggestionSets) {
+            libraryRefConsumer.consumeLibraryRef(includedSet, includedKinds);
           }
           return;
         }
@@ -720,6 +737,11 @@ public class DartAnalysisServerService implements Disposable {
 
   private void handleClosingLabelPreferenceChanged() {
     analysis_setSubscriptions();
+  }
+
+  @Nullable
+  public AvailableSuggestionSet getAvailableSuggestionSet(int id) {
+    return myServerData.getAvailableSuggestionSet(id);
   }
 
   @NotNull
@@ -1323,6 +1345,37 @@ public class DartAnalysisServerService implements Disposable {
   }
 
   @Nullable
+  public GetCompletionDetailsResult completion_getSuggestionDetails(@NotNull final VirtualFile file,
+                                                                    final int id,
+                                                                    final String label,
+                                                                    final int offset) {
+    final String filePath = FileUtil.toSystemDependentName(file.getPath());
+    final Ref<GetCompletionDetailsResult> resultRef = new Ref<>();
+
+    final AnalysisServer server = myServer;
+    if (server == null) {
+      return null;
+    }
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    server.completion_getSuggestionDetails(filePath, id, label, offset, new GetSuggestionDetailsConsumer() {
+      @Override
+      public void computedDetails(GetCompletionDetailsResult result) {
+        resultRef.set(result);
+        latch.countDown();
+      }
+
+      @Override
+      public void onError(RequestError requestError) {
+        latch.countDown();
+      }
+    });
+
+    awaitForLatchCheckingCanceled(server, latch, GET_SUGGESTIONS_TIMEOUT);
+    return resultRef.get();
+  }
+
+  @Nullable
   public String completion_getSuggestions(@NotNull final VirtualFile file, final int _offset) {
     final String filePath = FileUtil.toSystemDependentName(file.getPath());
     final Ref<String> resultRef = new Ref<>();
@@ -1813,11 +1866,14 @@ public class DartAnalysisServerService implements Disposable {
         if (Registry.is("dart.projects.without.pubspec", false) && isAnalyzedFilesSubscriptionEnabled()) {
           startedServer.analysis_setGeneralSubscriptions(Collections.singletonList(GeneralAnalysisService.ANALYZED_FILES));
         }
+        startedServer.completion_setSubscriptions(ImmutableList.of(CompletionService.AVAILABLE_SUGGESTION_SETS));
 
         if (!myInitializationOnServerStartupDone) {
           myInitializationOnServerStartupDone = true;
 
           registerFileEditorManagerListener();
+
+
           registerDocumentListener();
           setDasLogger();
         }
@@ -2114,6 +2170,10 @@ public class DartAnalysisServerService implements Disposable {
                                      final @NotNull CompletionSuggestion completionSuggestion);
   }
 
+  public interface CompletionLibraryRefConsumer {
+    void consumeLibraryRef(final IncludedSuggestionSet includedSet, Set<String> includedKinds);
+  }
+
   private static class CompletionInfo {
     @NotNull private final String myCompletionId;
     /**
@@ -2125,17 +2185,23 @@ public class DartAnalysisServerService implements Disposable {
      */
     private final int myOriginalReplacementLength;
     @NotNull private final List<CompletionSuggestion> myCompletions;
+    @NotNull private final List<IncludedSuggestionSet> myIncludedSuggestionSets;
+    @NotNull private final List<String> myIncludedSuggestionKinds;
     private final boolean isLast;
 
     CompletionInfo(@NotNull final String completionId,
                    int replacementOffset,
                    int originalReplacementLength,
                    @NotNull final List<CompletionSuggestion> completions,
+                   @NotNull final List<IncludedSuggestionSet> includedSuggestionSets,
+                   @NotNull final List<String> includedSuggestionKinds,
                    boolean isLast) {
       this.myCompletionId = completionId;
       this.myOriginalReplacementOffset = replacementOffset;
       this.myOriginalReplacementLength = originalReplacementLength;
       this.myCompletions = completions;
+      this.myIncludedSuggestionSets = includedSuggestionSets;
+      this.myIncludedSuggestionKinds = includedSuggestionKinds;
       this.isLast = isLast;
     }
   }

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -745,6 +745,9 @@ public class DartAnalysisServerService implements Disposable {
     return myServerData.getAvailableSuggestionSet(id);
   }
 
+  @Nullable
+  public Map<Integer, AvailableSuggestionSet> getAvailableSuggestionSets() { return myServerData.getAvailableSuggestionSetMap(); }
+
   @NotNull
   public List<DartServerData.DartError> getErrors(@NotNull final VirtualFile file) {
     return myServerData.getErrors(file);

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -105,6 +105,7 @@ public class DartAnalysisServerService implements Disposable {
   private static final long POSTFIX_INITIALIZATION_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(1000);
   private static final long STATEMENT_COMPLETION_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(100);
   private static final long GET_SUGGESTIONS_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
+  private static final long GET_SUGGESTION_DETAILS_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(100);
   private static final long FIND_ELEMENT_REFERENCES_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
   private static final long GET_TYPE_HIERARCHY_TIMEOUT = TimeUnit.SECONDS.toMillis(10);
   private static final long EXECUTION_CREATE_CONTEXT_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
@@ -1348,7 +1349,7 @@ public class DartAnalysisServerService implements Disposable {
   public GetCompletionDetailsResult completion_getSuggestionDetails(@NotNull final VirtualFile file,
                                                                     final int id,
                                                                     final String label,
-                                                                    final int offset) {
+                                                                    final int _offset) {
     final String filePath = FileUtil.toSystemDependentName(file.getPath());
     final Ref<GetCompletionDetailsResult> resultRef = new Ref<>();
 
@@ -1358,6 +1359,7 @@ public class DartAnalysisServerService implements Disposable {
     }
 
     final CountDownLatch latch = new CountDownLatch(1);
+    final int offset = getOriginalOffset(file, _offset);
     server.completion_getSuggestionDetails(filePath, id, label, offset, new GetSuggestionDetailsConsumer() {
       @Override
       public void computedDetails(GetCompletionDetailsResult result) {
@@ -1371,7 +1373,7 @@ public class DartAnalysisServerService implements Disposable {
       }
     });
 
-    awaitForLatchCheckingCanceled(server, latch, GET_SUGGESTIONS_TIMEOUT);
+    awaitForLatchCheckingCanceled(server, latch, GET_SUGGESTION_DETAILS_TIMEOUT);
     return resultRef.get();
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -31,6 +31,7 @@ public class DartServerData {
 
   private final EventDispatcher<OutlineListener> myEventDispatcher = EventDispatcher.create(OutlineListener.class);
 
+  private final Map<Integer, AvailableSuggestionSet> myAvailableSuggestionSetMap = Collections.synchronizedMap(new THashMap<>());
   private final Map<String, List<DartError>> myErrorData = Collections.synchronizedMap(new THashMap<>());
   private final Map<String, List<DartHighlightRegion>> myHighlightData = Collections.synchronizedMap(new THashMap<>());
   private final Map<String, List<DartNavigationRegion>> myNavigationData = Collections.synchronizedMap(new THashMap<>());
@@ -50,6 +51,16 @@ public class DartServerData {
 
   boolean isErrorInfoLost(@NotNull final String filePath) {
     return myFilePathsWithLostErrorInfo.contains(filePath);
+  }
+
+  void computedAvailableSuggestions(@NotNull final List<AvailableSuggestionSet> changed,
+                                    @NotNull final int[] removed) {
+    for (int id : removed) {
+      myAvailableSuggestionSetMap.remove(id);
+    }
+    for (AvailableSuggestionSet suggestionSet : changed) {
+      myAvailableSuggestionSetMap.put(suggestionSet.getId(), suggestionSet);
+    }
   }
 
   /**
@@ -196,6 +207,11 @@ public class DartServerData {
     if (hasChanges) {
       forceFileAnnotation(file, false);
     }
+  }
+
+  @Nullable
+  AvailableSuggestionSet getAvailableSuggestionSet(int id) {
+    return myAvailableSuggestionSetMap.get(id);
   }
 
   @NotNull

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -214,6 +214,9 @@ public class DartServerData {
     return myAvailableSuggestionSetMap.get(id);
   }
 
+  @Nullable
+  Map<Integer, AvailableSuggestionSet> getAvailableSuggestionSetMap() { return myAvailableSuggestionSetMap; }
+
   @NotNull
   List<DartError> getErrors(@NotNull final SearchScope scope) {
     final List<DartError> errors = new ArrayList<>();

--- a/Dart/testData/analysisServer/completion/NotYetImportedClass.after.dart
+++ b/Dart/testData/analysisServer/completion/NotYetImportedClass.after.dart
@@ -1,0 +1,5 @@
+import 'dart:io';
+
+main(String args) {
+  Process
+}

--- a/Dart/testData/analysisServer/completion/NotYetImportedClass.dart
+++ b/Dart/testData/analysisServer/completion/NotYetImportedClass.dart
@@ -1,0 +1,3 @@
+main(String args) {
+  Proc<caret>
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2014, the Dart project authors.
- * 
+ *
  * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -15,15 +15,15 @@ package com.google.dart.server;
 
 import com.google.dart.server.generated.AnalysisServer;
 import com.google.dart.server.internal.remote.utilities.ResponseUtilities;
-
 import org.dartlang.analysis.server.protocol.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 /**
  * The interface {@code AnalysisServerListener} defines the behavior of objects that listen for
  * results from an analysis server.
- * 
+ *
  * @coverage dart.server
  */
 public interface AnalysisServerListener {
@@ -32,33 +32,41 @@ public interface AnalysisServerListener {
    * <p>
    * This notification is not subscribed to by default. Clients can subscribe by including the value
    * "ANALYZED_FILES" in the list of services passed in an analysis.setGeneralSubscriptions request.
-   * 
+   *
    * @param directories a list of the paths of the files that are being analyzed
    */
   public void computedAnalyzedFiles(List<String> directories);
 
+  public void computedAvailableSuggestions(@NotNull final List<AvailableSuggestionSet> changed,
+                                           @NotNull final int[] removed);
+
   /**
    * A new collection of completions have been computed for the given completion id.
-   * 
-   * @param completionId the id associated with the completion
+   *
+   * @param completionId      the id associated with the completion
    * @param replacementOffset The offset of the start of the text to be replaced. This will be
-   *          different than the offset used to request the completion suggestions if there was a
-   *          portion of an identifier before the original offset. In particular, the
-   *          replacementOffset will be the offset of the beginning of said identifier.
+   *                          different than the offset used to request the completion suggestions if there was a
+   *                          portion of an identifier before the original offset. In particular, the
+   *                          replacementOffset will be the offset of the beginning of said identifier.
    * @param replacementLength The length of the text to be replaced if the remainder of the
-   *          identifier containing the cursor is to be replaced when the suggestion is applied
-   *          (that is, the number of characters in the existing identifier).
-   * @param completions the completion suggestions being reported
-   * @param isLast {@code true} if this is the last set of results that will be returned for the
-   *          indicated completion
+   *                          identifier containing the cursor is to be replaced when the suggestion is applied
+   *                          (that is, the number of characters in the existing identifier).
+   * @param completions       the completion suggestions being reported
+   * @param isLast            {@code true} if this is the last set of results that will be returned for the
+   *                          indicated completion
    */
-  public void computedCompletion(String completionId, int replacementOffset, int replacementLength,
-      List<CompletionSuggestion> completions, boolean isLast);
+  public void computedCompletion(String completionId,
+                                 int replacementOffset,
+                                 int replacementLength,
+                                 List<CompletionSuggestion> completions,
+                                 List<IncludedSuggestionSet> includedSuggestionSets,
+                                 List<String> includedSuggestionKinds,
+                                 boolean isLast);
 
   /**
    * Reports the errors associated with a given file.
-   * 
-   * @param file the file containing the errors
+   *
+   * @param file   the file containing the errors
    * @param errors the errors contained in the file
    */
   public void computedErrors(String file, List<AnalysisError> errors);
@@ -68,29 +76,29 @@ public interface AnalysisServerListener {
    * region represents a particular syntactic or semantic meaning associated with some range. Note
    * that the highlight regions that are returned can overlap other highlight regions if there is
    * more than one meaning associated with a particular region.
-   * 
-   * @param file the file containing the highlight regions
+   *
+   * @param file       the file containing the highlight regions
    * @param highlights the highlight regions contained in the file
    */
   public void computedHighlights(String file, List<HighlightRegion> highlights);
 
   /**
    * New collections of implemented classes and class members have been computed for the given file.
-   * 
-   * @param file the file with which the implementations are associated.
+   *
+   * @param file               the file with which the implementations are associated.
    * @param implementedClasses the classes defined in the file that are implemented or extended.
    * @param implementedMembers the member defined in the file that are implemented or overridden.
    */
   public void computedImplemented(String file, List<ImplementedClass> implementedClasses,
-      List<ImplementedMember> implementedMembers);
+                                  List<ImplementedMember> implementedMembers);
 
   /**
    * New launch data has been computed.
-   * 
-   * @param file the file for which launch data is being provided
-   * @param kind the kind of the executable file, or {@code null} for non-Dart files
+   *
+   * @param file            the file for which launch data is being provided
+   * @param kind            the kind of the executable file, or {@code null} for non-Dart files
    * @param referencedFiles a list of the Dart files that are referenced by the file, or
-   *          {@code null} for non-HTML files
+   *                        {@code null} for non-HTML files
    */
   public void computedLaunchData(String file, String kind, String[] referencedFiles);
 
@@ -100,8 +108,8 @@ public interface AnalysisServerListener {
    * a single target, but can contain more in the case of a part that is included in multiple
    * libraries or an Dart code that is compiled against multiple versions of a package. Note that
    * the navigation regions that are returned do not overlap other navigation regions.
-   * 
-   * @param file the file containing the navigation regions
+   *
+   * @param file       the file containing the navigation regions
    * @param highlights the highlight regions associated with the source
    */
   public void computedNavigation(String file, List<NavigationRegion> targets);
@@ -109,16 +117,16 @@ public interface AnalysisServerListener {
   /**
    * A new collection of occurrences that been computed for the given file. Each occurrences object
    * represents a list of occurrences for some element in the file.
-   * 
-   * @param file the file containing the occurrences
+   *
+   * @param file             the file containing the occurrences
    * @param occurrencesArray the array of occurrences in the passed file
    */
   public void computedOccurrences(String file, List<Occurrences> occurrencesArray);
 
   /**
    * A new outline has been computed for the given file.
-   * 
-   * @param file the file with which the outline is associated
+   *
+   * @param file    the file with which the outline is associated
    * @param outline the outline associated with the file
    */
   public void computedOutline(String file, Outline outline);
@@ -126,8 +134,8 @@ public interface AnalysisServerListener {
   /**
    * A new collection of overrides that have been computed for a given file. Each override array
    * represents a list of overrides for some file.
-   * 
-   * @param file the file with which the outline is associated
+   *
+   * @param file      the file with which the outline is associated
    * @param overrides the overrides associated with the file
    */
   public void computedOverrides(String file, List<OverrideMember> overrides);
@@ -136,11 +144,11 @@ public interface AnalysisServerListener {
 
   /**
    * A new collection of search results have been computed for the given completion id.
-   * 
+   *
    * @param searchId the id associated with the search
-   * @param results the search results being reported
-   * @param last {@code true} if this is the last set of results that will be returned for the
-   *          indicated search
+   * @param results  the search results being reported
+   * @param last     {@code true} if this is the last set of results that will be returned for the
+   *                 indicated search
    */
   public void computedSearchResults(String searchId, List<SearchResult> results, boolean last);
 
@@ -159,45 +167,45 @@ public interface AnalysisServerListener {
   public void flushedResults(List<String> files);
 
   /**
-   * An error returned in result of some request.
+
    */
   public void requestError(RequestError requestError);
 
   /**
    * Reports that the server is running. This notification is issued once after the server has
    * started running to let the client know that it started correctly.
-   * 
+   *
    * @param version the version of the server that is running
    */
   public void serverConnected(String version);
 
   /**
    * An error happened in the {@link AnalysisServer}.
-   * 
-   * @param isFatal {@code true} if the error is a fatal error, meaning that the server will
-   *          shutdown automatically after sending this notification
-   * @param message the error message indicating what kind of error was encountered
+   *
+   * @param isFatal    {@code true} if the error is a fatal error, meaning that the server will
+   *                   shutdown automatically after sending this notification
+   * @param message    the error message indicating what kind of error was encountered
    * @param stackTrace the stack trace associated with the generation of the error, used for
-   *          debugging the server
+   *                   debugging the server
    */
   public void serverError(boolean isFatal, String message, String stackTrace);
 
   /**
    * Reports that the server version is not compatible with the client version. All the requests
    * will fail with {@link ResponseUtilities#INCOMPATIBLE_SERVER_VERSION} error.
-   * 
+   *
    * @param version is the actual version of the server if not {@code null}, or {@code null} if an
-   *          error received as a version.
+   *                error received as a version.
    */
   public void serverIncompatibleVersion(String version);
 
   /**
    * Reports the current status of the server.
-   * 
+   *
    * @param analysisStatus the current analysis status of the server, or {@code null} if there is no
-   *          analysis status
-   * @param pubStatus the current pub status of the server, or {@code null} if there is no pub
-   *          status
+   *                       analysis status
+   * @param pubStatus      the current pub status of the server, or {@code null} if there is no pub
+   *                       status
    */
   public void serverStatus(AnalysisStatus analysisStatus, PubStatus pubStatus);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2014, the Dart project authors.
- * 
+ *
  * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -14,6 +14,7 @@
 package com.google.dart.server;
 
 import org.dartlang.analysis.server.protocol.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -28,8 +29,18 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
   }
 
   @Override
-  public void computedCompletion(String completionId, int replacementOffset, int replacementLength,
-      List<CompletionSuggestion> completions, boolean isLast) {
+  public void computedAvailableSuggestions(@NotNull List<AvailableSuggestionSet> changed,
+                                           @NotNull int[] removed) {
+  }
+
+  @Override
+  public void computedCompletion(String completionId,
+                                 int replacementOffset,
+                                 int replacementLength,
+                                 List<CompletionSuggestion> completions,
+                                 List<IncludedSuggestionSet> includedSuggestionSets,
+                                 List<String> includedSuggestionKinds,
+                                 boolean isLast) {
   }
 
   @Override
@@ -42,7 +53,7 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
 
   @Override
   public void computedImplemented(String file, List<ImplementedClass> implementedClasses,
-      List<ImplementedMember> implementedMembers) {
+                                  List<ImplementedMember> implementedMembers) {
   }
 
   @Override

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSuggestionDetailsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSuggestionDetailsConsumer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server;
+
+import org.dartlang.analysis.server.protocol.GetCompletionDetailsResult;
+import org.dartlang.analysis.server.protocol.RequestError;
+
+public interface GetSuggestionDetailsConsumer extends Consumer {
+  public void computedDetails(GetCompletionDetailsResult result);
+
+  public void onError(RequestError requestError);
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -380,6 +380,17 @@ public interface AnalysisServer {
   public void analytics_sendTiming(String event, int millis);
 
   /**
+   * {@code completion.getSuggestionDetails}
+   *
+   * Request that completion suggestions for the given offset in the given file be returned.
+   *
+   * @param file The file containing the point at which suggestions are to be made.
+   * @param id The identifier of the <tt>AvailableSuggestionSet</tt> containing the selected label.
+   * @param label The label from the <tt>AvailableSuggestionSet</tt> with the `id` for which insertion information is requested.
+   */
+  public void completion_getSuggestionDetails(String file, int id, String label, int offset, GetSuggestionDetailsConsumer consumer);
+
+  /**
    * {@code completion.getSuggestions}
    *
    * Request that completion suggestions for the given offset in the given file be returned.
@@ -388,6 +399,19 @@ public interface AnalysisServer {
    * @param offset The offset within the file at which suggestions are to be made.
    */
   public void completion_getSuggestions(String file, int offset, GetSuggestionsConsumer consumer);
+
+  /**
+   * {@code completion.setSubscriptions}
+   *
+   * Subscribe for completion services.
+   * All previous subscriptions are replaced by the given set of services.
+   *
+   * It is an error if any of the elements in the list are not valid services. If there is an error,
+   * then the current subscriptions will remain unchanged.
+   *
+   * @param subscriptions A list of the services being subscribed to.
+   */
+  public void completion_setSubscriptions(List<String> subscriptions);
 
   /**
    * {@code diagnostic.getDiagnostics}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2014, the Dart project authors.
- * 
+ *
  * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -17,13 +17,14 @@ package com.google.dart.server.internal;
 import com.google.common.collect.Lists;
 import com.google.dart.server.AnalysisServerListener;
 import org.dartlang.analysis.server.protocol.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 /**
  * The class {@code BroadcastAnalysisServerListener} implements {@link AnalysisServerListener} that
  * broadcasts events to other listeners.
- * 
+ *
  * @coverage dart.server
  */
 public class BroadcastAnalysisServerListener implements AnalysisServerListener {
@@ -32,7 +33,7 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
   /**
    * Add the given listener to the list of listeners that will receive notification when new
    * analysis results become available.
-   * 
+   *
    * @param listener the listener to be added
    */
   public void addListener(AnalysisServerListener listener) {
@@ -52,15 +53,30 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
   }
 
   @Override
-  public void computedCompletion(String completionId, int replacementOffset, int replacementLength,
-      List<CompletionSuggestion> completions, boolean isLast) {
+  public void computedAvailableSuggestions(@NotNull List<AvailableSuggestionSet> updated,
+                                           @NotNull int[] removed) {
+    for (AnalysisServerListener listener : getListeners()) {
+      listener.computedAvailableSuggestions(updated, removed);
+    }
+  }
+
+  @Override
+  public void computedCompletion(String completionId,
+                                 int replacementOffset,
+                                 int replacementLength,
+                                 List<CompletionSuggestion> completions,
+                                 List<IncludedSuggestionSet> includedSuggestionSets,
+                                 List<String> includedSuggestionKinds,
+                                 boolean isLast) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.computedCompletion(
-          completionId,
-          replacementOffset,
-          replacementLength,
-          completions,
-          isLast);
+        completionId,
+        replacementOffset,
+        replacementLength,
+        completions,
+        includedSuggestionSets,
+        includedSuggestionKinds,
+        isLast);
     }
   }
 
@@ -80,7 +96,7 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
 
   @Override
   public void computedImplemented(String file, List<ImplementedClass> implementedClasses,
-      List<ImplementedMember> implementedMembers) {
+                                  List<ImplementedMember> implementedMembers) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.computedImplemented(file, implementedClasses, implementedMembers);
     }
@@ -145,7 +161,7 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
   /**
    * Remove the given listener from the list of listeners that will receive notification when new
    * analysis results become available.
-   * 
+   *
    * @param listener the listener to be removed
    */
   public void removeListener(AnalysisServerListener listener) {

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/GetSuggestionDetailsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/GetSuggestionDetailsProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014, the Dart project authors.
+ * 
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.GetSuggestionDetailsConsumer;
+import com.google.dart.server.GetSuggestionsConsumer;
+import com.google.gson.JsonObject;
+
+import org.dartlang.analysis.server.protocol.GetCompletionDetailsResult;
+import org.dartlang.analysis.server.protocol.RequestError;
+import org.dartlang.analysis.server.protocol.SourceChange;
+
+/**
+ * Instances of {@code CompletionIdProcessor} translate JSON result objects for a given
+ * {@link GetSuggestionsConsumer}.
+ * 
+ * @coverage dart.server.remote
+ */
+public class GetSuggestionDetailsProcessor extends ResultProcessor {
+
+  private final GetSuggestionDetailsConsumer consumer;
+
+  public GetSuggestionDetailsProcessor(GetSuggestionDetailsConsumer consumer) {
+    this.consumer = consumer;
+  }
+
+  public void process(JsonObject resultObject, RequestError requestError) {
+    if (requestError != null) {
+      consumer.onError(requestError);
+      return;
+    }
+
+    try {
+      String completion = resultObject.get("completion").getAsString();
+      SourceChange change = SourceChange.fromJson(resultObject.get("change").getAsJsonObject());
+      consumer.computedDetails(new GetCompletionDetailsResult(completion, change));
+    } catch (Exception exception) {
+      // Catch any exceptions in the formatting of this response.
+      consumer.onError(generateRequestError(exception));
+    }
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionAvailableSuggestionsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionAvailableSuggestionsProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014, the Dart project authors.
+ * 
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.AnalysisServerListener;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.dartlang.analysis.server.protocol.AvailableSuggestionSet;
+
+import java.util.List;
+
+/**
+ * Processor for "completion.libraries" notification.
+ * 
+ * @coverage dart.server.remote
+ */
+public class NotificationCompletionAvailableSuggestionsProcessor extends NotificationProcessor {
+
+  public NotificationCompletionAvailableSuggestionsProcessor(AnalysisServerListener listener) {
+    super(listener);
+  }
+
+  /**
+   * Process the given {@link JsonObject} notification and notify {@link #listener}.
+   */
+  @Override
+  public void process(JsonObject response) throws Exception {
+    JsonObject paramsObject = response.get("params").getAsJsonObject();
+    JsonArray changedArray = paramsObject.get("changedLibraries").getAsJsonArray();
+    JsonArray removedArray = paramsObject.get("removedLibraries").getAsJsonArray();
+
+    final List<AvailableSuggestionSet> changed = AvailableSuggestionSet.fromJsonArray(changedArray);
+    final int[] removed = JsonUtilities.decodeIntArray(removedArray);
+
+    getListener().computedAvailableSuggestions(changed, removed);
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
@@ -14,10 +14,16 @@
 package com.google.dart.server.internal.remote.processor;
 
 import com.google.dart.server.AnalysisServerListener;
+import com.google.dart.server.utilities.general.JsonUtilities;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.dartlang.analysis.server.protocol.CompletionSuggestion;
+import org.dartlang.analysis.server.protocol.IncludedSuggestionSet;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Processor for "completion.results" notification.
@@ -38,6 +44,25 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
     JsonObject paramsObject = response.get("params").getAsJsonObject();
     String completionId = paramsObject.get("id").getAsString();
     JsonArray resultsArray = paramsObject.get("results").getAsJsonArray();
+
+    final List<IncludedSuggestionSet> includedSuggestionSets;
+    final JsonElement includedSuggestionSetsElement = paramsObject.get("includedSuggestionSets");
+    if (includedSuggestionSetsElement != null) {
+      final JsonArray includedSuggestionSetsArray = includedSuggestionSetsElement.getAsJsonArray();
+      includedSuggestionSets = IncludedSuggestionSet.fromJsonArray(includedSuggestionSetsArray);
+    } else {
+      includedSuggestionSets = Collections.emptyList();
+    }
+
+    final List<String> includedSuggestionKinds;
+    final JsonElement includedSuggestionKindsElement = paramsObject.get("includedSuggestionKinds");
+    if (includedSuggestionKindsElement != null) {
+      final JsonArray includedSuggestionKindsArray = includedSuggestionKindsElement.getAsJsonArray();
+      includedSuggestionKinds = JsonUtilities.decodeStringList(includedSuggestionKindsArray);
+    } else {
+      includedSuggestionKinds = Collections.emptyList();
+    }
+
     int replacementOffset = paramsObject.get("replacementOffset").getAsInt();
     int replacementLength = paramsObject.get("replacementLength").getAsInt();
     boolean isLast = paramsObject.get("isLast").getAsBoolean();
@@ -47,6 +72,8 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
         replacementOffset,
         replacementLength,
         CompletionSuggestion.fromJsonArray(resultsArray),
+        includedSuggestionSets,
+        includedSuggestionKinds,
         isLast);
   }
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2014, the Dart project authors.
- * 
+ *
  * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -37,6 +37,7 @@ public class RequestUtilities {
   private static final String EXPRESSIONS = "expressions";
   private static final String FILE = "file";
   private static final String ID = "id";
+  private static final String LABEL = "label";
   private static final String LENGTH = "length";
   private static final String LINE_LENGTH = "lineLength";
   private static final String METHOD = "method";
@@ -96,7 +97,9 @@ public class RequestUtilities {
   private static final String METHOD_LIST_POSTFIX_COMPLETION_TEMPLATES = "edit.listPostfixCompletionTemplates";
 
   // Code Completion domain
+  private static final String METHOD_COMPLETION_GET_SUGGESTION_DETAILS = "completion.getSuggestionDetails";
   private static final String METHOD_COMPLETION_GET_SUGGESTIONS = "completion.getSuggestions";
+  private static final String METHOD_COMPLETION_SET_SUBSCRIPTIONS = "completion.setSubscriptions";
 
   // Search domain
   private static final String METHOD_SEARCH_FIND_ELEMENT_REFERENCES = "search.findElementReferences";
@@ -180,7 +183,8 @@ public class RequestUtilities {
     }
     else if (object instanceof Location) {
       return buildJsonObjectLocation((Location)object);
-    } else if (object instanceof ImportedElements) {
+    }
+    else if (object instanceof ImportedElements) {
       return ((ImportedElements)object).toJson();
     }
     throw new IllegalArgumentException("Unable to convert to JSON: " + object);
@@ -420,6 +424,30 @@ public class RequestUtilities {
   }
 
   /**
+   * Generate and return a {@value #METHOD_COMPLETION_GET_SUGGESTION_DETAILS} request.
+   * <p>
+   * <pre>
+   * request: {
+   *   "id": String
+   *   "method": "completion.getSuggestionDetails"
+   *   "params": {
+   *     "file": FilePath
+   *     "id": int
+   *     "label": String
+   *   }
+   * }
+   * </pre>
+   */
+  public static JsonObject generateCompletionGetSuggestionDetails(String idValue, String file, int id, String label, int offset) {
+    JsonObject params = new JsonObject();
+    params.addProperty(FILE, file);
+    params.addProperty(ID, id);
+    params.addProperty(LABEL, label);
+    params.addProperty(OFFSET, offset);
+    return buildJsonObjectRequest(idValue, METHOD_COMPLETION_GET_SUGGESTION_DETAILS, params);
+  }
+
+  /**
    * Generate and return a {@value #METHOD_COMPLETION_GET_SUGGESTIONS} request.
    * <p>
    * <pre>
@@ -438,6 +466,26 @@ public class RequestUtilities {
     params.addProperty(FILE, file);
     params.addProperty(OFFSET, offset);
     return buildJsonObjectRequest(idValue, METHOD_COMPLETION_GET_SUGGESTIONS, params);
+  }
+
+  /**
+   * Generate and return a {@value #METHOD_COMPLETION_SET_SUBSCRIPTIONS} request.
+   * <p>
+   * <pre>
+   * request: {
+   *   "id": String
+   *   "method": "completion.setSubscriptions"
+   *   "params": {
+   *     "subscriptions": List&lt;CompletionService&gt;
+   *   }
+   * }
+   * </pre>
+   */
+  public static JsonObject generateCompletionSetSubscriptions(String idValue,
+                                                              List<String> subscriptions) {
+    JsonObject params = new JsonObject();
+    params.add(SUBSCRIPTIONS, buildJsonElement(subscriptions));
+    return buildJsonObjectRequest(idValue, METHOD_COMPLETION_SET_SUBSCRIPTIONS, params);
   }
 
   /**

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A partial completion suggestion that can be used in combination with info from
+ * completion.results to build completion suggestions for not yet imported library tokens.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class AvailableSuggestion {
+
+  public static final AvailableSuggestion[] EMPTY_ARRAY = new AvailableSuggestion[0];
+
+  public static final List<AvailableSuggestion> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The identifier to present to the user for code completion.
+   */
+  private final String label;
+
+  /**
+   * Information about the element reference being suggested.
+   */
+  private final Element element;
+
+  /**
+   * The Dartdoc associated with the element being suggested. This field is omitted if there is no
+   * Dartdoc associated with the element.
+   */
+  private final String docComplete;
+
+  /**
+   * An abbreviated version of the Dartdoc associated with the element being suggested. This field is
+   * omitted if there is no Dartdoc associated with the element.
+   */
+  private final String docSummary;
+
+  /**
+   * If the element is an executable, the names of the formal parameters of all kinds - required,
+   * optional positional, and optional named. The names of positional parameters are empty strings.
+   * Omitted if the element is not an executable.
+   */
+  private final List<String> parameterNames;
+
+  /**
+   * If the element is an executable, the declared types of the formal parameters of all kinds -
+   * required, optional positional, and optional named. Omitted if the element is not an executable.
+   */
+  private final List<String> parameterTypes;
+
+  private final Integer requiredParameterCount;
+
+  /**
+   * Constructor for {@link AvailableSuggestion}.
+   */
+  public AvailableSuggestion(String label, Element element, String docComplete, String docSummary, List<String> parameterNames, List<String> parameterTypes, Integer requiredParameterCount) {
+    this.label = label;
+    this.element = element;
+    this.docComplete = docComplete;
+    this.docSummary = docSummary;
+    this.parameterNames = parameterNames;
+    this.parameterTypes = parameterTypes;
+    this.requiredParameterCount = requiredParameterCount;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof AvailableSuggestion) {
+      AvailableSuggestion other = (AvailableSuggestion) obj;
+      return
+        ObjectUtilities.equals(other.label, label) &&
+        ObjectUtilities.equals(other.element, element) &&
+        ObjectUtilities.equals(other.docComplete, docComplete) &&
+        ObjectUtilities.equals(other.docSummary, docSummary) &&
+        ObjectUtilities.equals(other.parameterNames, parameterNames) &&
+        ObjectUtilities.equals(other.parameterTypes, parameterTypes) &&
+        ObjectUtilities.equals(other.requiredParameterCount, requiredParameterCount);
+    }
+    return false;
+  }
+
+  public static AvailableSuggestion fromJson(JsonObject jsonObject) {
+    String label = jsonObject.get("label").getAsString();
+    Element element = Element.fromJson(jsonObject.get("element").getAsJsonObject());
+    String docComplete = jsonObject.get("docComplete") == null ? null : jsonObject.get("docComplete").getAsString();
+    String docSummary = jsonObject.get("docSummary") == null ? null : jsonObject.get("docSummary").getAsString();
+    List<String> parameterNames = jsonObject.get("parameterNames") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("parameterNames").getAsJsonArray());
+    List<String> parameterTypes = jsonObject.get("parameterTypes") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("parameterTypes").getAsJsonArray());
+    Integer requiredParameterCount = jsonObject.get("requiredParameterCount") == null ? null : jsonObject.get("requiredParameterCount").getAsInt();
+    return new AvailableSuggestion(label, element, docComplete, docSummary, parameterNames, parameterTypes, requiredParameterCount);
+  }
+
+  public static List<AvailableSuggestion> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<AvailableSuggestion> list = new ArrayList<AvailableSuggestion>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The Dartdoc associated with the element being suggested. This field is omitted if there is no
+   * Dartdoc associated with the element.
+   */
+  public String getDocComplete() {
+    return docComplete;
+  }
+
+  /**
+   * An abbreviated version of the Dartdoc associated with the element being suggested. This field is
+   * omitted if there is no Dartdoc associated with the element.
+   */
+  public String getDocSummary() {
+    return docSummary;
+  }
+
+  /**
+   * Information about the element reference being suggested.
+   */
+  public Element getElement() {
+    return element;
+  }
+
+  /**
+   * The identifier to present to the user for code completion.
+   */
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * If the element is an executable, the names of the formal parameters of all kinds - required,
+   * optional positional, and optional named. The names of positional parameters are empty strings.
+   * Omitted if the element is not an executable.
+   */
+  public List<String> getParameterNames() {
+    return parameterNames;
+  }
+
+  /**
+   * If the element is an executable, the declared types of the formal parameters of all kinds -
+   * required, optional positional, and optional named. Omitted if the element is not an executable.
+   */
+  public List<String> getParameterTypes() {
+    return parameterTypes;
+  }
+
+  public Integer getRequiredParameterCount() {
+    return requiredParameterCount;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(label);
+    builder.append(element);
+    builder.append(docComplete);
+    builder.append(docSummary);
+    builder.append(parameterNames);
+    builder.append(parameterTypes);
+    builder.append(requiredParameterCount);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("label", label);
+    jsonObject.add("element", element.toJson());
+    if (docComplete != null) {
+      jsonObject.addProperty("docComplete", docComplete);
+    }
+    if (docSummary != null) {
+      jsonObject.addProperty("docSummary", docSummary);
+    }
+    if (parameterNames != null) {
+      JsonArray jsonArrayParameterNames = new JsonArray();
+      for (String elt : parameterNames) {
+        jsonArrayParameterNames.add(new JsonPrimitive(elt));
+      }
+      jsonObject.add("parameterNames", jsonArrayParameterNames);
+    }
+    if (parameterTypes != null) {
+      JsonArray jsonArrayParameterTypes = new JsonArray();
+      for (String elt : parameterTypes) {
+        jsonArrayParameterTypes.add(new JsonPrimitive(elt));
+      }
+      jsonObject.add("parameterTypes", jsonArrayParameterTypes);
+    }
+    if (requiredParameterCount != null) {
+      jsonObject.addProperty("requiredParameterCount", requiredParameterCount);
+    }
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("label=");
+    builder.append(label + ", ");
+    builder.append("element=");
+    builder.append(element + ", ");
+    builder.append("docComplete=");
+    builder.append(docComplete + ", ");
+    builder.append("docSummary=");
+    builder.append(docSummary + ", ");
+    builder.append("parameterNames=");
+    builder.append(StringUtils.join(parameterNames, ", ") + ", ");
+    builder.append("parameterTypes=");
+    builder.append(StringUtils.join(parameterTypes, ", ") + ", ");
+    builder.append("requiredParameterCount=");
+    builder.append(requiredParameterCount);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestionSet.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestionSet.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class AvailableSuggestionSet {
+
+  public static final AvailableSuggestionSet[] EMPTY_ARRAY = new AvailableSuggestionSet[0];
+
+  public static final List<AvailableSuggestionSet> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The id associated with the library.
+   */
+  private final int id;
+
+  /**
+   * The URI of the library.
+   */
+  private final String uri;
+
+  private final List<AvailableSuggestion> items;
+
+  /**
+   * Constructor for {@link AvailableSuggestionSet}.
+   */
+  public AvailableSuggestionSet(int id, String uri, List<AvailableSuggestion> items) {
+    this.id = id;
+    this.uri = uri;
+    this.items = items;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof AvailableSuggestionSet) {
+      AvailableSuggestionSet other = (AvailableSuggestionSet) obj;
+      return
+        other.id == id &&
+        ObjectUtilities.equals(other.uri, uri) &&
+        ObjectUtilities.equals(other.items, items);
+    }
+    return false;
+  }
+
+  public static AvailableSuggestionSet fromJson(JsonObject jsonObject) {
+    int id = jsonObject.get("id").getAsInt();
+    String uri = jsonObject.get("uri").getAsString();
+    List<AvailableSuggestion> items = AvailableSuggestion.fromJsonArray(jsonObject.get("items").getAsJsonArray());
+    return new AvailableSuggestionSet(id, uri, items);
+  }
+
+  public static List<AvailableSuggestionSet> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<AvailableSuggestionSet> list = new ArrayList<AvailableSuggestionSet>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The id associated with the library.
+   */
+  public int getId() {
+    return id;
+  }
+
+  public List<AvailableSuggestion> getItems() {
+    return items;
+  }
+
+  /**
+   * The URI of the library.
+   */
+  public String getUri() {
+    return uri;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(id);
+    builder.append(uri);
+    builder.append(items);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("id", id);
+    jsonObject.addProperty("uri", uri);
+    JsonArray jsonArrayItems = new JsonArray();
+    for (AvailableSuggestion elt : items) {
+      jsonArrayItems.add(elt.toJson());
+    }
+    jsonObject.add("items", jsonArrayItems);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("id=");
+    builder.append(id + ", ");
+    builder.append("uri=");
+    builder.append(uri + ", ");
+    builder.append("items=");
+    builder.append(StringUtils.join(items, ", "));
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionService.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+/**
+ * An enumeration of the completion services to which a client can subscribe.
+ *
+ * @coverage dart.server.generated.types
+ */
+public class CompletionService {
+
+  /**
+   * The client will receive notifications once subscribed with completion suggestion sets from the
+   * libraries of interest. The client should keep an up-to-date record of these in memory so that it
+   * will be able to union these candidates with other completion suggestions when applicable at
+   * completion time.
+   */
+  public static final String AVAILABLE_SUGGESTION_SETS = "AVAILABLE_SUGGESTION_SETS";
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/GetCompletionDetailsResult.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/GetCompletionDetailsResult.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated.  Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A result of requesting runtime completion.
+ *
+ * @coverage dart.server.generated.types
+ */
+public class GetCompletionDetailsResult {
+  @NotNull public final String completion;
+  @Nullable public final SourceChange change;
+
+  public GetCompletionDetailsResult(String completion, SourceChange change) {
+    this.completion = completion;
+    this.change = change;
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/IncludedSuggestionSet.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/IncludedSuggestionSet.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A reference to an AvailableSuggestionSet noting that the library's members which match the kind
+ * of this ref should be presented to the user.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class IncludedSuggestionSet {
+
+  public static final IncludedSuggestionSet[] EMPTY_ARRAY = new IncludedSuggestionSet[0];
+
+  public static final List<IncludedSuggestionSet> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * Clients should use it to access the set of precomputed completions to be displayed to the user.
+   */
+  private final int id;
+
+  /**
+   * The relevance of completion suggestions from this library where a higher number indicates a
+   * higher relevance.
+   */
+  private final int relevance;
+
+  /**
+   * Constructor for {@link IncludedSuggestionSet}.
+   */
+  public IncludedSuggestionSet(int id, int relevance) {
+    this.id = id;
+    this.relevance = relevance;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof IncludedSuggestionSet) {
+      IncludedSuggestionSet other = (IncludedSuggestionSet) obj;
+      return
+        other.id == id &&
+        other.relevance == relevance;
+    }
+    return false;
+  }
+
+  public static IncludedSuggestionSet fromJson(JsonObject jsonObject) {
+    int id = jsonObject.get("id").getAsInt();
+    int relevance = jsonObject.get("relevance").getAsInt();
+    return new IncludedSuggestionSet(id, relevance);
+  }
+
+  public static List<IncludedSuggestionSet> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<IncludedSuggestionSet> list = new ArrayList<IncludedSuggestionSet>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * Clients should use it to access the set of precomputed completions to be displayed to the user.
+   */
+  public int getId() {
+    return id;
+  }
+
+  /**
+   * The relevance of completion suggestions from this library where a higher number indicates a
+   * higher relevance.
+   */
+  public int getRelevance() {
+    return relevance;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(id);
+    builder.append(relevance);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("id", id);
+    jsonObject.addProperty("relevance", relevance);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("id=");
+    builder.append(id + ", ");
+    builder.append("relevance=");
+    builder.append(relevance);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/LibraryPathSet.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/LibraryPathSet.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A list of associations between paths and the libraries that should be included for code
+ * completion when editing a file beneath that path.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class LibraryPathSet {
+
+  public static final LibraryPathSet[] EMPTY_ARRAY = new LibraryPathSet[0];
+
+  public static final List<LibraryPathSet> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The filepath for which this request's libraries should be active in completion suggestions. This
+   * object associates filesystem regions to libraries and library directories of interest to the
+   * client.
+   */
+  private final String scope;
+
+  /**
+   * The paths of the libraries of interest to the client for completion suggestions.
+   */
+  private final List<String> libraryPaths;
+
+  /**
+   * Constructor for {@link LibraryPathSet}.
+   */
+  public LibraryPathSet(String scope, List<String> libraryPaths) {
+    this.scope = scope;
+    this.libraryPaths = libraryPaths;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof LibraryPathSet) {
+      LibraryPathSet other = (LibraryPathSet) obj;
+      return
+        ObjectUtilities.equals(other.scope, scope) &&
+        ObjectUtilities.equals(other.libraryPaths, libraryPaths);
+    }
+    return false;
+  }
+
+  public static LibraryPathSet fromJson(JsonObject jsonObject) {
+    String scope = jsonObject.get("scope").getAsString();
+    List<String> libraryPaths = JsonUtilities.decodeStringList(jsonObject.get("libraryPaths").getAsJsonArray());
+    return new LibraryPathSet(scope, libraryPaths);
+  }
+
+  public static List<LibraryPathSet> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<LibraryPathSet> list = new ArrayList<LibraryPathSet>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The paths of the libraries of interest to the client for completion suggestions.
+   */
+  public List<String> getLibraryPaths() {
+    return libraryPaths;
+  }
+
+  /**
+   * The filepath for which this request's libraries should be active in completion suggestions. This
+   * object associates filesystem regions to libraries and library directories of interest to the
+   * client.
+   */
+  public String getScope() {
+    return scope;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(scope);
+    builder.append(libraryPaths);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("scope", scope);
+    JsonArray jsonArrayLibraryPaths = new JsonArray();
+    for (String elt : libraryPaths) {
+      jsonArrayLibraryPaths.add(new JsonPrimitive(elt));
+    }
+    jsonObject.add("libraryPaths", jsonArrayLibraryPaths);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("scope=");
+    builder.append(scope + ", ");
+    builder.append("libraryPaths=");
+    builder.append(StringUtils.join(libraryPaths, ", "));
+    builder.append("]");
+    return builder.toString();
+  }
+
+}


### PR DESCRIPTION
This change is associated with the analysis server protocol changes from
https://github.com/dart-lang/sdk/commit/d4b8e0696df14a7834b2f89659b7e3fc41fd3c91
which @scheglov has added support for on the server side. At a high
level, the flow has client send server a subscription for the available
suggestion sets. Server will then send availableSuggestions notifications
that give the client pending completions to cache. At completion time,
we include a couple new fields in CompletionSuggestion which allow us to
identify which of the cached suggestions should be included (in addition
to the default ones).

TODO: Either in this CL or a follow-up we need to update the client to respect relevance tags.

![screenshot from 2019-02-14 15-43-01](https://user-images.githubusercontent.com/535859/52825076-3084f100-3070-11e9-9565-8550b2cc8a37.png)

Note that before this change, you would need to have imported `dart:io` and `dart:html` to get these suggestions.

/cc @alexander-doroshko @bwilkerson