### PR TITLE
indicate that the analyzer provides lints for AndroidManifest.xml

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -842,6 +842,7 @@ public class DartAnalysisServerService implements Disposable {
              HtmlUtil.isHtmlFile(file) ||
              file.getName().equals(PubspecYamlUtil.PUBSPEC_YAML) ||
              file.getName().equals("analysis_options.yaml") ||
+             file.getName().equals("AndroidManifest.xml") ||
              file.getName().equals(DartYamlFileTypeFactory.DOT_ANALYSIS_OPTIONS);
     }
     return false;


### PR DESCRIPTION
- indicate that the analyzer provides lints for AndroidManifest.xml

We now can provide analyzer warnings for `AndroidManifest.xml` files. I believe this change will allow us to show underlined warnings in editors (the issues already show in the Dart Analysis view). (admittedly, I wasn't able to verify this, as my local setup didn't survive an upgrade to 2019.1)

@alexander-doroshko @keertip
