### PR TITLE
Introduced option to extract META-INF and OSGI-INF folder from generated jar file into modules output folder

### DIFF
--- a/osmorc/doc/getting-started.txt
+++ b/osmorc/doc/getting-started.txt
@@ -1,0 +1,80 @@
+=======================================================
+ Quick Instructions for new developers of Osmorc
+=======================================================
+
+1. Get the latest IDEA EAP
+   - Download it from the EAP page https://www.jetbrains.com/idea/nextversion/ and install <idea-eap-folder>
+   - remove osmorc.jar and osmorc-jps-plugin.jar from the <idea-epa-folder>/Contents/plugins/osmorc
+
+2. Launch IDEA EAP 
+   - Create New Project -> IntelliJ Platform Plugin
+   	- delete folder META-INF and src in the generated project
+   - Project SDK -> New IntellIj Platform SDK
+	   - Select <idea-eap-folder> and Finish
+   - Projectstructure -> Project Settings
+	   - Libraries: add Java libs
+		 + bndlib -> <idea-eap-folder>/Contents/plugins/osmorc/lib/biz*.jar
+		 + bundelor-all -> <idea-eap-folder>/Contents/plugins/osmorc/lib/bundlor-all.jar
+		 + osgi -> <idea-eap-folder>/Contents/plugins/osmorc/lib/org.osgi*.jar
+		 + maven -> <idea-eap-folder>/Contents/plugins/maven/lib/maven-jps-plugin.jar, maven-server-api.jar, 	maven.jar
+		 to compile the tests you need:
+		  checkout IntelliJ IDEA Community Edition
+		    - git clone --depth 1 https://github.com/JetBrains/intellij-community.git idea-community
+		    - Build IntelliJ IDEA Community Edition described in https://github.com/JetBrains/intellij-community
+		  + test-jps -> <idea-community>/out/test/intellij.platform.jps.build
+		  + assertj -> .m2/repository/org/assertj/assertj-core/3.*/assertj-core-3.*.jar
+		  + hamcrest -> .m2/repository/org/hamcrest/hamcrest-all/1.*/hamcrest-all-1.*.jar
+   - Modules:
+   + Import Module -> osmorc, in import dialog deselect osmorc-jps-plugin/src
+      Mark as:
+   		Sources -> src
+		Resources -> resources
+		Tests -> src_test
+	  Dependencies:
+	  	osmorc-jps-plugin Compile, add this as module dependency
+		bndlib Compile
+		maven Compile
+		osgi Compile
+		test-jps Test
+
+     + Import Module -> osmorc/osmorc-jps-plugin
+      Mark as: 
+   		Sources -> src 
+		Tests -> test
+	  Dependencies:
+	 	bndlib Compile
+		bundelor-all Compile
+		maven Compile
+		osgi Compile
+		assertj Test
+		hamcrest Test
+	+ configure Osmorc Plugin Module
+		- goto modul settings -> Plugin Deployment
+		- enter the path of <project_folder>/osmorc/resources
+		- add Dependencies
+			- Modul dependency to osmorc and osmorc-jps-plugin
+
+
+3. Ready to run.
+   - make sure Osmorc Plugin Project has module dependencies to osmorc and osmorc-jps-plugin
+   - Try building
+   - Add a new run configuration of type "plugin"
+   - add VM options: -Xmx512m -XX:MaxPermSize=256m so you can test bigger projects
+   - Start that configuration (might take some time to fire up)
+
+4. Build Plugin
+	Project Settings/Artifact
+	+ osmorc-jps-plugin
+	 Name: osmorc-jps-plugin
+		Available Elements
+			'osmorc-jps-plugin' compile output
+	+ osmorc
+	 Name: osmorc
+	 	Available Elements
+			'osmorc' compile output
+
+5. Before committing
+   - Run the unit tests using the "All in Osmorc" run configuration.
+
+
+   

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsgiBuildSession.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsgiBuildSession.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.ArrayUtilRt;
 import com.intellij.util.containers.ContainerUtil;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.builders.logging.ProjectBuilderLogger;
