### PR TITLE
Dart plugin changes to support CompletionSuggestion.includedRelevanceTags

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -285,10 +285,11 @@ public class DartAnalysisServerService implements Disposable {
                                    @NotNull final List<CompletionSuggestion> completions,
                                    @NotNull final List<IncludedSuggestionSet> includedSuggestionSets,
                                    @NotNull final List<String> includedSuggestionKinds,
+                                   @NotNull final List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                    final boolean isLast) {
       synchronized (myCompletionInfos) {
         myCompletionInfos.add(new CompletionInfo(completionId, replacementOffset, replacementLength, completions, includedSuggestionSets,
-                                                 includedSuggestionKinds, isLast));
+                                                 includedSuggestionKinds, includedSuggestionRelevanceTags, isLast));
         myCompletionInfos.notifyAll();
       }
     }
@@ -470,8 +471,12 @@ public class DartAnalysisServerService implements Disposable {
           }
 
           final Set<String> includedKinds = Sets.newHashSet(completionInfo.myIncludedSuggestionKinds);
+          final Map<String, IncludedSuggestionRelevanceTag> includedRelevanceTags = new HashMap<>();
+          for (IncludedSuggestionRelevanceTag includedRelevanceTag : completionInfo.myIncludedSuggestionRelevanceTags) {
+            includedRelevanceTags.put(includedRelevanceTag.getTag(), includedRelevanceTag);
+          }
           for (final IncludedSuggestionSet includedSet : completionInfo.myIncludedSuggestionSets) {
-            libraryRefConsumer.consumeLibraryRef(includedSet, includedKinds);
+            libraryRefConsumer.consumeLibraryRef(includedSet, includedKinds, includedRelevanceTags);
           }
           return;
         }
