### PR TITLE
Add support for `AndroidManifest.xml` files for errors and warnings from the Dart Analysis Server support.

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -171,6 +171,7 @@
 
     <annotator language="Dart" implementationClass="com.jetbrains.lang.dart.ide.annotator.DartAnnotator"/>
     <annotator language="HTML" implementationClass="com.jetbrains.lang.dart.ide.annotator.DartAnnotator"/>
+    <annotator language="XML" implementationClass="com.jetbrains.lang.dart.ide.annotator.DartAnnotator"/>
 
     <lang.findUsagesProvider language="Dart" implementationClass="com.jetbrains.lang.dart.ide.findUsages.DartFindUsagesProvider"/>
     <usageTypeProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartUsageTypeProvider"/>

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -842,7 +842,8 @@ public class DartAnalysisServerService implements Disposable {
              HtmlUtil.isHtmlFile(file) ||
              file.getName().equals(PubspecYamlUtil.PUBSPEC_YAML) ||
              file.getName().equals("analysis_options.yaml") ||
-             file.getName().equals(DartYamlFileTypeFactory.DOT_ANALYSIS_OPTIONS);
+             file.getName().equals(DartYamlFileTypeFactory.DOT_ANALYSIS_OPTIONS) ||
+             file.getName().equals("AndroidManifest.xml");
     }
     return false;
   }

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -133,7 +133,18 @@ public class DartServerRootsHandler {
       if (fileIndex.isInLibraryClasses(vFile)) return true;
 
       final Module module = fileIndex.getModuleForFile(vFile);
-      return (module != null && DartSdkLibUtil.isDartSdkEnabled(module));
+      if (module != null && DartSdkLibUtil.isDartSdkEnabled(module)) {
+        return true;
+      }
+      else if (vFile.getName().equals("AndroidManifest.xml")) {
+        // These types of files can be part of an android module, not dart sdk enabled,
+        // but should still be considered in the root for Dart Analysis errors and warnings.
+        for (String root : myIncludedRoots) {
+          if (vFile.getPath().startsWith(FileUtil.toSystemIndependentName(root) + "/")) {
+            return true;
+          }
+        }
+      }
     }
     else if (scopedAnalysisMode == DartProblemsViewSettings.ScopedAnalysisMode.DartPackage) {
       for (String root : myIncludedRoots) {


### PR DESCRIPTION
Confirmed the behavior (appearance of warning in the editor and Analysis view) on the master branch, 2019.2.

Additional context: https://github.com/JetBrains/intellij-plugins/pull/645