### PR TITLE
Add judgement on adding formatter to debug configuration program argument

### DIFF
--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaRunConfigurationProducer.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaRunConfigurationProducer.java
@@ -122,7 +122,10 @@ public abstract class CucumberJavaRunConfigurationProducer extends JavaRunConfig
     configuration.setNameFilter(getNameFilter(context));
     configuration.setFilePath(file.getPath());
     String programParametersFromDefaultConfiguration = StringUtil.defaultIfEmpty(configuration.getProgramParameters(), "");
-    configuration.setProgramParameters(programParametersFromDefaultConfiguration + formatterOptions);
+
+    if(programParametersFromDefaultConfiguration == null) {
+      configuration.setProgramParameters(formatterOptions);
+    }
 
     if (configuration.getMainClassName() == null) {
       configuration.setMainClassName(mainClassName);


### PR DESCRIPTION
For my case, i want to add "-p pretty" to default program argument. 
But the current code would directly append the formatter which caused the console output color affected. So i add a judgement which adds formatter only if default program argument is null.

In this way, for debug configuration, i could set template program arguments as "-p pretty" and the configurations derived from the template will be "-p pretty" instead of "-p pretty --plugin org.jetbrains.plugins.cucumber.java.run.CucumberJvm2SMFormatter --monochrome".