@@ -2170,7 +2175,8 @@ public class DartAnalysisServerService implements Disposable {
   }
 
   public interface CompletionLibraryRefConsumer {
-    void consumeLibraryRef(final IncludedSuggestionSet includedSet, Set<String> includedKinds);
+    void consumeLibraryRef(final IncludedSuggestionSet includedSet, Set<String> includedKinds,
+                           Map<String, IncludedSuggestionRelevanceTag> includedRelevanceTags);
   }
 
   private static class CompletionInfo {
@@ -2186,6 +2192,7 @@ public class DartAnalysisServerService implements Disposable {
     @NotNull private final List<CompletionSuggestion> myCompletions;
     @NotNull private final List<IncludedSuggestionSet> myIncludedSuggestionSets;
     @NotNull private final List<String> myIncludedSuggestionKinds;
+    @NotNull private final List<IncludedSuggestionRelevanceTag> myIncludedSuggestionRelevanceTags;
     private final boolean isLast;
 
     CompletionInfo(@NotNull final String completionId,
@@ -2194,6 +2201,7 @@ public class DartAnalysisServerService implements Disposable {
                    @NotNull final List<CompletionSuggestion> completions,
                    @NotNull final List<IncludedSuggestionSet> includedSuggestionSets,
                    @NotNull final List<String> includedSuggestionKinds,
+                   @NotNull final List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                    boolean isLast) {
       this.myCompletionId = completionId;
       this.myOriginalReplacementOffset = replacementOffset;
@@ -2201,6 +2209,7 @@ public class DartAnalysisServerService implements Disposable {
       this.myCompletions = completions;
       this.myIncludedSuggestionSets = includedSuggestionSets;
       this.myIncludedSuggestionKinds = includedSuggestionKinds;
+      this.myIncludedSuggestionRelevanceTags = includedSuggestionRelevanceTags;
       this.isLast = isLast;
     }
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -397,7 +397,9 @@ public class DartServerCompletionContributor extends CompletionContributor {
       }
 
       // If this is a class, try to show which package it's coming from.
-      if (element.getKind().equals(ElementKind.CLASS) && displayUri != null) {
+      if (!element.getKind().equals(ElementKind.FUNCTION) &&
+          !element.getKind().equals(ElementKind.FUNCTION_INVOCATION) &&
+          displayUri != null) {
         lookup = lookup.appendTailText(" (" + displayUri + ")", true);
       }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -61,6 +61,7 @@ public interface AnalysisServerListener {
                                  List<CompletionSuggestion> completions,
                                  List<IncludedSuggestionSet> includedSuggestionSets,
                                  List<String> includedSuggestionKinds,
+                                 List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast);
 
   /**

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -40,6 +40,7 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
                                  List<CompletionSuggestion> completions,
                                  List<IncludedSuggestionSet> includedSuggestionSets,
                                  List<String> includedSuggestionKinds,
+                                 List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast) {
   }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -67,6 +67,7 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
                                  List<CompletionSuggestion> completions,
                                  List<IncludedSuggestionSet> includedSuggestionSets,
                                  List<String> includedSuggestionKinds,
+                                 List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.computedCompletion(
@@ -76,6 +77,7 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
         completions,
         includedSuggestionSets,
         includedSuggestionKinds,
+        includedSuggestionRelevanceTags,
         isLast);
     }
   }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.dartlang.analysis.server.protocol.CompletionSuggestion;
+import org.dartlang.analysis.server.protocol.IncludedSuggestionRelevanceTag;
 import org.dartlang.analysis.server.protocol.IncludedSuggestionSet;
 
 import java.util.Collections;
@@ -63,6 +64,15 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
       includedSuggestionKinds = Collections.emptyList();
     }
 
+    final List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags;
+    final JsonElement includedSuggestionRelevanceKindsElement = paramsObject.get("includedSuggestionRelevanceTags");
+    if (includedSuggestionRelevanceKindsElement != null) {
+      final JsonArray includedSuggestionRelevanceTagsArray = includedSuggestionRelevanceKindsElement.getAsJsonArray();
+      includedSuggestionRelevanceTags = IncludedSuggestionRelevanceTag.fromJsonArray(includedSuggestionRelevanceTagsArray);
+    } else {
+      includedSuggestionRelevanceTags = Collections.emptyList();
+    }
+
     int replacementOffset = paramsObject.get("replacementOffset").getAsInt();
     int replacementLength = paramsObject.get("replacementLength").getAsInt();
     boolean isLast = paramsObject.get("isLast").getAsBoolean();
@@ -74,6 +84,7 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
         CompletionSuggestion.fromJsonArray(resultsArray),
         includedSuggestionSets,
         includedSuggestionKinds,
+        includedSuggestionRelevanceTags,
         isLast);
   }
 }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
@@ -47,6 +47,20 @@ public class AvailableSuggestion {
   private final Element element;
 
   /**
+   * A default String for use in generating argument list source contents on the client side.
+   */
+  private final String defaultArgumentListString;
+
+  /**
+   * Pairs of offsets and lengths describing 'defaultArgumentListString' text ranges suitable for use
+   * by clients to set up linked edits of default argument source contents. For example, given an
+   * argument list string 'x, y', the corresponding text range [0, 1, 3, 1], indicates two text
+   * ranges of length 1, starting at offsets 0 and 3. Clients can use these ranges to treat the 'x'
+   * and 'y' values specially for linked edits.
+   */
+  private final int[] defaultArgumentListTextRanges;
+
+  /**
    * The Dartdoc associated with the element being suggested. This field is omitted if there is no
    * Dartdoc associated with the element.
    */
@@ -71,18 +85,27 @@ public class AvailableSuggestion {
    */
   private final List<String> parameterTypes;
 
+  /**
+   * This field is set if the relevance of this suggestion might be changed depending on where
+   * completion is requested.
+   */
+  private final List<String> relevanceTags;
+
   private final Integer requiredParameterCount;
 
   /**
    * Constructor for {@link AvailableSuggestion}.
    */
-  public AvailableSuggestion(String label, Element element, String docComplete, String docSummary, List<String> parameterNames, List<String> parameterTypes, Integer requiredParameterCount) {
+  public AvailableSuggestion(String label, Element element, String defaultArgumentListString, int[] defaultArgumentListTextRanges, String docComplete, String docSummary, List<String> parameterNames, List<String> parameterTypes, List<String> relevanceTags, Integer requiredParameterCount) {
     this.label = label;
     this.element = element;
+    this.defaultArgumentListString = defaultArgumentListString;
+    this.defaultArgumentListTextRanges = defaultArgumentListTextRanges;
     this.docComplete = docComplete;
     this.docSummary = docSummary;
     this.parameterNames = parameterNames;
     this.parameterTypes = parameterTypes;
+    this.relevanceTags = relevanceTags;
     this.requiredParameterCount = requiredParameterCount;
   }
 
@@ -93,10 +116,13 @@ public class AvailableSuggestion {
       return
         ObjectUtilities.equals(other.label, label) &&
         ObjectUtilities.equals(other.element, element) &&
+        ObjectUtilities.equals(other.defaultArgumentListString, defaultArgumentListString) &&
+        Arrays.equals(other.defaultArgumentListTextRanges, defaultArgumentListTextRanges) &&
         ObjectUtilities.equals(other.docComplete, docComplete) &&
         ObjectUtilities.equals(other.docSummary, docSummary) &&
         ObjectUtilities.equals(other.parameterNames, parameterNames) &&
         ObjectUtilities.equals(other.parameterTypes, parameterTypes) &&
+        ObjectUtilities.equals(other.relevanceTags, relevanceTags) &&
         ObjectUtilities.equals(other.requiredParameterCount, requiredParameterCount);
     }
     return false;
@@ -105,12 +131,15 @@ public class AvailableSuggestion {
   public static AvailableSuggestion fromJson(JsonObject jsonObject) {
     String label = jsonObject.get("label").getAsString();
     Element element = Element.fromJson(jsonObject.get("element").getAsJsonObject());
+    String defaultArgumentListString = jsonObject.get("defaultArgumentListString") == null ? null : jsonObject.get("defaultArgumentListString").getAsString();
+    int[] defaultArgumentListTextRanges = jsonObject.get("defaultArgumentListTextRanges") == null ? null : JsonUtilities.decodeIntArray(jsonObject.get("defaultArgumentListTextRanges").getAsJsonArray());
     String docComplete = jsonObject.get("docComplete") == null ? null : jsonObject.get("docComplete").getAsString();
     String docSummary = jsonObject.get("docSummary") == null ? null : jsonObject.get("docSummary").getAsString();
     List<String> parameterNames = jsonObject.get("parameterNames") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("parameterNames").getAsJsonArray());
     List<String> parameterTypes = jsonObject.get("parameterTypes") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("parameterTypes").getAsJsonArray());
+    List<String> relevanceTags = jsonObject.get("relevanceTags") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("relevanceTags").getAsJsonArray());
     Integer requiredParameterCount = jsonObject.get("requiredParameterCount") == null ? null : jsonObject.get("requiredParameterCount").getAsInt();
-    return new AvailableSuggestion(label, element, docComplete, docSummary, parameterNames, parameterTypes, requiredParameterCount);
+    return new AvailableSuggestion(label, element, defaultArgumentListString, defaultArgumentListTextRanges, docComplete, docSummary, parameterNames, parameterTypes, relevanceTags, requiredParameterCount);
   }
 
   public static List<AvailableSuggestion> fromJsonArray(JsonArray jsonArray) {
@@ -123,6 +152,24 @@ public class AvailableSuggestion {
       list.add(fromJson(iterator.next().getAsJsonObject()));
     }
     return list;
+  }
+
+  /**
+   * A default String for use in generating argument list source contents on the client side.
+   */
+  public String getDefaultArgumentListString() {
+    return defaultArgumentListString;
+  }
+
+  /**
+   * Pairs of offsets and lengths describing 'defaultArgumentListString' text ranges suitable for use
+   * by clients to set up linked edits of default argument source contents. For example, given an
+   * argument list string 'x, y', the corresponding text range [0, 1, 3, 1], indicates two text
+   * ranges of length 1, starting at offsets 0 and 3. Clients can use these ranges to treat the 'x'
+   * and 'y' values specially for linked edits.
+   */
+  public int[] getDefaultArgumentListTextRanges() {
+    return defaultArgumentListTextRanges;
   }
 
   /**
@@ -172,6 +219,14 @@ public class AvailableSuggestion {
     return parameterTypes;
   }
 
+  /**
+   * This field is set if the relevance of this suggestion might be changed depending on where
+   * completion is requested.
+   */
+  public List<String> getRelevanceTags() {
+    return relevanceTags;
+  }
+
   public Integer getRequiredParameterCount() {
     return requiredParameterCount;
   }
@@ -181,10 +236,13 @@ public class AvailableSuggestion {
     HashCodeBuilder builder = new HashCodeBuilder();
     builder.append(label);
     builder.append(element);
+    builder.append(defaultArgumentListString);
+    builder.append(defaultArgumentListTextRanges);
     builder.append(docComplete);
     builder.append(docSummary);
     builder.append(parameterNames);
     builder.append(parameterTypes);
+    builder.append(relevanceTags);
     builder.append(requiredParameterCount);
     return builder.toHashCode();
   }
@@ -193,6 +251,16 @@ public class AvailableSuggestion {
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("label", label);
     jsonObject.add("element", element.toJson());
+    if (defaultArgumentListString != null) {
+      jsonObject.addProperty("defaultArgumentListString", defaultArgumentListString);
+    }
+    if (defaultArgumentListTextRanges != null) {
+      JsonArray jsonArrayDefaultArgumentListTextRanges = new JsonArray();
+      for (int elt : defaultArgumentListTextRanges) {
+        jsonArrayDefaultArgumentListTextRanges.add(new JsonPrimitive(elt));
+      }
+      jsonObject.add("defaultArgumentListTextRanges", jsonArrayDefaultArgumentListTextRanges);
+    }
     if (docComplete != null) {
       jsonObject.addProperty("docComplete", docComplete);
     }
@@ -213,6 +281,13 @@ public class AvailableSuggestion {
       }
       jsonObject.add("parameterTypes", jsonArrayParameterTypes);
     }
+    if (relevanceTags != null) {
+      JsonArray jsonArrayRelevanceTags = new JsonArray();
+      for (String elt : relevanceTags) {
+        jsonArrayRelevanceTags.add(new JsonPrimitive(elt));
+      }
+      jsonObject.add("relevanceTags", jsonArrayRelevanceTags);
+    }
     if (requiredParameterCount != null) {
       jsonObject.addProperty("requiredParameterCount", requiredParameterCount);
     }
@@ -227,6 +302,10 @@ public class AvailableSuggestion {
     builder.append(label + ", ");
     builder.append("element=");
     builder.append(element + ", ");
+    builder.append("defaultArgumentListString=");
+    builder.append(defaultArgumentListString + ", ");
+    builder.append("defaultArgumentListTextRanges=");
+    builder.append(StringUtils.join(defaultArgumentListTextRanges, ", ") + ", ");
     builder.append("docComplete=");
     builder.append(docComplete + ", ");
     builder.append("docSummary=");
@@ -235,6 +314,8 @@ public class AvailableSuggestion {
     builder.append(StringUtils.join(parameterNames, ", ") + ", ");
     builder.append("parameterTypes=");
     builder.append(StringUtils.join(parameterTypes, ", ") + ", ");
+    builder.append("relevanceTags=");
+    builder.append(StringUtils.join(relevanceTags, ", ") + ", ");
     builder.append("requiredParameterCount=");
     builder.append(requiredParameterCount);
     builder.append("]");

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionSuggestion.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionSuggestion.java
@@ -60,12 +60,6 @@ public class CompletionSuggestion {
   private final String displayText;
 
   /**
-   * The URI of the element corresponding to this suggestion. It will be set whenever analysis server
-   * is able to compute it.
-   */
-  private final String elementUri;
-
-  /**
    * The offset, relative to the beginning of the completion, of where the selection should be placed
    * after insertion.
    */
@@ -167,20 +161,13 @@ public class CompletionSuggestion {
   private final String parameterType;
 
   /**
-   * The import to be added if the suggestion is out of scope and needs an import to be added to be
-   * in scope.
-   */
-  private final String importUri;
-
-  /**
    * Constructor for {@link CompletionSuggestion}.
    */
-  public CompletionSuggestion(String kind, int relevance, String completion, String displayText, String elementUri, int selectionOffset, int selectionLength, boolean isDeprecated, boolean isPotential, String docSummary, String docComplete, String declaringType, String defaultArgumentListString, int[] defaultArgumentListTextRanges, Element element, String returnType, List<String> parameterNames, List<String> parameterTypes, Integer requiredParameterCount, Boolean hasNamedParameters, String parameterName, String parameterType, String importUri) {
+  public CompletionSuggestion(String kind, int relevance, String completion, String displayText, int selectionOffset, int selectionLength, boolean isDeprecated, boolean isPotential, String docSummary, String docComplete, String declaringType, String defaultArgumentListString, int[] defaultArgumentListTextRanges, Element element, String returnType, List<String> parameterNames, List<String> parameterTypes, Integer requiredParameterCount, Boolean hasNamedParameters, String parameterName, String parameterType) {
     this.kind = kind;
     this.relevance = relevance;
     this.completion = completion;
     this.displayText = displayText;
-    this.elementUri = elementUri;
     this.selectionOffset = selectionOffset;
     this.selectionLength = selectionLength;
     this.isDeprecated = isDeprecated;
@@ -198,7 +185,6 @@ public class CompletionSuggestion {
     this.hasNamedParameters = hasNamedParameters;
     this.parameterName = parameterName;
     this.parameterType = parameterType;
-    this.importUri = importUri;
   }
 
   @Override
@@ -210,7 +196,6 @@ public class CompletionSuggestion {
         other.relevance == relevance &&
         ObjectUtilities.equals(other.completion, completion) &&
         ObjectUtilities.equals(other.displayText, displayText) &&
-        ObjectUtilities.equals(other.elementUri, elementUri) &&
         other.selectionOffset == selectionOffset &&
         other.selectionLength == selectionLength &&
         other.isDeprecated == isDeprecated &&
@@ -227,8 +212,7 @@ public class CompletionSuggestion {
         ObjectUtilities.equals(other.requiredParameterCount, requiredParameterCount) &&
         ObjectUtilities.equals(other.hasNamedParameters, hasNamedParameters) &&
         ObjectUtilities.equals(other.parameterName, parameterName) &&
-        ObjectUtilities.equals(other.parameterType, parameterType) &&
-        ObjectUtilities.equals(other.importUri, importUri);
+        ObjectUtilities.equals(other.parameterType, parameterType);
     }
     return false;
   }
@@ -238,7 +222,6 @@ public class CompletionSuggestion {
     int relevance = jsonObject.get("relevance").getAsInt();
     String completion = jsonObject.get("completion").getAsString();
     String displayText = jsonObject.get("displayText") == null ? null : jsonObject.get("displayText").getAsString();
-    String elementUri = jsonObject.get("elementUri") == null ? null : jsonObject.get("elementUri").getAsString();
     int selectionOffset = jsonObject.get("selectionOffset").getAsInt();
     int selectionLength = jsonObject.get("selectionLength").getAsInt();
     boolean isDeprecated = jsonObject.get("isDeprecated").getAsBoolean();
@@ -256,8 +239,7 @@ public class CompletionSuggestion {
     Boolean hasNamedParameters = jsonObject.get("hasNamedParameters") == null ? null : jsonObject.get("hasNamedParameters").getAsBoolean();
     String parameterName = jsonObject.get("parameterName") == null ? null : jsonObject.get("parameterName").getAsString();
     String parameterType = jsonObject.get("parameterType") == null ? null : jsonObject.get("parameterType").getAsString();
-    String importUri = jsonObject.get("importUri") == null ? null : jsonObject.get("importUri").getAsString();
-    return new CompletionSuggestion(kind, relevance, completion, displayText, elementUri, selectionOffset, selectionLength, isDeprecated, isPotential, docSummary, docComplete, declaringType, defaultArgumentListString, defaultArgumentListTextRanges, element, returnType, parameterNames, parameterTypes, requiredParameterCount, hasNamedParameters, parameterName, parameterType, importUri);
+    return new CompletionSuggestion(kind, relevance, completion, displayText, selectionOffset, selectionLength, isDeprecated, isPotential, docSummary, docComplete, declaringType, defaultArgumentListString, defaultArgumentListTextRanges, element, returnType, parameterNames, parameterTypes, requiredParameterCount, hasNamedParameters, parameterName, parameterType);
   }
 
   public static List<CompletionSuggestion> fromJsonArray(JsonArray jsonArray) {
@@ -339,27 +321,11 @@ public class CompletionSuggestion {
   }
 
   /**
-   * The URI of the element corresponding to this suggestion. It will be set whenever analysis server
-   * is able to compute it.
-   */
-  public String getElementUri() {
-    return elementUri;
-  }
-
-  /**
    * True if the function or method being suggested has at least one named parameter. This field is
    * omitted if the parameterNames field is omitted.
    */
   public Boolean getHasNamedParameters() {
     return hasNamedParameters;
-  }
-
-  /**
-   * The import to be added if the suggestion is out of scope and needs an import to be added to be
-   * in scope.
-   */
-  public String getImportUri() {
-    return importUri;
   }
 
   /**
@@ -461,7 +427,6 @@ public class CompletionSuggestion {
     builder.append(relevance);
     builder.append(completion);
     builder.append(displayText);
-    builder.append(elementUri);
     builder.append(selectionOffset);
     builder.append(selectionLength);
     builder.append(isDeprecated);
@@ -479,7 +444,6 @@ public class CompletionSuggestion {
     builder.append(hasNamedParameters);
     builder.append(parameterName);
     builder.append(parameterType);
-    builder.append(importUri);
     return builder.toHashCode();
   }
 
@@ -490,9 +454,6 @@ public class CompletionSuggestion {
     jsonObject.addProperty("completion", completion);
     if (displayText != null) {
       jsonObject.addProperty("displayText", displayText);
-    }
-    if (elementUri != null) {
-      jsonObject.addProperty("elementUri", elementUri);
     }
     jsonObject.addProperty("selectionOffset", selectionOffset);
     jsonObject.addProperty("selectionLength", selectionLength);
@@ -549,9 +510,6 @@ public class CompletionSuggestion {
     if (parameterType != null) {
       jsonObject.addProperty("parameterType", parameterType);
     }
-    if (importUri != null) {
-      jsonObject.addProperty("importUri", importUri);
-    }
     return jsonObject;
   }
 
@@ -567,8 +525,6 @@ public class CompletionSuggestion {
     builder.append(completion + ", ");
     builder.append("displayText=");
     builder.append(displayText + ", ");
-    builder.append("elementUri=");
-    builder.append(elementUri + ", ");
     builder.append("selectionOffset=");
     builder.append(selectionOffset + ", ");
     builder.append("selectionLength=");
@@ -602,9 +558,7 @@ public class CompletionSuggestion {
     builder.append("parameterName=");
     builder.append(parameterName + ", ");
     builder.append("parameterType=");
-    builder.append(parameterType + ", ");
-    builder.append("importUri=");
-    builder.append(importUri);
+    builder.append(parameterType);
     builder.append("]");
     return builder.toString();
   }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/IncludedSuggestionRelevanceTag.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/IncludedSuggestionRelevanceTag.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Each AvailableSuggestion can specify zero or more tags in the field relevanceTags, so that when
+ * the included tag is equal to one of the relevanceTags, the suggestion is given higher relevance
+ * than the whole IncludedSuggestionSet.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class IncludedSuggestionRelevanceTag {
+
+  public static final IncludedSuggestionRelevanceTag[] EMPTY_ARRAY = new IncludedSuggestionRelevanceTag[0];
+
+  public static final List<IncludedSuggestionRelevanceTag> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The opaque value of the tag.
+   */
+  private final String tag;
+
+  /**
+   * The boost to the relevance of the completion suggestions that match this tag, which is added to
+   * the relevance of the containing IncludedSuggestionSet.
+   */
+  private final int relevanceBoost;
+
+  /**
+   * Constructor for {@link IncludedSuggestionRelevanceTag}.
+   */
+  public IncludedSuggestionRelevanceTag(String tag, int relevanceBoost) {
+    this.tag = tag;
+    this.relevanceBoost = relevanceBoost;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof IncludedSuggestionRelevanceTag) {
+      IncludedSuggestionRelevanceTag other = (IncludedSuggestionRelevanceTag) obj;
+      return
+        ObjectUtilities.equals(other.tag, tag) &&
+        other.relevanceBoost == relevanceBoost;
+    }
+    return false;
+  }
+
+  public static IncludedSuggestionRelevanceTag fromJson(JsonObject jsonObject) {
+    String tag = jsonObject.get("tag").getAsString();
+    int relevanceBoost = jsonObject.get("relevanceBoost").getAsInt();
+    return new IncludedSuggestionRelevanceTag(tag, relevanceBoost);
+  }
+
+  public static List<IncludedSuggestionRelevanceTag> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<IncludedSuggestionRelevanceTag> list = new ArrayList<IncludedSuggestionRelevanceTag>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The boost to the relevance of the completion suggestions that match this tag, which is added to
+   * the relevance of the containing IncludedSuggestionSet.
+   */
+  public int getRelevanceBoost() {
+    return relevanceBoost;
+  }
+
+  /**
+   * The opaque value of the tag.
+   */
+  public String getTag() {
+    return tag;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(tag);
+    builder.append(relevanceBoost);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("tag", tag);
+    jsonObject.addProperty("relevanceBoost", relevanceBoost);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("tag=");
+    builder.append(tag + ", ");
+    builder.append("relevanceBoost=");
+    builder.append(relevanceBoost);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}


### PR DESCRIPTION
This is a follow up from https://github.com/JetBrains/intellij-plugins/commit/96fe224d4578583671570d65c4aae7fca0d0ba15. In this patch, I'm updating the client to read the includedSuggestionRelevanceTags and apply them on top of the base relevances of available suggestion sets. The corresponding protocol patch from @scheglov was https://github.com/dart-lang/sdk/commit/67c5923ccedf6e04af617f47ee734f574f13ad87#diff-441befac1720a80d45409f9dfe72ec80.

/cc @alexander-doroshko 