### PR TITLE
Enable support for the Context Info (alt+q) action in Dart (WIP)

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -131,6 +131,9 @@
     <library.type implementation="com.jetbrains.lang.dart.sdk.DartPackagesLibraryType"/>
 
     <treeStructureProvider implementation="com.jetbrains.lang.dart.projectView.DartTreeStructureProvider"/>
+    <declarationRangeHandler
+        key="com.intellij.psi.PsiElement"
+        implementationClass="com.jetbrains.lang.dart.projectView.DartDeclarationRangeHandler"/>
     <projectViewNestingRulesProvider implementation="com.jetbrains.lang.dart.projectView.DartNestingRulesProvider"/>
     <iconProvider implementation="com.jetbrains.lang.dart.projectView.DartIconProvider" order="first" id="DartIconProvider"/>
     <projectViewNodeDecorator implementation="com.jetbrains.lang.dart.projectView.DartNodeDecorator"/>

--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -132,7 +132,7 @@
 
     <treeStructureProvider implementation="com.jetbrains.lang.dart.projectView.DartTreeStructureProvider"/>
     <declarationRangeHandler
-        key="com.intellij.psi.PsiElement"
+        key="com.jetbrains.lang.dart.psi.DartPsiCompositeElement"
         implementationClass="com.jetbrains.lang.dart.projectView.DartDeclarationRangeHandler"/>
     <projectViewNestingRulesProvider implementation="com.jetbrains.lang.dart.projectView.DartNestingRulesProvider"/>
     <iconProvider implementation="com.jetbrains.lang.dart.projectView.DartIconProvider" order="first" id="DartIconProvider"/>

--- a/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
@@ -67,8 +67,6 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
   public Object getCurrentEditorElement() {
     // Note: this should return an object of type PsiElement to be compatible with the Context Info (alt+q) action.
     if (getEditor() == null) return null;
-    //final int offset = getEditor().getCaretModel().getOffset();
-    //return getPsiFile().getViewProvider().findElementAt(offset);
 
     final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getPsiFile().getProject());
     final Outline outline = service.getOutline(getPsiFile().getVirtualFile());
@@ -76,7 +74,6 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
 
     final Outline result = findDeepestOutlineForOffset(getEditor().getCaretModel().getOffset(), outline);
     return getPsiFile().getViewProvider().findElementAt(result.getOffset());
-    //return DartStructureViewElement.getValue(result);
   }
 
   /**

--- a/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
@@ -70,8 +70,10 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
     final Outline outline = service.getOutline(getPsiFile().getVirtualFile());
     if (outline == null) return null;
 
-    final Outline result = findDeepestOutlineForOffset(getEditor().getCaretModel().getOffset(), outline);
-    return DartStructureViewElement.getValue(result);
+    final int offset = getEditor().getCaretModel().getOffset();
+    final Outline result = findDeepestOutlineForOffset(offset, outline);
+    return getPsiFile().getOriginalElement().findElementAt(offset);
+    //return DartStructureViewElement.getValue(result);
   }
 
   /**

--- a/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
@@ -19,6 +19,7 @@ import com.intellij.ide.structureView.TextEditorBasedStructureViewModel;
 import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
 import com.intellij.ide.util.treeView.smartTree.Sorter;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
@@ -66,13 +67,16 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
   public Object getCurrentEditorElement() {
     // Note: this should return an object of type PsiElement to be compatible with the Context Info (alt+q) action.
     if (getEditor() == null) return null;
+    //final int offset = getEditor().getCaretModel().getOffset();
+    //return getPsiFile().getViewProvider().findElementAt(offset);
 
     final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getPsiFile().getProject());
     final Outline outline = service.getOutline(getPsiFile().getVirtualFile());
     if (outline == null) return null;
 
-    final int offset = getEditor().getCaretModel().getOffset();
-    return getPsiFile().getOriginalElement().findElementAt(offset);
+    final Outline result = findDeepestOutlineForOffset(getEditor().getCaretModel().getOffset(), outline);
+    return getPsiFile().getViewProvider().findElementAt(result.getOffset());
+    //return DartStructureViewElement.getValue(result);
   }
 
   /**

--- a/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
@@ -64,6 +64,7 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
   @Override
   @Nullable
   public Object getCurrentEditorElement() {
+    // Note: this should return an object of type PsiElement to be compatible with the Context Info (alt+q) action.
     if (getEditor() == null) return null;
 
     final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getPsiFile().getProject());
@@ -71,9 +72,7 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
     if (outline == null) return null;
 
     final int offset = getEditor().getCaretModel().getOffset();
-    final Outline result = findDeepestOutlineForOffset(offset, outline);
     return getPsiFile().getOriginalElement().findElementAt(offset);
-    //return DartStructureViewElement.getValue(result);
   }
 
   /**

--- a/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.projectView;
+
+import com.intellij.codeInsight.hint.DeclarationRangeHandler;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+public class DartDeclarationRangeHandler implements DeclarationRangeHandler {
+  @Override
+  public @NotNull TextRange getDeclarationRange(@NotNull PsiElement component) {
+    component.getContext().getText();
+    return new TextRange(component.getStartOffsetInParent(), component.getStartOffsetInParent() + 50);
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
@@ -36,7 +36,8 @@ public class DartDeclarationRangeHandler implements DeclarationRangeHandler<Dart
   /**
    * @return The first line of {@param element}'s {@link TextRange}, or the entire {@link TextRange} if it contains no new lines.
    */
