### PR TITLE
Add Dart plugin mechanism to listen to quick assist invocations

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.editor.event.DocumentListener;
@@ -48,6 +49,7 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileSystemItem;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.SearchScope;
@@ -62,7 +64,10 @@ import com.jetbrains.lang.dart.DartFileListener;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartYamlFileTypeFactory;
 import com.jetbrains.lang.dart.assists.DartQuickAssistIntention;
+import com.jetbrains.lang.dart.assists.DartQuickAssistIntentionListener;
 import com.jetbrains.lang.dart.assists.QuickAssistSet;
+import com.jetbrains.lang.dart.fixes.DartQuickFix;
+import com.jetbrains.lang.dart.fixes.DartQuickFixListener;
 import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartFeedbackBuilder;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
@@ -177,6 +182,8 @@ public class DartAnalysisServerService implements Disposable {
   @NotNull private final List<AnalysisServerListener> myAdditionalServerListeners = new SmartList<>();
   @NotNull private final List<RequestListener> myRequestListeners = new SmartList<>();
   @NotNull private final List<ResponseListener> myResponseListeners = new SmartList<>();
+  @NotNull private final List<DartQuickAssistIntentionListener> myQuickAssistIntentionListeners = new SmartList<>();
+  @NotNull private final List<DartQuickFixListener> myQuickFixListeners = new SmartList<>();
 
   private static final String ENABLE_ANALYZED_FILES_SUBSCRIPTION_KEY =
     "com.jetbrains.lang.dart.analyzer.DartAnalysisServerService.enableAnalyzedFilesSubscription";
@@ -622,6 +629,41 @@ public class DartAnalysisServerService implements Disposable {
     if (myServer != null) {
       myServer.removeResponseListener(responseListener);
     }
+  }
+
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void addQuickAssistIntentionListener(DartQuickAssistIntentionListener listener) {
+    if (!myQuickAssistIntentionListeners.contains(listener)) {
+      myQuickAssistIntentionListeners.add(listener);
+    }
+  }
+
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void removeQuickAssistIntentionListener(DartQuickAssistIntentionListener listener) {
+    myQuickAssistIntentionListeners.remove(listener);
+  }
+
+  public void fireQuickAssistEvent(DartQuickAssistIntention intention,
+                                   Editor editor, PsiFile file) {
+    myQuickAssistIntentionListeners.stream()
+      .forEach(listener -> listener.onQuickAssistIntentionInvoked(intention, editor, file));
+  }
+
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void addQuickFixListener(DartQuickFixListener listener) {
+    if (!myQuickFixListeners.contains(listener)) {
+      myQuickFixListeners.add(listener);
+    }
+  }
+
+  @SuppressWarnings("unused") // for Flutter plugin
+  public void removeQuickFixListener(DartQuickFixListener listener) {
+    myQuickFixListeners.remove(listener);
+  }
+
+  public void fireQuickFixEvent(DartQuickFix fix, Editor editor, PsiFile file) {
+    myQuickFixListeners.stream()
+      .forEach(listener -> listener.onQuickFixInvoked(fix, editor, file));
   }
 
   private static void setDasLogger() {

--- a/Dart/src/com/jetbrains/lang/dart/assists/DartQuickAssistIntention.java
+++ b/Dart/src/com/jetbrains/lang/dart/assists/DartQuickAssistIntention.java
@@ -76,6 +76,8 @@ public class DartQuickAssistIntention implements IntentionAction, Comparable<Int
       catch (DartSourceEditException e) {
         CommonRefactoringUtil.showErrorHint(project, editor, e.getMessage(), CommonBundle.getErrorTitle(), null);
       }
+
+      DartAnalysisServerService.getInstance(project).fireQuickAssistIntentionEvent(this, editor, file);
     }
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/assists/DartQuickAssistIntentionListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/assists/DartQuickAssistIntentionListener.java
@@ -1,0 +1,12 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.assists;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+
+public interface DartQuickAssistIntentionListener {
+  public void onQuickAssistIntentionInvoked(
+      DartQuickAssistIntention intention,
+      Editor editor,
+      PsiFile file);
+}

--- a/Dart/src/com/jetbrains/lang/dart/assists/DartQuickFixListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/assists/DartQuickFixListener.java
@@ -1,0 +1,12 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.fixes;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+
+public interface DartQuickFixListener {
+  public void onQuickFixInvoked(
+      DartQuickFix fix,
+      Editor editor,
+      PsiFile file);
+}

--- a/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFix.java
+++ b/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFix.java
@@ -121,6 +121,7 @@ public final class DartQuickFix implements IntentionAction, Comparable<Intention
     catch (DartSourceEditException e) {
       CommonRefactoringUtil.showErrorHint(project, editor, e.getMessage(), CommonBundle.getErrorTitle(), null);
     }
+    DartAnalysisServerService.getInstance(project).fireQuickFixEvent(this, editor, file);
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFixListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFixListener.java
@@ -1,0 +1,12 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.assists;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+
+public interface DartQuickFixListener {
+  public void onQuickFixInvoked(
+      DartQuickFix intention,
+      Editor editor,
+      PsiFile file);
+}


### PR DESCRIPTION
See https://intellij-support.jetbrains.com/hc/en-us/community/posts/360003384140-Listening-for-whenever-a-quick-fix-is-applied-?page=1#community_comment_360000423640 for more context. We would like to quantify + understand when users apply quick fixes.

/cc @bwilkerson @alexander-doroshko 