### PR TITLE
Make RequestListener and ResponseListener pass Strings instead of JsonObjects

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/RequestListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/RequestListener.java
@@ -1,11 +1,9 @@
 // Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.google.dart.server;
 
-import com.google.gson.JsonObject;
-
 /**
  * Listener for arbitrary requests sent from the analysis server.
  */
 public interface RequestListener {
-  void onRequest(JsonObject json);
+  void onRequest(String jsonString);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ResponseListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ResponseListener.java
@@ -1,10 +1,8 @@
 package com.google.dart.server;
 
-import com.google.gson.JsonObject;
-
 /**
  * Listener for arbitrary responses received from the analysis server.
  */
 public interface ResponseListener {
-  void onResponse(JsonObject json);
+  void onResponse(String jsonString);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -851,7 +851,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     synchronized (requestListenerList) {
       List<RequestListener> listeners = ImmutableList.copyOf(requestListenerList);
       for (RequestListener listener : listeners) {
-        listener.onRequest(request);
+        listener.onRequest(request.toString());
       }
     }
   }
@@ -860,7 +860,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     synchronized (responseListenerList) {
       List<ResponseListener> listeners = ImmutableList.copyOf(responseListenerList);
       for (ResponseListener listener : listeners) {
-        listener.onResponse(response);
+        listener.onResponse(response.toString());
       }
     }
   }


### PR DESCRIPTION
This change switches the Dart plugin's `RequestListener` and `ResponseListener` objects to use primitive `String` instead of `JsonObject`. The rationale is so that downstream plugins can make their own choices about JSON parsing and representation instead of needing to use gson at a specific version.

/cc @alexander-doroshko @jwren 