### PR TITLE
Max rather than sum for included suggestion relevance boost

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -543,13 +543,13 @@ public class DartServerCompletionContributor extends CompletionContributor {
   private static CompletionSuggestion createCompletionSuggestionFromAvailableSuggestion(@NotNull AvailableSuggestion suggestion,
                                                                                         int suggestionSetRelevance,
                                                                                         @NotNull Map<String, IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags) {
-    int relevance = suggestionSetRelevance;
+    int relevanceBoost = 0;
     List<String> relevanceTags = suggestion.getRelevanceTags();
     if (relevanceTags != null) {
       for (String tag : relevanceTags) {
         IncludedSuggestionRelevanceTag relevanceTag = includedSuggestionRelevanceTags.get(tag);
         if (relevanceTag != null) {
-          relevance += includedSuggestionRelevanceTags.get(tag).getRelevanceBoost();
+          relevanceBoost = Math.max(relevanceBoost, relevanceTag.getRelevanceBoost());
         }
       }
     }
@@ -557,7 +557,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
     Element element = suggestion.getElement();
     return new CompletionSuggestion(
       "UNKNOWN", // we don't have info about CompletionSuggestionKind
-      relevance,
+      suggestionSetRelevance + relevanceBoost,
       suggestion.getLabel(),
       null,
       0,


### PR DESCRIPTION
Continued from #659 since I made a git whoopsie, sorry!

From the [API spec](https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/doc/api.html):

> If an AvailableSuggestion has relevance tags that match more than one
> IncludedSuggestionRelevanceTag, the maximum relevance boost is used.

/cc @alexander-doroshko @scheglov @DanTup