-  private TextRange getFirstLine(PsiElement element) {
+  @NotNull
+  private static TextRange getFirstLine(@NotNull PsiElement element) {
     final int offset = element.getTextOffset();
     final int firstLineLength = element.getText().indexOf('\n');
     if (firstLineLength == -1) {

--- a/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
@@ -8,16 +8,16 @@ package com.jetbrains.lang.dart.projectView;
 import com.intellij.codeInsight.hint.DeclarationRangeHandler;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
-import com.jetbrains.lang.dart.psi.DartCallExpression;
-import com.jetbrains.lang.dart.psi.DartClassDefinition;
-import com.jetbrains.lang.dart.psi.DartFunctionExpression;
-import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
+import com.jetbrains.lang.dart.psi.*;
 import org.jetbrains.annotations.NotNull;
 
-public class DartDeclarationRangeHandler implements DeclarationRangeHandler {
+/**
+ * A handler to compute the declaring {@link TextRange} of some {@link DartPsiCompositeElement}.
+ */
+public class DartDeclarationRangeHandler implements DeclarationRangeHandler<DartPsiCompositeElement> {
   @Override
   public @NotNull
-  TextRange getDeclarationRange(@NotNull PsiElement component) {
+  TextRange getDeclarationRange(@NotNull DartPsiCompositeElement component) {
     // Find the named parent of the given component -- either a dart call expression or a class definition.
     PsiElement namedParent = component;
     while (!(namedParent == null ||
@@ -26,13 +26,22 @@ public class DartDeclarationRangeHandler implements DeclarationRangeHandler {
              namedParent instanceof DartMethodDeclaration)) {
       namedParent = namedParent.getParent();
     }
-    // We found nothing, so default to the first line of the given component.
+    // If we did not find a named parent of this component, default to the first line of the starting component.
     if (namedParent == null) {
-      namedParent = component;
+      return getFirstLine(component);
     }
-    final int offset = namedParent.getTextOffset();
-    final int firstLineLength = namedParent.getText().indexOf('\n');
-    if (firstLineLength == -1) return namedParent.getTextRange();
+    return getFirstLine(namedParent);
+  }
+
+  /**
+   * @return The first line of {@param element}'s {@link TextRange}, or the entire {@link TextRange} if it contains no new lines.
+   */
+  private TextRange getFirstLine(PsiElement element) {
+    final int offset = element.getTextOffset();
+    final int firstLineLength = element.getText().indexOf('\n');
+    if (firstLineLength == -1) {
+      return element.getTextRange();
+    }
     return new TextRange(offset, offset + firstLineLength);
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectView/DartDeclarationRangeHandler.java
@@ -8,12 +8,31 @@ package com.jetbrains.lang.dart.projectView;
 import com.intellij.codeInsight.hint.DeclarationRangeHandler;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
+import com.jetbrains.lang.dart.psi.DartClassDefinition;
+import com.jetbrains.lang.dart.psi.DartFunctionExpression;
+import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
 import org.jetbrains.annotations.NotNull;
 
 public class DartDeclarationRangeHandler implements DeclarationRangeHandler {
   @Override
-  public @NotNull TextRange getDeclarationRange(@NotNull PsiElement component) {
-    component.getContext().getText();
-    return new TextRange(component.getStartOffsetInParent(), component.getStartOffsetInParent() + 50);
+  public @NotNull
+  TextRange getDeclarationRange(@NotNull PsiElement component) {
+    // Find the named parent of the given component -- either a dart call expression or a class definition.
+    PsiElement namedParent = component;
+    while (!(namedParent == null ||
+             namedParent instanceof DartClassDefinition ||
+             namedParent instanceof DartFunctionExpression ||
+             namedParent instanceof DartMethodDeclaration)) {
+      namedParent = namedParent.getParent();
+    }
+    // We found nothing, so default to the first line of the given component.
+    if (namedParent == null) {
+      namedParent = component;
+    }
+    final int offset = namedParent.getTextOffset();
+    final int firstLineLength = namedParent.getText().indexOf('\n');
+    if (firstLineLength == -1) return namedParent.getTextRange();
+    return new TextRange(offset, offset + firstLineLength);
   }
 }


### PR DESCRIPTION
From everything I can find about supporting this action, the declarationRangeHandler and corresponding activation in XML is all that's needed to enable the action.

However, at 4bb344e the declaration range handler is never invoked.  Is there anything I'm missing?

cc @alexander-doroshko 