### PR TITLE
Add action that calls the Dart VM Service reloadSources

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -302,5 +302,6 @@
     </group>
     <action id="Dart.pub.cache.repair" class="com.jetbrains.lang.dart.ide.actions.DartPubCacheRepairAction" text="Pub: Repair Cache..."
             description="Run 'pub cache repair'"/>
+    <action id="Dart.reload.sources" class="com.jetbrains.lang.dart.ide.runner.actions.DartReloadSourcesAction"/>
   </actions>
 </idea-plugin>

--- a/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
+++ b/Dart/src/com/jetbrains/lang/dart/DartBundle.properties
@@ -208,6 +208,8 @@ open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 dart.pop.frame.action.text=Drop Frame (Dart)
 dart.pop.frame.action.description=Pop the current frame off the stack
+dart.reload.sources.action.text=Reload Sources (Dart)
+dart.reload.sources.action.description=Save files and reload sources of current isolate
 stop.dart.webdev.server=Stop Dart Webdev Server
 dart.webdev.server.output.contains.errors=<html><a href="">Dart Webdev Server</a> output contains errors.</html>
 dart.webdev.server.output.contains.warnings=<html><a href="">Dart Webdev Server</a> output contains warnings.</html>

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/actions/DartReloadSourcesAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/actions/DartReloadSourcesAction.java
@@ -1,0 +1,64 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.runner.actions;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebugSession;
+import com.intellij.xdebugger.XDebuggerManager;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugProcess;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DartReloadSourcesAction extends AnAction implements DumbAware {
+
+  public DartReloadSourcesAction() {
+    Presentation presentation = getTemplatePresentation();
+    presentation.setText(DartBundle.message("dart.reload.sources.action.text"));
+    presentation.setDescription(DartBundle.message("dart.reload.sources.action.description"));
+    presentation.setIcon(AllIcons.Actions.Lightning);
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    DartVmServiceDebugProcess process = getProcess(e);
+    if (process != null && process.getCurrentIsolateId() != null) {
+      FileDocumentManager.getInstance().saveAllDocuments();
+      process.reloadSources();
+    }
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    DartVmServiceDebugProcess process = getProcess(e);
+    String isolateId = process == null ? null : process.getCurrentIsolateId();
+    e.getPresentation().setEnabled(isolateId != null);
+  }
+
+  @Nullable
+  private static DartVmServiceDebugProcess getProcess(AnActionEvent e) {
+    final Project project = e.getProject();
+    if (project == null) return null;
+
+    XDebugSession session = e.getData(XDebugSession.DATA_KEY);
+
+    if (session == null) {
+      session = XDebuggerManager.getInstance(project).getCurrentSession();
+    }
+
+    if (session != null) {
+      XDebugProcess process = session.getDebugProcess();
+      if (process instanceof DartVmServiceDebugProcess) {
+        return ((DartVmServiceDebugProcess) process);
+      }
+    }
+
+    return null;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -35,6 +35,7 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.actions.DartPopFrameAction;
+import com.jetbrains.lang.dart.ide.runner.actions.DartReloadSourcesAction;
 import com.jetbrains.lang.dart.ide.runner.base.DartDebuggerEditorsProvider;
 import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceEvaluator;
@@ -357,6 +358,13 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     myVmServiceWrapper.dropFrame(frame.getIsolateId(), frame.getFrameIndex() + 1);
   }
 
+  public void reloadSources() {
+    String isolateId = getCurrentIsolateId();
+    if (isolateId != null) {
+      myVmServiceWrapper.reloadSources(isolateId);
+    }
+  }
+
   @Override
   public void stop() {
     myVmConnected = false;
@@ -447,6 +455,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     topToolbar.addSeparator();
     topToolbar.addAction(myOpenObservatoryAction);
     topToolbar.addAction(new DartPopFrameAction());
+    topToolbar.addAction(new DartReloadSourcesAction());
   }
 
   @NotNull

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceConsumers.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceConsumers.java
@@ -1,10 +1,7 @@
 package com.jetbrains.lang.dart.ide.runner.server.vmService;
 
 import org.dartlang.vm.service.consumer.*;
-import org.dartlang.vm.service.element.ErrorRef;
-import org.dartlang.vm.service.element.RPCError;
-import org.dartlang.vm.service.element.Sentinel;
-import org.dartlang.vm.service.element.Success;
+import org.dartlang.vm.service.element.*;
 
 public class VmServiceConsumers {
 
@@ -38,6 +35,11 @@ public class VmServiceConsumers {
 
   public static abstract class BreakpointConsumerWrapper implements BreakpointConsumer {
     abstract void sourcePositionNotApplicable();
+  }
+
+  public static abstract class ReloadReportConsumerWrapper extends ConsumerWrapper implements ReloadReportConsumer {
+    @Override
+    abstract public void received(ReloadReport response);
   }
 
   public static abstract class EvaluateConsumerWrapper implements EvaluateConsumer {


### PR DESCRIPTION
Adds an action to the Debugger window that exposes the `reloadSources` RPC of the Dart VM Service (similar to Flutter's Hot Reload, but for any Dart program):

https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md#reloadsources

If the debugger is attached to a Dart isolate, the action saves all files and reloads the sources into the currently running isolate. As an example, I used the following Dart program:

```
main(List<String> arguments) {
  _ping();
}

void _ping() {
  Future.delayed(Duration(milliseconds: 4000)).then((_) {
    _printTime();
    _ping();
  });
}

void _printTime() {
  print('ping? ${DateTime.now()}');
}
```

The `Reload Sources (Dart)` action can then be used to change the output of `_printTime()` while the isolate is still running. The change will take effect once the next future is completed and `_printTime()` is called:

<img width="514" alt="Dart Reload Sources Action" src="https://user-images.githubusercontent.com/358580/55097548-59ab8f00-50bc-11e9-87c6-d1df42fac4db.png">
