### PR TITLE
Fix issue where DartContributedReference.myRefRange starts at negative numbers

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/psi/DartContributedReference.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/DartContributedReference.java
@@ -28,9 +28,7 @@ class DartContributedReference implements PsiPolyVariantReference {
                                   @NotNull final DartServerData.DartNavigationRegion navigationRegion) {
     myElement = element;
     myNavigationRegion = navigationRegion;
-    final int startOffset =
-      InjectedLanguageManager.getInstance(element.getProject()).injectedToHost(element, element.getTextRange().getStartOffset());
-    myRefRange = TextRange.from(navigationRegion.getOffset() - startOffset, navigationRegion.getLength());
+    myRefRange = TextRange.from(navigationRegion.getOffset(), navigationRegion.getLength());
     myRefText = element.getText().substring(myRefRange.getStartOffset(), myRefRange.getEndOffset());
   }
 


### PR DESCRIPTION
The Dart plugin throws a lot of exceptions like `String index out of range: -593` from the `element.getText().substring()` call in the `DartContributedReference` constructor. I could be totally off, but the caller here https://github.com/JetBrains/intellij-plugins/blob/a2032f89fc97f0e997e0440238f815655329276e/Dart/src/com/jetbrains/lang/dart/resolve/DartResolver.java#L148 doesn't look like we'd need further to subtract the element's start offset?

/cc @alexander-doroshko @jwren @devoncarew 