### PR TITLE
Make Dart IntelliJ plugin recognize includedSuggestionKinds if includedElementKinds is missing from CompletionSuggestion

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
@@ -57,9 +57,13 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
 
     final List<String> includedElementKinds;
     final JsonElement includedElementKindsElement = paramsObject.get("includedElementKinds");
+    final JsonElement includedSuggestionKindsElement = paramsObject.get("includedSuggestionKinds");
     if (includedElementKindsElement != null) {
       final JsonArray includedElementKindsArray = includedElementKindsElement.getAsJsonArray();
       includedElementKinds = JsonUtilities.decodeStringList(includedElementKindsArray);
+    } else if (includedSuggestionKindsElement != null) {
+      final JsonArray includedSuggestionKindsArray = includedSuggestionKindsElement.getAsJsonArray();
+      includedElementKinds = JsonUtilities.decodeStringList(includedSuggestionKindsArray);
     } else {
       includedElementKinds = Collections.emptyList();
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/3338.

This change makes it so that the Dart plugin will respect an "includedSuggestionKinds" field on `CompletionSuggestion` in place of "includedElementKinds" if the latter is missing. The reason for this change is that Flutter cut a version of the Dart SDK with a WIP version of the new code completion spec, and we only added support for the latest version in the Dart plugin. Adding this fallback will make it so that code completion continues to work for Flutter SDK 1.2.1 stable users.

If it's possible to publish a new Dart plugin ASAP after this is landed, it would be greatly appreciated as code completion is mostly unavailable for a significant number of Flutter users.

/cc @alexander-doroshko @scheglov 