@@ -28,8 +29,13 @@ import org.jetbrains.osgi.jps.model.impl.JpsOsmorcModuleExtensionImpl;
 import org.jetbrains.osgi.jps.util.OsgiBuildUtil;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+
 import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -37,6 +43,9 @@ import static com.intellij.util.ObjectUtils.coalesce;
 
 public class OsgiBuildSession implements Reporter {
   private static final Logger LOG = Logger.getInstance(OsgiBuildSession.class);
+
+  private static final String META_INF = "META-INF";
+  private static final String OSGI_INF = "OSGI-INF";
 
   private OsmorcBuildTarget myTarget;
   private CompileContext myContext;
@@ -81,7 +90,78 @@ public class OsgiBuildSession implements Reporter {
       logger.logCompiledFiles(myOutputJarFiles, OsmorcBuilder.ID, "Built OSGi bundles:");
     }
 
+    if (myExtension.isExtractMetaInfOsgIInfToTargetClasses()) {
+
+          extractJarToTargetClasses();
+    }
+
     context.processMessage(DoneSomethingNotification.INSTANCE);
+  }
+
+  private void extractJarToTargetClasses() throws IOException {
+    for (File file : myOutputJarFiles) {
+      try (JarFile jarFile = new JarFile(file)) {
+
+        boolean extractedMetaInf = false;
+        boolean extractedOsgiInf = false;
+
+        for (JarEntry entry : Collections.list(jarFile.entries())) {
+
+          if (extractedMetaInf && extractedOsgiInf) {
+            break;
+          }
+
+          if (entry.getName().startsWith(META_INF)) {
+            extractEntry(jarFile, entry);
+            extractedMetaInf = true;
+
+          }
+
+          if (entry.getName().startsWith(OSGI_INF)) {
+            extractEntry(jarFile, entry);
+            extractedOsgiInf = true;
+          }
+
+
+        }
+      }
+
+    }
+  }
+
+  private void extractEntry(JarFile jarFile, JarEntry entry) throws IOException {
+
+    try (InputStream is = jarFile.getInputStream(entry)) {
+
+      File targetFile = new File(myModuleOutputDir, entry.getName());
+
+      if (entry.isDirectory()) {
+        if (!targetFile.exists()) {
+          targetFile.mkdirs();
+        }
+
+      } else {
+        if (!targetFile.getParentFile().exists()) {
+          targetFile.getParentFile().mkdirs();
+        }
+        try (FileOutputStream fos = new FileOutputStream(targetFile)) {
+          // Allocate a buffer for reading the entry data.
+          byte[] buffer = new byte[1024];
+          int bytesRead;
+
+          // Read the entry data and write it to the output file.
+
+          while ((bytesRead = is.read(buffer)) != -1) {
+            fos.write(buffer, 0, bytesRead);
+          }
+          fos.flush();
+        }
+      }
+    } catch (IOException e) {
+      error(e.getMessage(), e.getCause(), jarFile.getName(), -1);
+      throw e;
+
+    }
   }
 
   private void prepare() throws OsgiBuildException {

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/JpsOsmorcModuleExtension.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/JpsOsmorcModuleExtension.java
@@ -68,6 +68,8 @@ public interface JpsOsmorcModuleExtension extends JpsElement {
 
   boolean isAlwaysRebuildBundleJar();
 
+  boolean isExtractMetaInfOsgIInfToTargetClasses();
+
   @NotNull
   List<OsmorcJarContentEntry> getAdditionalJarContents();
 

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/JpsOsmorcModuleExtensionImpl.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/JpsOsmorcModuleExtensionImpl.java
@@ -218,6 +218,11 @@ public class JpsOsmorcModuleExtensionImpl extends JpsElementBase<JpsOsmorcModule
     return myProperties.myAlwaysRebuildBundleJar;
   }
 
+  @Override
+  public boolean isExtractMetaInfOsgIInfToTargetClasses() {
+    return myProperties.myExtractMetaInfOsgIInfToTargetClasses;
+  }
+
   @NotNull
   @Override
   public List<OsmorcJarContentEntry> getAdditionalJarContents() {

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/OsmorcModuleExtensionProperties.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/OsmorcModuleExtensionProperties.java
@@ -55,6 +55,9 @@ public class OsmorcModuleExtensionProperties {
   @Attribute("extractMetaInfOsgiInfToTargetClasses")
   public boolean myExtractMetaInfOsgIInfToTargetClasses = true;
 
+  @Attribute("extractMetaInfOsgiInfToTargetClasses")
+  public boolean myExtractMetaInfOsgIInfToTargetClasses = true;
+
   @Attribute("ignoreFilePattern")
   public String myIgnoreFilePattern;
 

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/OsmorcModuleExtensionProperties.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/OsmorcModuleExtensionProperties.java
@@ -52,6 +52,9 @@ public class OsmorcModuleExtensionProperties {
   @XCollection(propertyElementName = "additionalJARContents")
   public List<OsmorcJarContentEntry> myAdditionalJARContents = new ArrayList<>();
 
+  @Attribute("extractMetaInfOsgiInfToTargetClasses")
+  public boolean myExtractMetaInfOsgIInfToTargetClasses = true;
+
   @Attribute("ignoreFilePattern")
   public String myIgnoreFilePattern;
 

--- a/osmorc/resources/META-INF/plugin.xml
+++ b/osmorc/resources/META-INF/plugin.xml
@@ -34,6 +34,7 @@
     <li>Add the OSGi framework that you want to work with (Equinox, Felix, etc.).</li>
     <li>Add the OSGi facet to any module that should be an OSGi bundle.</li>
     <li>You can either write your own manifest or let the plugin calculate the manifest for you.</li>
+    <li>Introduced option to extract META-INF and OSGI-INF folder from generated jar file into modules output folder.</li>
     </ol>
 
     <p>

--- a/osmorc/src/org/osmorc/facet/OsmorcFacetConfiguration.java
+++ b/osmorc/src/org/osmorc/facet/OsmorcFacetConfiguration.java
@@ -88,6 +88,7 @@ public class OsmorcFacetConfiguration implements FacetConfiguration, Modificatio
   private static final String ADDITIONAL_PROPERTIES = "additionalProperties";
   private static final String IGNORE_FILE_PATTERN = "ignoreFilePattern";
   private static final String ALWAYS_REBUILD_BUNDLE_JAR = "alwaysRebuildBundleJAR";
+  private static final String EXTRACT_META_INF_OSGI_INF_TO_TARGET_CLASSES = "extractMetaInfOsgiInfToTargetClasses";
   private static final String DO_NOT_SYNCHRONIZE_WITH_MAVEN = "doNotSynchronizeWithMaven";
   private static final String OUTPUT_PATH_TYPE = "outputPathType";
   private static final String PROPERTY = "property";
@@ -108,6 +109,7 @@ public class OsmorcFacetConfiguration implements FacetConfiguration, Modificatio
   private String myBundlorFileLocation;
   private String myIgnoreFilePattern;
   private boolean myAlwaysRebuildBundleJAR;
+  private boolean myExtractMetaInfOsgIInfToTargetClasses = true;
   private OutputPathType myOutputPathType;
   private ManifestGenerationMode myManifestGenerationMode = ManifestGenerationMode.OsmorcControlled;
 
@@ -176,6 +178,7 @@ public class OsmorcFacetConfiguration implements FacetConfiguration, Modificatio
     setIgnoreFilePattern(element.getAttributeValue(IGNORE_FILE_PATTERN));
     setUseProjectDefaultManifestFileLocation(Boolean.parseBoolean(element.getAttributeValue(USE_PROJECT_DEFAULT_MANIFEST_FILE_LOCATION, "true")));
     setAlwaysRebuildBundleJAR(Boolean.parseBoolean(element.getAttributeValue(ALWAYS_REBUILD_BUNDLE_JAR, "false")));
+    setExtractMetaInfOsgIInfToTargetClasses(Boolean.parseBoolean(element.getAttributeValue(EXTRACT_META_INF_OSGI_INF_TO_TARGET_CLASSES, "true")));
     setDoNotSynchronizeWithMaven(Boolean.parseBoolean(element.getAttributeValue(DO_NOT_SYNCHRONIZE_WITH_MAVEN, "false")));
 
     Element props = element.getChild(ADDITIONAL_PROPERTIES);
@@ -224,6 +227,7 @@ public class OsmorcFacetConfiguration implements FacetConfiguration, Modificatio
     element.setAttribute(IGNORE_FILE_PATTERN, getIgnoreFilePattern());
     element.setAttribute(USE_PROJECT_DEFAULT_MANIFEST_FILE_LOCATION, String.valueOf(isUseProjectDefaultManifestFileLocation()));
     element.setAttribute(ALWAYS_REBUILD_BUNDLE_JAR, String.valueOf(isAlwaysRebuildBundleJAR()));
+    element.setAttribute(EXTRACT_META_INF_OSGI_INF_TO_TARGET_CLASSES, String.valueOf(isExtractMetaInfOsgIInfToTargetClasses()));
     element.setAttribute(DO_NOT_SYNCHRONIZE_WITH_MAVEN, String.valueOf(myDoNotSynchronizeWithMaven));
 
     Element props = new Element(ADDITIONAL_PROPERTIES);
@@ -557,6 +561,15 @@ public class OsmorcFacetConfiguration implements FacetConfiguration, Modificatio
   public void setAlwaysRebuildBundleJAR(boolean alwaysRebuildBundleJAR) {
     myAlwaysRebuildBundleJAR = alwaysRebuildBundleJAR;
     myModificationCount++;
+  }
+
+  public boolean isExtractMetaInfOsgIInfToTargetClasses() {
+      return myExtractMetaInfOsgIInfToTargetClasses;
+  }
+
+  public void setExtractMetaInfOsgIInfToTargetClasses(boolean extractMetaInfOsgIInfToTargetClasses) {
+      myExtractMetaInfOsgIInfToTargetClasses = extractMetaInfOsgIInfToTargetClasses;
+      myModificationCount++;
   }
 
   public boolean isDoNotSynchronizeWithMaven() {

--- a/osmorc/src/org/osmorc/facet/ui/OsmorcFacetJAREditorTab.form
+++ b/osmorc/src/org/osmorc/facet/ui/OsmorcFacetJAREditorTab.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.osmorc.facet.ui.OsmorcFacetJAREditorTab">
-  <grid id="bbf5b" binding="myRoot" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="bbf5b" binding="myRoot" layout-manager="GridLayoutManager" row-count="8" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="638" height="405"/>
@@ -21,7 +21,7 @@
       </component>
       <component id="d6235" class="javax.swing.JCheckBox" binding="myAlwaysRebuildBundleJARCheckBox" default-binding="true">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Always rebuild bundle .jar"/>
@@ -29,7 +29,7 @@
       </component>
       <component id="ca0f8" class="javax.swing.JTextField" binding="myJarFileTextField" default-binding="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="3" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -45,7 +45,7 @@
       </component>
       <component id="ad914" class="javax.swing.JRadioButton" binding="myPlaceInCompilerOutputPathRadioButton" default-binding="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="3" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Place in module's output path"/>
@@ -53,7 +53,7 @@
       </component>
       <component id="9016" class="javax.swing.JRadioButton" binding="myPlaceInProjectWideRadioButton" default-binding="true">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="3" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Place in project-wide OSGi bundle output path"/>
@@ -61,7 +61,7 @@
       </component>
       <component id="f3f8" class="javax.swing.JRadioButton" binding="myPlaceInThisPathRadioButton" default-binding="true">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Place in this path:"/>
@@ -69,19 +69,16 @@
       </component>
       <grid id="17691" binding="myAdditionalJarContentsPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="5" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithoutIndent"/>
-        </clientProperties>
         <border type="etched" title="Additional Contents"/>
         <children/>
       </grid>
       <grid id="c02f5" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -106,9 +103,17 @@
       </grid>
       <component id="33cce" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myJarOutputPathChooser">
         <constraints>
-          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
+      </component>
+      <component id="59fb" class="javax.swing.JCheckBox" binding="myExtractMetaInfOSGIInfoToTargetClassesCheckBox">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="5" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Extract META-INF and OSGI-INF to module's output path"/>
+        </properties>
       </component>
     </children>
   </grid>

--- a/osmorc/src/org/osmorc/facet/ui/OsmorcFacetJAREditorTab.java
+++ b/osmorc/src/org/osmorc/facet/ui/OsmorcFacetJAREditorTab.java
@@ -91,6 +91,7 @@ public class OsmorcFacetJAREditorTab extends FacetEditorTab {
   private JRadioButton myPlaceInThisPathRadioButton;
   private TextFieldWithBrowseButton myJarOutputPathChooser;
   private JPanel myAdditionalJarContentsPanel;
+  private JCheckBox myExtractMetaInfOSGIInfoToTargetClassesCheckBox;
 
   private final FacetEditorContext myEditorContext;
   private final FacetValidatorsManager myValidatorsManager;
@@ -337,6 +338,7 @@ public class OsmorcFacetJAREditorTab extends FacetEditorTab {
     }
     configuration.setIgnoreFilePattern(myIgnoreFilePatternTextField.getText());
     configuration.setAlwaysRebuildBundleJAR(myAlwaysRebuildBundleJARCheckBox.isSelected());
+    configuration.setExtractMetaInfOsgIInfToTargetClasses(myExtractMetaInfOSGIInfoToTargetClassesCheckBox.isSelected());
     configuration.setAdditionalJARContents(myAdditionalJARContentsTableModel.getAdditionalContents());
     myModified = false;
   }
@@ -361,6 +363,7 @@ public class OsmorcFacetJAREditorTab extends FacetEditorTab {
     myAdditionalJARContentsTableModel.replaceContent(configuration.getAdditionalJARContents());
     myIgnoreFilePatternTextField.setText(configuration.getIgnoreFilePattern());
     myAlwaysRebuildBundleJARCheckBox.setSelected(configuration.isAlwaysRebuildBundleJAR());
+    myExtractMetaInfOSGIInfoToTargetClassesCheckBox.setSelected(configuration.isExtractMetaInfOsgIInfToTargetClasses());
 
     updateGui();
     myModified = false;


### PR DESCRIPTION
**Context of the pullrequest**

We are currently working on a Eclipse E4 RCP application, which is completely build by Maven and Tycho and we would like to have support for that approach in
Intellij because it is our preferred IDE. Eclipse in its own is a pure OSGI application.

The only plugin we've found to support the development of a OSGI based Eclipse application was the Osmorc plugin. Therefore we've choosen Osmorc to start the
development.

**Our development process**

- have a Maven based module
- have a BND file in the root directory of each module
- use these Osgi plugins to package and start a Eclipse application
- configure the Bnd maven plugin like this

```
<plugin>
    <groupId>biz.aQute.bnd</groupId>
    <artifactId>bnd-maven-plugin</artifactId>
    <version>3.3.0</version>
    <executions>
        <execution>
            <id>default-bnd-process</id>
            <goals>
                <goal>bnd-process</goal>
            </goals>
        </execution>
    </executions>
    <configuration>
        <skip>false</skip>
    </configuration>
</plugin>
```

- the plugin execution generates the Manifest and DS Component definitions under target/classes/META-INF
- this will be part of the final packaged jar file
- all that works like any other maven based module
- if the module/application is started, these generated information are considered and the bundle is useable in the launched OSGI framework
- if we start the application from Intellij itself, a maven run configuration is used where "Resolve Workspace" option is enabled.
- the whole bundle content comes from target/classes directory

To support that approach we can benefit from the Osmorc Builder to start the Bnd generation process before the application is started. So our assumption is
that everything that is part at the bundle is located under target/classes.

**Plugin requirements for our development approach**

1. let Bnd process the bnd file in each module and generate the stuff under target/classes

2. do that generation within the step "Build project" as part of a run configuration 

3. let inspections work on the generated Manifest.mf files instead of the source Bnd file
 
With the changes provided by the pullrequest we can fulfill 1. and 2. but not 3. (is a lower priority)

**Customization of the Osmorc plugin to meet our needs**

We introduced a new option in the facet configuration dialog for each module. This option is enabled by default and extracts everything under META-INF and
OSGI-INF from the bundle jar into the module output path. That is for Maven project target/classes.

With that in place we get our requirements fulfilled. Every build creates a bundle jar (if private-package instruction in the Bnd file references all
packages) and the Manifest.mf and DS component defintions are extacted and are visible at runtime.

**Questions**

That is the way we've gone, but it is a good one? if yes, we would like to have the stuff included into the main development line to be in sync with the upcoming changes of the Osmorc plugin. There are some other questions:

- any idea to improve this approach?
- Should this simple approach be converted (somehow) to something that matches the Bndtools idea better? Any hints for that?
- How to use inspections for export/import packages if the Manifest is generated by Bnd? The main point we see here is that the current inspections are working on the plain Bnd file. A bnd file can have a lot of makros and these makros are generating, e.g. import package statements, at build time. How can an Intellij inspection use these generated information?
- Why does the manifest generation behaves differently if using osmorc instead of maven bnd plugin? For Osmorc the private-package statement in the bnd file is needed and need to reference all packages that should be analyzed. With the maven bnd plugin it is not needed.

Thanks for your time to review the pullrequest.