### PR TITLE
Dart hover change

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
@@ -61,7 +61,7 @@ public class DartDocUtil {
     }
 
     final String docText = getDocumentationText(namedComponent);
-    return generateDoc(signatureHtml, true, docText, containingLibraryName, containingClassDescription, null, null, false);
+    return generateDoc(signatureHtml, true, docText, containingLibraryName, containingClassDescription, null, false);
   }
 
   @NotNull
@@ -71,15 +71,19 @@ public class DartDocUtil {
                                    @Nullable final String containingLibraryName,
                                    @Nullable final String containingClassDescription,
                                    @Nullable final String staticType,
-                                   @Nullable final String propagatedType,
                                    final boolean compactPresentation) {
     final boolean hasContainingLibraryName = !StringUtil.isEmpty(containingLibraryName);
     final boolean hasContainingClassDescription = !StringUtil.isEmpty(containingClassDescription);
     final boolean hasStaticType = !StringUtil.isEmpty(staticType);
-    final boolean hasPropagatedType = !StringUtil.isEmpty(propagatedType);
     // generate
     final StringBuilder builder = new StringBuilder();
     builder.append("<code>");
+    if (hasContainingLibraryName) {
+      builder.append("<b>");
+      builder.append(StringUtil.escapeXmlEntities(containingLibraryName));
+      builder.append("</b>");
+      builder.append("<br>");
+    }
     if (signature != null) {
       if (signatureIsHtml) {
         builder.append(signature);
@@ -89,35 +93,21 @@ public class DartDocUtil {
       }
       builder.append("<br>");
     }
-    if (hasContainingLibraryName || hasContainingClassDescription) {
+    if (hasContainingClassDescription) {
       builder.append("<br>");
-      if (hasContainingLibraryName) {
-        builder.append("<b>Containing library:</b> ");
-        builder.append(StringUtil.escapeXmlEntities(containingLibraryName));
-        builder.append("<br>");
-      }
-      if (hasContainingClassDescription) {
-        builder.append("<b>Containing class:</b> ");
-        builder.append(StringUtil.escapeXmlEntities(containingClassDescription));
-        builder.append("<br>");
-      }
+      builder.append("<b>Containing class:</b> ");
+      builder.append(StringUtil.escapeXmlEntities(containingClassDescription));
+      builder.append("<br>");
     }
-    if (hasStaticType || hasPropagatedType) {
+    if (hasStaticType) {
       if (!compactPresentation) {
         builder.append("<br>");
       }
-
-      if (hasStaticType) {
-        builder.append("<b>Static type:</b> ");
-        builder.append(StringUtil.escapeXmlEntities(staticType));
-        builder.append("<br>");
-      }
-      if (hasPropagatedType) {
-        builder.append("<b>Propagated type:</b> ");
-        builder.append(StringUtil.escapeXmlEntities(propagatedType));
-        builder.append("<br>");
-      }
+      builder.append("<b>Type:</b> ");
+      builder.append(StringUtil.escapeXmlEntities(staticType));
+      builder.append("<br>");
     }
+    builder.append("<br>");
     builder.append("</code>\n");
     if (docText != null) {
       final MarkdownProcessor processor = new MarkdownProcessor();

--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -93,9 +93,8 @@ public class DartDocumentationProvider implements DocumentationProvider {
   public static String buildHoverTextServer(@NotNull final HoverInformation hover) {
     final String elementDescription = hover.getElementDescription();
     final String staticType = elementDescription == null || elementDescription.equals(hover.getStaticType()) ? null : hover.getStaticType();
-    final String propagatedType =
-      elementDescription == null || elementDescription.equals(hover.getPropagatedType()) ? null : hover.getPropagatedType();
-    return DartDocUtil.generateDoc(elementDescription, false, null, null, null, staticType, propagatedType, true);
+    final String containingLibraryName = hover.getContainingLibraryName();
+    return DartDocUtil.generateDoc(elementDescription, false, null, containingLibraryName, null, staticType, true);
   }
 
   @NotNull
@@ -104,10 +103,9 @@ public class DartDocumentationProvider implements DocumentationProvider {
     final String containingLibraryName = hover.getContainingLibraryName();
     final String containingClassDescription = hover.getContainingClassDescription();
     final String staticType = hover.getStaticType();
-    final String propagatedType = hover.getPropagatedType();
     final String docText = hover.getDartdoc();
     return DartDocUtil.generateDoc(elementDescription, false, docText, containingLibraryName, containingClassDescription,
-                                   staticType, propagatedType, false);
+                                   staticType, false);
   }
 
   @Nullable

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
@@ -29,11 +29,11 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testAbstractClassSig() {
-    doTest("<code>abstract class Foo extends Bar<br></code>", "abstract class <caret>Foo extends Bar { }\nclass Bar { }");
+    doTest("<code>abstract class Foo extends Bar<br><br></code>", "abstract class <caret>Foo extends Bar { }\nclass Bar { }");
   }
 
   public void testClassMultilineDoc1() {
-    doTest("<code>class A<br></code>\n" +
+    doTest("<code>class A<br><br></code>\n" +
            "<p>doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
@@ -43,99 +43,99 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
            "<pre><code>    code\n" +
            "</code></pre>",
 
-           "/** 1 */\n"     +
-           "/**\n"          +
+           "/** 1 */\n" +
+           "/**\n" +
            " *      doc1\n" +
-           " * doc2\n"      +
-           " *  doc3\n"     +
-           " *\n"           +
-           " *    doc4\n"   +
-           " * \n"          +
-           " *     code\n"  +
-           " */\n"          +
-           "// non-doc\n"   +
+           " * doc2\n" +
+           " *  doc3\n" +
+           " *\n" +
+           " *    doc4\n" +
+           " * \n" +
+           " *     code\n" +
+           " */\n" +
+           "// non-doc\n" +
            "class <caret>A{}");
   }
 
   public void testClassMultilineDoc2() {
-    doTest("<code>abstract class A<br></code>\n<p>doc1\n" +
-           "doc2\n"                                                           +
-           " doc3\n"                                                          +
-           "doc4\n"                                                           +
-           "doc5\n"                                                           +
+    doTest("<code>abstract class A<br><br></code>\n<p>doc1\n" +
+           "doc2\n" +
+           " doc3\n" +
+           "doc4\n" +
+           "doc5\n" +
            " doc6</p>",
 
-           "@deprecated\n"  +
-           "/**\n"          +
-           "*doc1\n"        +
-           "* doc2\n"       +
-           "*  doc3\n"      +
-           "     *doc4\n"   +
-           "     * doc5\n"  +
+           "@deprecated\n" +
+           "/**\n" +
+           "*doc1\n" +
+           "* doc2\n" +
+           "*  doc3\n" +
+           "     *doc4\n" +
+           "     * doc5\n" +
            "     *  doc6\n" +
-           " */\n"          +
+           " */\n" +
            "abstract class <caret>A{}");
   }
 
   public void testClassSingleLineDocs1() {
-    doTest("<code>class A<br></code>\n<p>doc1\n" +
+    doTest("<code>class A<br><br></code>\n<p>doc1\n" +
            "doc2</p>",
 
-           "// not doc \n"    +
-           "///   doc1  \n"   +
+           "// not doc \n" +
+           "///   doc1  \n" +
            " /* not doc */\n" +
            "   /// doc2   \n" +
-           " // not doc \n"   +
+           " // not doc \n" +
            "class <caret>A{}");
   }
 
   public void testClassSingleLineDocs2() {
-    doTest("<code>class A<br></code>\n<p>doc1\n" +
+    doTest("<code>class A<br><br></code>\n<p>doc1\n" +
            "doc2</p>",
 
-           "@deprecated"      +
-           "// not doc \n"    +
-           "///   doc1  \n"   +
+           "@deprecated" +
+           "// not doc \n" +
+           "///   doc1  \n" +
            " /* not doc */\n" +
            "   /// doc2   \n" +
-           " // not doc \n"   +
+           " // not doc \n" +
            "class <caret>A{}");
   }
 
   public void testConstructorSig() {
-    doTest("<code>Z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z(); }");
+    doTest("<code>Z() → Z<br><br><b>Containing class:</b> Z<br><br></code>", "class Z { <caret>Z(); }");
   }
 
   public void testEnumSig() {
-    doTest("<code>enum Foo<br></code>", "enum <caret>Foo { BAR }");
+    doTest("<code>enum Foo<br><br></code>", "enum <caret>Foo { BAR }");
   }
 
   public void testFieldSig1() {
-    doTest("<code>int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
+    doTest("<code>int y<br><br><b>Containing class:</b> Z<br><br><b>Type:</b> int<br><br></code>",
            "class Z { int <caret>y = 42; }");
   }
 
   public void testFieldSig2() {
-    doTest("<code>int y<br><br><b>Containing class:</b> Z<br><br><b>Static type:</b> int<br></code>",
+    doTest("<code>int y<br><br><b>Containing class:</b> Z<br><br><b>Type:</b> int<br><br></code>",
            "class Z { int <caret>y; }");
   }
 
   public void testFunctionDoc1() {
-    doTest("<code>foo(int x) → void<br></code>\n<p>A function on [x]s.</p>",
+    doTest("<code>foo(int x) → void<br><br></code>\n<p>A function on [x]s.</p>",
            "/// A function on [x]s.\nvoid <caret>foo(int x) { }");
   }
 
   public void testFunctionDoc2() {
-    doTest("<code>foo(int x) → void<br></code>\n<p>Good for:</p>\n" +
+    doTest("<code>foo(int x) → void<br><br></code>\n<p>Good for:</p>\n" +
            "\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
            "<li>that</li>\n" +
            "</ul>", "/** Good for:\n\n" +
-                      " * * this\n" +
-                      " * * that\n" +
-                      "*/\n" +
-                      "\nvoid <caret>foo(int x) { }");
+                    " * * this\n" +
+                    " * * that\n" +
+                    "*/\n" +
+                    "\nvoid <caret>foo(int x) { }");
   }
 
   //public void testMetaClassSig2() throws Exception {
@@ -148,65 +148,65 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   //}
 
   public void testFunctionSig1() {
-    doTest("<code>calc(int x) → int<br></code>", "int <caret>calc(int x) => x + 42;");
+    doTest("<code>calc(int x) → int<br><br></code>", "int <caret>calc(int x) => x + 42;");
   }
 
   public void testFunctionSig10() {
-    doTest("<code>x({bool b}) → void<br></code>", "void <caret>x({bool b}){};");
+    doTest("<code>x({bool b}) → void<br><br></code>", "void <caret>x({bool b}){};");
   }
 
   public void testFunctionSig2() {
-    doTest("<code>foo([int x = 3]) → dynamic<br></code>", "<caret>foo([int x = 3]) { print(x); }");
+    doTest("<code>foo([int x = 3]) → dynamic<br><br></code>", "<caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig3() {
-    doTest("<code>foo([int x = 3]) → void<br></code>", "void <caret>foo([int x = 3]) { print(x); }");
+    doTest("<code>foo([int x = 3]) → void<br><br></code>", "void <caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig4() {
-    doTest("<code>foo(int x, {int y, int z}) → void<br></code>", "void <caret>foo(int x, {int y, int z}) { }");
+    doTest("<code>foo(int x, {int y, int z}) → void<br><br></code>", "void <caret>foo(int x, {int y, int z}) { }");
   }
 
   public void testFunctionSig5() {
-    doTest("<code>x(List&lt;dynamic&gt; e) → dynamic<br></code>", "E <caret>x(List<E> e) { }");
+    doTest("<code>x(List&lt;dynamic&gt; e) → dynamic<br><br></code>", "E <caret>x(List<E> e) { }");
   }
 
   public void testFunctionSig6() {
-    doTest("<code>calc(() → int x) → int<br></code>", "int <caret>calc(int x()) => null;");
+    doTest("<code>calc(() → int x) → int<br><br></code>", "int <caret>calc(int x()) => null;");
   }
 
   public void testFunctionSig7() {
-    doTest("<code>foo(Map&lt;int, String&gt; p) → Map&lt;String, int&gt;<br></code>",
+    doTest("<code>foo(Map&lt;int, String&gt; p) → Map&lt;String, int&gt;<br><br></code>",
            "Map<String, int> <caret>foo(Map<int, String> p) => null;");
   }
 
   public void testFunctionSig8() {
-    doTest("<code>x() → dynamic<br></code>", "<caret>x() => null;");
+    doTest("<code>x() → dynamic<br><br></code>", "<caret>x() => null;");
   }
 
   public void testFunctionSig9() {
-    doTest("<code>x({bool b: true}) → dynamic<br></code>", "<caret>x({bool b: true}){};");
+    doTest("<code>x({bool b: true}) → dynamic<br><br></code>", "<caret>x({bool b: true}){};");
   }
 
   public void testGetterSig() {
-    doTest("<code>get x → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int get <caret>x => 0; }");
+    doTest("<code>get x → int<br><br><b>Containing class:</b> Z<br><br></code>", "class Z { int get <caret>x => 0; }");
   }
 
   public void testImplementsSig1() {
-    doTest("<code>abstract class Foo implements Bar<br></code>",
+    doTest("<code>abstract class Foo implements Bar<br><br></code>",
            "abstract class <caret>Foo implements Bar<T> { }\nclass Bar { }");
   }
 
   public void testLibraryClassDoc() {
-    doTest("<code>class A<br><br><b>Containing library:</b> c.b.a<br></code>", "library c.b.a;\nclass <caret>A {}");
+    doTest("<code><b>c.b.a</b><br>class A<br><br></code>", "library c.b.a;\nclass <caret>A {}");
   }
 
   public void testMetaClassSig1() {
-    doTest("<code>class A<br></code>", " @deprecated class <caret>A {}");
+    doTest("<code>class A<br><br></code>", " @deprecated class <caret>A {}");
   }
 
   public void testMethodMultilineDoc() {
-    doTest("<code>foo() → dynamic<br><br><b>Containing class:</b> A<br></code>\n" +
+    doTest("<code>foo() → dynamic<br><br><b>Containing class:</b> A<br><br></code>\n" +
            "<p>doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
@@ -216,111 +216,107 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
            "<pre><code>    code\n" +
            "</code></pre>",
 
-           "class A{\n"       +
-           "/** 1 */\n"       +
-           "/**\n"            +
-           " *      doc1\n"   +
-           " * doc2\n"        +
-           " *  doc3\n"       +
-           " *\n"             +
-           " *    doc4\n"     +
-           " * \n"            +
-           " *     code\n"    +
-           " */\n"            +
-           "// non-doc\n"     +
+           "class A{\n" +
+           "/** 1 */\n" +
+           "/**\n" +
+           " *      doc1\n" +
+           " * doc2\n" +
+           " *  doc3\n" +
+           " *\n" +
+           " *    doc4\n" +
+           " * \n" +
+           " *     code\n" +
+           " */\n" +
+           "// non-doc\n" +
            "<caret>foo(){}\n" +
            "}");
   }
 
   public void testMethodSig1() {
-    doTest("<code>y() → int<br><br><b>Containing class:</b> Z<br></code>", "class Z { int <caret>y() => 42; }");
+    doTest("<code>y() → int<br><br><b>Containing class:</b> Z<br><br></code>", "class Z { int <caret>y() => 42; }");
   }
 
   public void testMethodSingleLineDocs() {
-    doTest("<code>foo() → dynamic<br><br><b>Containing class:</b> A<br></code>\n<p>doc1\n" +
+    doTest("<code>foo() → dynamic<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
            "doc2</p>", "class A{\n" +
-                         "// not doc \n" +
-                         "///   doc1  \n" +
-                         " /* not doc */\n" +
-                         "   /// doc2   \n" +
-                         " // not doc \n" +
-                         "<caret>foo(){}\n" +
-                         "}");
+                       "// not doc \n" +
+                       "///   doc1  \n" +
+                       " /* not doc */\n" +
+                       "   /// doc2   \n" +
+                       " // not doc \n" +
+                       "<caret>foo(){}\n" +
+                       "}");
   }
 
   public void testMixinSig1() {
-    doTest("<code>class Foo2 extends Bar1 with Baz1, Baz2<br></code>",
+    doTest("<code>class Foo2 extends Bar1 with Baz1, Baz2<br><br></code>",
            "class Bar1 {} class Baz1{} class Baz2 {} class <caret>Foo2 = Bar1<E> with Baz1<K>, Baz2");
   }
 
   public void testMixinSig2() {
-    doTest("<code>class X extends Y with Z<br></code>", "class Y {} class Z {} class <caret>X extends Y with Z { }");
+    doTest("<code>class X extends Y with Z<br><br></code>", "class Y {} class Z {} class <caret>X extends Y with Z { }");
   }
 
   public void testNamedConstructorSig() {
-    doTest("<code>Z.z() → Z<br><br><b>Containing class:</b> Z<br></code>", "class Z { <caret>Z.z(); }");
+    doTest("<code>Z.z() → Z<br><br><b>Containing class:</b> Z<br><br></code>", "class Z { <caret>Z.z(); }");
   }
 
   public void testParamClassSig() {
-    doTest("<code>class Foo&lt;T&gt;<br></code>", "class <caret>Foo<T>{ }");
+    doTest("<code>class Foo&lt;T&gt;<br><br></code>", "class <caret>Foo<T>{ }");
   }
 
   public void testParamClassSig2() {
-    doTest("<code>class Foo&lt;T, Z&gt;<br></code>", "class <caret>Foo<T,Z>{ }");
+    doTest("<code>class Foo&lt;T, Z&gt;<br><br></code>", "class <caret>Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() {
-    doTest("<code>class Foo implements Bar<br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
+    doTest("<code>class Foo implements Bar<br><br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() {
-    doTest("<code>class Foo implements Bar, Baz<br></code>",
+    doTest("<code>class Foo implements Bar, Baz<br><br></code>",
            "class <caret>Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
   }
 
   public void testParamClassSig5() {
-    doTest("<code>class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br></code>",
+    doTest("<code>class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br><br></code>",
            "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
   }
 
   public void testParamClassSig6() {
-    doTest("<code>List&lt;String&gt; ids<br><br><b>Static type:</b> List&lt;String&gt;<br></code>",
+    doTest("<code>List&lt;String&gt; ids<br><br><b>Type:</b> List&lt;String&gt;<br><br></code>",
            "class A { foo() { List<String> <caret>ids; }}");
   }
 
   public void testParamClassSig7() {
     doTest(
-      "<code>List&lt;Map&lt;String, int&gt;&gt; ids<br><br><b>Static type:</b> List&lt;Map&lt;String, int&gt;&gt;<br></code>",
+      "<code>List&lt;Map&lt;String, int&gt;&gt; ids<br><br><b>Type:</b> List&lt;Map&lt;String, int&gt;&gt;<br><br></code>",
       "class A { foo() { List<Map<String, int>> <caret>ids; }}");
   }
 
   public void testParamClassSig8() {
     doTest("<code>List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; list<br><br>" +
-           "<b>Static type:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt;<br></code>",
+           "<b>Type:</b> List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt;<br><br></code>",
            "class A { foo() { List<List<Map<String, List<Object>>>> <caret>list; }}");
   }
 
   public void testSetterSig() {
-    doTest("<code>set x(int x) → void<br><br><b>Containing class:</b> Z<br></code>",
+    doTest("<code>set x(int x) → void<br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { void set <caret>x(int x) { } }");
   }
 
   public void testTopLevelVarDoc1() {
-    doTest("<code>String x<br><br><b>Containing library:</b> a.b.c<br><br>" +
-           "<b>Static type:</b> String<br></code>\n<p>docs1\n" +
-           "docs2</p>", "library a.b.c;\n" +
-                          "/// docs1\n" +
-                          "/// docs2\n" +
-                          "@deprecated var <caret>x = 'foo';");
+    doTest("<code><b>a.b.c</b><br>String x<br><br><b>Type:</b> String<br><br></code>\n<p>docs1\ndocs2</p>",
+           "library a.b.c;\n" + "/// docs1\n" + "/// docs2\n" + "@deprecated var <caret>x = 'foo';");
   }
 
   public void testTopLevelVarDoc2() {
-    doTest("<code>int x<br><br><b>Containing library:</b> a.b.c<br><br><b>Static type:</b> int<br></code>",
+    doTest("<code><b>a.b.c</b><br>int x<br><br><b>Type:</b> int<br><br></code>",
            "library a.b.c;\nint <caret>x = 3;\n");
   }
 
   public void testTypedefSig() {
-    doTest("<code>typedef F = int Function(int x)<br></code>", "typedef int <caret>F(int x);");
+    doTest("<code>typedef F = int Function(int x)<br><br></code>", "typedef int <caret>F(int x);");
   }
 
   private void doTest(String expectedDoc, String fileContents) {

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
@@ -21,59 +21,59 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testAbstractClassSig() {
-    doTest("<code>abstract class <b>Foo</b> extends Bar<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>abstract class <b>Foo</b> extends Bar<br><br></code>",
            "<caret>abstract class Foo extends Bar { }\nclass Bar { }");
   }
 
   public void testParamClassSig() {
-    doTest("<code>class <b>Foo</b>&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>Foo</b>&lt;T&gt;<br><br></code>",
            "<caret>class Foo<T>{ }");
   }
 
   public void testParamClassSig2() {
-    doTest("<code>class <b>Foo</b>&lt;T, Z&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>Foo</b>&lt;T, Z&gt;<br><br></code>",
            "<caret>class Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() {
-    doTest("<code>class <b>Foo</b> implements Bar<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>Foo</b> implements Bar<br><br></code>",
            "<caret>class Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() {
-    doTest("<code>class <b>Foo</b> implements Bar, Baz<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>Foo</b> implements Bar, Baz<br><br></code>",
            "<caret>class Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
   }
 
   public void testParamClassSig5() {
-    doTest("<code>class <b>Foo</b>&lt;A, B&gt; extends Bar&lt;A,B&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>Foo</b>&lt;A, B&gt; extends Bar&lt;A,B&gt;<br><br></code>",
            "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
   }
 
   public void testParamClassSig6() {
-    doTest("<code>List&lt;String&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
+    doTest("<code><b>test.dart</b><br>List&lt;String&gt; <b>ids</b><br><br><b>Containing class:</b> A<br><br></code>",
            "class A { foo() { List<String> <caret>ids; }}");
   }
 
   public void testParamClassSig7() {
-    doTest("<code>List&lt;Map&lt;String, int&gt;&gt; <b>ids</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
-           "class A { foo() { List<Map<String, int>> <caret>ids; }}");
+    doTest(
+      "<code><b>test.dart</b><br>List&lt;Map&lt;String, int&gt;&gt; <b>ids</b><br><br><b>Containing class:</b> A<br><br></code>",
+      "class A { foo() { List<Map<String, int>> <caret>ids; }}");
   }
 
   public void testParamClassSig8() {
     doTest(
-      "<code>List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; <b>list</b><br><br>" +
-      "<b>Containing library:</b> test.dart<br><b>Containing class:</b> A<br></code>",
+      "<code><b>test.dart</b><br>List&lt;List&lt;Map&lt;String, List&lt;Object&gt;&gt;&gt;&gt; <b>list</b><br><br><b>Containing class:</b> A<br><br></code>",
       "class A { foo() { List<List<Map<String, List<Object>>>> <caret>list; }}");
   }
 
   public void testMetaClassSig1() {
-    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>",
            " @deprecated class <caret>A {}");
   }
 
   public void testMetaClassSig2() {
-    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>",
            "@Meta(\'foo\') class <caret>A {};\n" +
            "class Meta {\n" +
            "  final String name;\n" +
@@ -82,131 +82,129 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testLibraryClassDoc() {
-    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> c.b.a<br></code>",
+    doTest("<code><b>c.b.a</b><br>class <b>A</b><br><br></code>",
            "library c.b.a;\nclass <caret>A {}");
   }
 
   public void testImplementsSig1() {
-    doTest("<code>abstract class <b>Foo</b> implements Bar&lt;T&gt;<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>abstract class <b>Foo</b> implements Bar&lt;T&gt;<br><br></code>",
            "<caret>abstract class Foo implements Bar<T> { }\nclass Bar { }");
   }
 
   public void testMixinSig1() {
     doTest(
-      "<code>class <b>Foo2</b> extends Bar1&lt;E&gt; with Baz1&lt;K&gt;, Baz2<br><br>" +
-      "<b>Containing library:</b> test.dart<br></code>",
+      "<code><b>test.dart</b><br>class <b>Foo2</b> extends Bar1&lt;E&gt; with Baz1&lt;K&gt;, Baz2<br><br></code>",
       "<caret>class Foo2 = Bar1<E> with Baz1<K>, Baz2");
   }
 
   public void testMixinSig2() {
-    doTest("<code>class <b>X</b> extends Y with Z<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>class <b>X</b> extends Y with Z<br><br></code>",
            "<caret>class X extends Y with Z { }");
   }
 
   public void testEnumSig() {
-    doTest("<code>enum <b>Foo</b><br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>enum <b>Foo</b><br><br></code>",
            "<caret>enum Foo { BAR }");
   }
 
   public void testFunctionSig1() {
-    doTest("<code><b>calc</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>calc</b>(int x) " + RIGHT_ARROW + " int<br><br></code>",
            "<caret>int calc(int x) => x + 42;");
   }
 
   public void testFunctionSig2() {
-    doTest("<code><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " dynamic<br><br></code>",
            "<caret>foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig3() {
-    doTest("<code><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>foo</b>([int x = 3]) " + RIGHT_ARROW + " void<br><br></code>",
            "<caret>void foo([int x = 3]) { print(x); }");
   }
 
   public void testFunctionSig4() {
-    doTest("<code><b>foo</b>(int x, {int y, int z}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>foo</b>(int x, {int y, int z}) " + RIGHT_ARROW + " void<br><br></code>",
            "<caret>void foo(int x, {int y, int z}) { }");
   }
 
   public void testFunctionSig5() {
-    doTest("<code><b>x</b>(List&lt;E&gt; e) " + RIGHT_ARROW + " E<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>x</b>(List&lt;E&gt; e) " + RIGHT_ARROW + " E<br><br></code>",
            "E <caret>x(List<E> e) { }");
   }
 
   public void testFunctionSig6() {
     doTest(
-      "<code><b>calc</b>(x() " + RIGHT_ARROW + " int) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
+      "<code><b>test.dart</b><br><b>calc</b>(x() " + RIGHT_ARROW + " int) " + RIGHT_ARROW + " int<br><br></code>",
       "<caret>int calc(int x()) => null;");
   }
 
   public void testFunctionSig7() {
-    doTest("<code><b>foo</b>(Map&lt;int, String&gt; p) " + RIGHT_ARROW + " Map&lt;String, int&gt;<br><br>" +
-           "<b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>foo</b>(Map&lt;int, String&gt; p) " + RIGHT_ARROW + " Map&lt;String, int&gt;<br><br></code>",
            "Map<String, int> <caret>foo(Map<int, String> p) => null;");
   }
 
   public void testFunctionSig8() {
-    doTest("<code><b>x</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>x</b>() " + RIGHT_ARROW + " dynamic<br><br></code>",
            "<caret>x() => null;");
   }
 
   public void testFunctionSig9() {
-    doTest("<code><b>x</b>({bool b: true}) " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>x</b>({bool b: true}) " + RIGHT_ARROW + " dynamic<br><br></code>",
            "<caret>x({bool b: true}){};");
   }
 
   public void testFunctionSig10() {
-    doTest("<code><b>x</b>({bool b}) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>x</b>({bool b}) " + RIGHT_ARROW + " void<br><br></code>",
            "void <caret>x({bool b}){};");
   }
 
   public void testFunctionType() {
-    doTest("<code><b>x</b>({bool b}) " + RIGHT_ARROW + " Function<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br><b>x</b>({bool b}) " + RIGHT_ARROW + " Function<br><br></code>",
            "Function<T>(y) <caret>x({bool b}){};");
   }
 
   public void testTypedefSig() {
-    doTest("<code>typedef <b>a</b>(int x) " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br></code>",
+    doTest("<code><b>test.dart</b><br>typedef <b>a</b>(int x) " + RIGHT_ARROW + " int<br><br></code>",
            "<caret>typedef int a(int x);");
   }
 
   public void testFieldSig1() {
-    doTest("<code>int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br>int <b>y</b><br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>int y = 42; }");
   }
 
   public void testFieldSig2() {
-    doTest("<code>int <b>y</b><br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br>int <b>y</b><br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>int y; }");
   }
 
   public void testMethodSig1() {
-    doTest("<code><b>y</b>() " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br><b>y</b>() " + RIGHT_ARROW + " int<br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>int y() => 42; }");
   }
 
   public void testNamedConstructorSig() {
-    doTest("<code><b>Z.</b><b>z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br><b>Z.</b><b>z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>Z.z(); }");
   }
 
   public void testConstructorSig() {
-    doTest("<code><b>Z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br><b>Z</b>() " + RIGHT_ARROW + " Z<br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>Z(); }");
   }
 
   public void testGetterSig() {
-    doTest("<code>get <b>x</b> " + RIGHT_ARROW + " int<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br>get <b>x</b> " + RIGHT_ARROW + " int<br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>int get x => 0; }");
   }
 
   public void testSetterSig() {
-    doTest("<code>set <b>x</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br><b>Containing class:</b> Z<br></code>",
+    doTest("<code><b>test.dart</b><br>set <b>x</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing class:</b> Z<br><br></code>",
            "class Z { <caret>void set x(int x) { } }");
   }
 
   public void testTopLevelVarDoc1() {
-    doTest("<code>var <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code>\n<p>docs1\ndocs2</p>",
+    doTest("<code><b>a.b.c</b><br>var <b>x</b><br><br></code>\n<p>docs1\ndocs2</p>",
            "library a.b.c;\n" +
            "/// docs1\n" +
            "/// docs2\n" +
@@ -214,18 +212,18 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testTopLevelVarDoc2() {
-    doTest("<code>int <b>x</b><br><br><b>Containing library:</b> a.b.c<br></code>",
+    doTest("<code><b>a.b.c</b><br>int <b>x</b><br><br></code>",
            "library a.b.c;\n<caret>int x = 3;\n");
   }
 
   public void testFunctionDoc1() {
-    doTest("<code><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br>" +
-           "<b>Containing library:</b> test.dart<br></code>\n<p>A function on <code>x</code>s.</p>",
+    doTest("<code><b>test.dart</b><br><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br></code>\n" +
+           "<p>A function on <code>x</code>s.</p>",
            "/// A function on <code>x</code>s.\n<caret>void foo(int x) { }");
   }
 
   public void testFunctionDoc2() {
-    doTest("<code><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>\n" +
+    doTest("<code><b>test.dart</b><br><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br></code>\n" +
            "<p>Good for:</p>\n\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
@@ -239,7 +237,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc1() {
-    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1\n" +
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n<p>doc1\n" +
            "doc2\n" +
            " doc3</p>\n" +
            "\n" +
@@ -263,7 +261,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc2() {
-    doTest("<code>abstract class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1\n" +
+    doTest("<code><b>test.dart</b><br>abstract class <b>A</b><br><br></code>\n<p>doc1\n" +
            "doc2\n" +
            " doc3\n" +
            "doc4\n" +
@@ -283,87 +281,88 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs1() {
-    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1 <br />\n" +
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n" +
+           "<p>doc1 <br />\n" +
            "doc2</p>",
 
-           "// not doc \n"    +
-           "///   doc1  \n"   +
+           "// not doc \n" +
+           "///   doc1  \n" +
            " /* not doc */\n" +
            "   /// doc2   \n" +
-           " // not doc \n"   +
+           " // not doc \n" +
            "<caret>class A{}");
   }
 
   public void testClassSingleLineDocs2() {
-    doTest("<code>class <b>A</b><br><br><b>Containing library:</b> test.dart<br></code>\n<p>doc1 <br />\n" +
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n" +
+           "<p>doc1 <br />\n" +
            "doc2</p>",
 
-           "@deprecated"      +
-           "// not doc \n"    +
-           "///   doc1  \n"   +
+           "@deprecated" +
+           "// not doc \n" +
+           "///   doc1  \n" +
            " /* not doc */\n" +
-           "   ///doc2   \n"  +
-           " // not doc \n"   +
+           "   ///doc2   \n" +
+           " // not doc \n" +
            "<caret>class A{}");
   }
 
   public void testMethodMultilineDoc() {
-    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
-           "<b>Containing class:</b> A<br></code>\n<p>doc1\n" +
-           "doc2\n" +
-           " doc3</p>\n" +
+    doTest(
+      "<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
+      "doc2\n" +
+      " doc3</p>\n" +
+      "\n" +
+      "<p>   doc4</p>\n" +
+      "\n" +
+      "<pre><code>    code\n" +
+      "</code></pre>",
+
+      "class A{\n" +
+      "/** 1 */\n" +
+      "/**\n" +
+      " *      doc1\n" +
+      " * doc2\n" +
+      " *  doc3\n" +
+      " *\n" +
+      " *    doc4\n" +
+      " * \n" +
+      " *     code\n" +
+      " */\n" +
+      "// non-doc\n" +
+      "<caret>foo(){}\n" +
+      "}");
+  }
+
+  public void testMethodSingleLineDocs() {
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br>" +
+           "<b>Containing class:</b> A<br><br></code>\n<p>doc1  </p>\n" +
            "\n" +
-           "<p>   doc4</p>\n" +
-           "\n" +
-           "<pre><code>    code\n" +
+           "<pre><code>    doc2\n" +
            "</code></pre>",
 
            "class A{\n" +
-           "/** 1 */\n" +
-           "/**\n" +
-           " *      doc1\n" +
-           " * doc2\n" +
-           " *  doc3\n" +
-           " *\n" +
-           " *    doc4\n" +
-           " * \n" +
-           " *     code\n" +
-           " */\n" +
-           "// non-doc\n" +
+           "// not doc \n" +
+           "///   doc1  \n" +
+           " /* not doc */\n" +
+           "   ///\n" +
+           "   ///     doc2   \n" +
+           "   ///\n" +
+           " // not doc \n" +
            "<caret>foo(){}\n" +
            "}");
   }
 
-  public void testMethodSingleLineDocs() {
-    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing library:</b> test.dart<br>" +
-           "<b>Containing class:</b> A<br></code>\n<p>doc1  </p>\n"                                                       +
-           "\n"                                                                                                               +
-           "<pre><code>    doc2\n"                                                                                            +
-           "</code></pre>",
-
-           "class A{\n"           +
-           "// not doc \n"        +
-           "///   doc1  \n"       +
-           " /* not doc */\n"     +
-           "   ///\n"             +
-           "   ///     doc2   \n" +
-           "   ///\n"             +
-           " // not doc \n"       +
-           "<caret>foo(){}\n"     +
-           "}");
-  }
-
   public void testHyperlink() {
-    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>\n" +
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " void<br><br></code>\n" +
            "<p>my <a href=\"www.cheese.com\">fancy link</a></p>",
            "/// my [fancy link](www.cheese.com)\nvoid <caret>foo() => null;\n");
   }
 
   public void testHyperlinkMultiLine() {
-    doTest("<code><b>foo</b>() " + RIGHT_ARROW + " void<br><br><b>Containing library:</b> test.dart<br></code>\n" +
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " void<br><br></code>\n" +
            "<p>my <a href=\"www.cheese.com\">fancy\n" +
            "link</a></p>",
            "/// my [fancy\n/// link](www.cheese.com)\nvoid <caret>foo() => null;\n");
   }
-
 }


### PR DESCRIPTION
Dart Plugin hover changes: no "propagated" types, this notion was removed with the migration to Dart 2.  Also, the library name formatting is changing from being labeled as the "Containing library: " to simply being the first item.  A recent change in the Dart Analysis Server will also change the library name from what is after the 'library' keyword, to the importing URI, see https://dart-review.googlesource.com/c/sdk/+/10348