### PR TITLE
Use `toStringDeep()` for better display of variable in Dart debugger

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
@@ -164,12 +164,14 @@ public class DartVmServiceValue extends XNamedValue {
         public void received(final InstanceRef toStringInstanceRef) {
           if (toStringInstanceRef.getKind() == InstanceKind.String) {
             String content = toStringInstanceRef.getValueAsString();
-            String summary = content.split("\n")[0];
+            int firstLineBreak = content.indexOf('\n');
+            String summary = firstLineBreak < 0 ? content : content.substring(0, firstLineBreak);
             node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), summary, true);
             if (toStringInstanceRef.getValueAsStringIsTruncated()) {
               addFullStringValueEvaluator(node, toStringInstanceRef);
             }
-            else {
+            else if (firstLineBreak >= 0){
+              // Multi-line content. Display a View link to reveal full content.
               node.setFullValueEvaluator(new ImmediateFullValueEvaluator("View", content));
             }
           }

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
@@ -172,7 +172,7 @@ public class DartVmServiceValue extends XNamedValue {
             }
             else if (firstLineBreak >= 0){
               // Multi-line content. Display a View link to reveal full content.
-              node.setFullValueEvaluator(new ImmediateFullValueEvaluator("View", content));
+              node.setFullValueEvaluator(new ImmediateFullValueEvaluator("...View", content));
             }
           }
           else {


### PR DESCRIPTION
We've added (and will add more) usages of a method called `toStringDeep()` to some classes, which expose more debugging information so that the IDE (like IntelliJ) can use it to gather more information and have a better display of the variables in debugger. It uses a new method instead of just `toString()` because we don't want to change the original behavior of all those objects. Also because sometimes the debug information is quite long, not suitable for logging etc.

Screenshot [here](https://photos.app.goo.gl/V53LkmLbzSeorapf6).

This can already be used in the [webdriver.dart](https://github.com/google/webdriver.dart) project after [this commit](https://github.com/google/webdriver.dart/commit/9a187cb44a288d7d0d4c64103dcbfc3e395440ed) has been submitted. Just debug the [chrome_json_wire_web_element_test](https://github.com/google/webdriver.dart/blob/master/test/chrome_json_wire_web_element_test.dart) and see.

Safety for failing case: The new method won't be touched if previous calculation of presentation works. And the new method will go back to the original computeDefaultPresentation method if it doesn't work out. Worst case, those variables without an already known presentation may be impacted. So in general it should be quite safe.