### PR TITLE
Provide getter for DartQuickFix#getSourceChange

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFix.java
+++ b/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFix.java
@@ -145,6 +145,10 @@ public final class DartQuickFix implements IntentionAction, Comparable<Intention
     return true;
   }
 
+  SourceChange getSourceChange() {
+    return mySourceChange;
+  }
+
   void setSourceChange(@Nullable final SourceChange sourceChange) {
     mySourceChange = sourceChange;
   }


### PR DESCRIPTION
This will allow DartQuickFixListener implementations to read the source change off of this object when beforeQuickFixInvoked is triggered. This is a follow-up from #643. Would you be able to cherry pick this onto 2019.1 @alexander-doroshko?

/cc @jwren