### PR TITLE
Provide package info for constructors in the type area

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -401,10 +401,9 @@ public class DartServerCompletionContributor extends CompletionContributor {
       }
 
       // If this is a class or similar global symbol, try to show which package it's coming from.
-      if (displayUri != null &&
-          element.getTypeParameters() == null &&
-          element.getParameters() == null) {
-        lookup = lookup.appendTailText(" (" + displayUri + ")", true);
+      if (displayUri != null) {
+        String packageInfo = "(" + displayUri + ")";
+        lookup = lookup.withTypeText(StringUtils.isEmpty(returnType) ? packageInfo : returnType + " " + packageInfo , true);
       }
 
       // icon


### PR DESCRIPTION
We were seeing an issue where multiple libraries re-export a constructor which makes it difficult to know from where you're importing a constructor. This patch makes it so that we use the space in type text if there are parameters that would conflict (rather than dropping this information altogether).

![B0H4ArypjAu](https://user-images.githubusercontent.com/535859/56321705-1ae98180-611c-11e9-99de-90ce771852ec.png)

/cc @alexander-doroshko @scheglov @devoncarew @bwilkerson 