### PR TITLE
Dart client changes to support completion.registerLibraryPaths

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -2319,4 +2319,15 @@ public class DartAnalysisServerService implements Disposable {
       server.sendRequestToServer(id, request, consumer);
     }
   }
+
+  /**
+   * Express interest in particular libraries to be included in code completion suggestions.
+   */
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void registerLibraryPaths(List<LibraryPathSet> paths) {
+    final AnalysisServer server = myServer;
+    if (server != null) {
+      server.completion_registerLibraryPaths(paths);
+    }
+  }
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -401,6 +401,22 @@ public interface AnalysisServer {
   public void completion_getSuggestions(String file, int offset, GetSuggestionsConsumer consumer);
 
   /**
+   * {@code completion.registerLibraryPaths}
+   *
+   * The client can make this request to express interest in certain libraries to receive completion
+   * suggestions from based on the client path. If this request is received before the client has
+   * used 'completion.setSubscriptions' to subscribe to the AVAILABLE_SUGGESTION_SETS service, then
+   * an error of type NOT_SUBSCRIBED_TO_AVAILABLE_SUGGESTION_SETS will be generated. All previous
+   * paths are replaced by the given set of paths.
+   *
+   * @param paths A list of objects each containing a path and the additional libraries from which
+   *         the client is interested in receiving completion suggestions. If one configured path is
+   *         beneath another, the descendent will override the ancestors' configured libraries of
+   *         interest.
+   */
+  public void completion_registerLibraryPaths(List<LibraryPathSet> paths);
+
+  /**
    * {@code completion.setSubscriptions}
    *
    * Subscribe for completion services.

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -301,6 +301,12 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   }
 
   @Override
+  public void completion_registerLibraryPaths(List<LibraryPathSet> paths) {
+    String id = generateUniqueId();
+    sendRequestToServer(id, RequestUtilities.generateCompletionRegisterLibraryPaths(id, paths));
+  }
+
+  @Override
   public void completion_getSuggestionDetails(String file, int id, String label, int offset, GetSuggestionDetailsConsumer consumer) {
     String requestId = generateUniqueId();
     sendRequestToServer(requestId, RequestUtilities.generateCompletionGetSuggestionDetails(requestId, file, id, label, offset), consumer);

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.intellij.icons.AllIcons;
 import org.dartlang.analysis.server.protocol.*;
 
 import java.util.List;
@@ -100,6 +101,7 @@ public class RequestUtilities {
   private static final String METHOD_COMPLETION_GET_SUGGESTION_DETAILS = "completion.getSuggestionDetails";
   private static final String METHOD_COMPLETION_GET_SUGGESTIONS = "completion.getSuggestions";
   private static final String METHOD_COMPLETION_SET_SUBSCRIPTIONS = "completion.setSubscriptions";
+  private static final String METHOD_COMPLETION_REGISTER_LIBRARY_PATHS = "completion.registerLibraryPaths";
 
   // Search domain
   private static final String METHOD_SEARCH_FIND_ELEMENT_REFERENCES = "search.findElementReferences";
@@ -421,6 +423,26 @@ public class RequestUtilities {
     JsonObject params = new JsonObject();
     params.add("options", buildJsonElement(options));
     return buildJsonObjectRequest(idValue, METHOD_ANALYSIS_UPDATE_OPTIONS, params);
+  }
+
+  /**
+   * Generate and return a {@value #METHOD_COMPLETION_REGISTER_LIBRARY_PATHS} request.
+   * <p>
+   * <pre>
+   * request: {
+   *   "id": string",
+   *   "method": "completion.registerLibraryPaths",
+   *   "params": {
+   *     "paths": List&lt;LibraryPathSet&gt;
+   *   }
+   * }
+   * </pre>
+   * </p>
+   */
+  public static JsonObject generateCompletionRegisterLibraryPaths(String idValue, List<LibraryPathSet> paths) {
+    JsonObject params = new JsonObject();
+    params.add("paths", buildJsonElement(paths));
+    return buildJsonObjectRequest(idValue, METHOD_COMPLETION_REGISTER_LIBRARY_PATHS, params);
   }
 
   /**


### PR DESCRIPTION
This change follows the Dart analysis server protocol changes in https://github.com/dart-lang/sdk/commit/d4b8e0696df14a7834b2f89659b7e3fc41fd3c91 and will allow other IntelliJ plugins (ie Flutter) to configure the libraries from which analysis server should provide code completions.

/cc @alexander-doroshko @scheglov @bwilkerson