### PR TITLE
Use completion.existingImports to filter completion suggestions

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -204,8 +204,8 @@ public class DartAnalysisServerService implements Disposable {
     }
 
     @Override
-    public void computedExistingImports(@NotNull String file, @NotNull Map<String, Set<String>> uriToNames) {
-      myServerData.computedExistingImports(file, uriToNames);
+    public void computedExistingImports(@NotNull String file, @NotNull Map<String, Map<String, Set<String>>> existingImports) {
+      myServerData.computedExistingImports(file, existingImports);
     }
 
     @Override
@@ -814,7 +814,7 @@ public class DartAnalysisServerService implements Disposable {
   }
 
   @Nullable
-  public Map<String, Set<String>> getExistingImports(String file) {
+  public Map<String, Map<String, Set<String>>> getExistingImports(String file) {
     return myServerData.getExistingImports(file);
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -302,7 +302,7 @@ public class DartAnalysisServerService implements Disposable {
                                    @NotNull final List<String> includedElementKinds,
                                    @NotNull final List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                    final boolean isLast,
-                                   String libraryFile) {
+                                   @Nullable String libraryFile) {
       synchronized (myCompletionInfos) {
         myCompletionInfos.add(new CompletionInfo(completionId, replacementOffset, replacementLength, completions, includedSuggestionSets,
                                                  includedElementKinds, includedSuggestionRelevanceTags, isLast, libraryFile));
@@ -2253,7 +2253,7 @@ public class DartAnalysisServerService implements Disposable {
     void consumeLibraryRef(@NotNull IncludedSuggestionSet includedSet,
                            @NotNull Set<String> includedKinds,
                            @NotNull Map<String, IncludedSuggestionRelevanceTag> includedRelevanceTags,
-                           String libraryFile);
+                           @Nullable String libraryFile);
   }
 
   private static class CompletionInfo {
@@ -2271,7 +2271,7 @@ public class DartAnalysisServerService implements Disposable {
     @NotNull private final List<String> myIncludedElementKinds;
     @NotNull private final List<IncludedSuggestionRelevanceTag> myIncludedSuggestionRelevanceTags;
     private final boolean isLast;
-    private final String myLibraryFile;
+    @Nullable private final String myLibraryFile;
 
     CompletionInfo(@NotNull final String completionId,
                    int replacementOffset,
@@ -2281,7 +2281,7 @@ public class DartAnalysisServerService implements Disposable {
                    @NotNull final List<String> includedElementKinds,
                    @NotNull final List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                    boolean isLast,
-                   String libraryFile) {
+                   @Nullable String libraryFile) {
       this.myCompletionId = completionId;
       this.myOriginalReplacementOffset = replacementOffset;
       this.myOriginalReplacementLength = originalReplacementLength;

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -42,6 +42,7 @@ public class DartServerData {
   private final Map<String, List<DartRegion>> myImplementedMemberData = Collections.synchronizedMap(new THashMap<>());
   private final Map<String, Outline> myOutlineData = Collections.synchronizedMap(new THashMap<>());
   private final Map<Integer, AvailableSuggestionSet> myAvailableSuggestionSetMap = Collections.synchronizedMap(new THashMap<>());
+  private final Map<String, Map<String, Set<String>>> myExistingImports = Collections.synchronizedMap(new THashMap<>());
 
   private final Set<String> myFilePathsWithUnsentChanges = Sets.newConcurrentHashSet();
 
@@ -139,6 +140,15 @@ public class DartServerData {
     for (AvailableSuggestionSet suggestionSet : changed) {
       myAvailableSuggestionSetMap.put(suggestionSet.getId(), suggestionSet);
     }
+  }
+
+  void computedExistingImports(@NotNull String file, @NotNull Map<String, Set<String>> uriToNames) {
+    if (uriToNames.isEmpty()) {
+      myExistingImports.remove(file);
+      return;
+    }
+
+    myExistingImports.put(file, uriToNames);
   }
 
   @NotNull
@@ -280,6 +290,9 @@ public class DartServerData {
   AvailableSuggestionSet getAvailableSuggestionSet(int id) {
     return myAvailableSuggestionSetMap.get(id);
   }
+
+  @Nullable
+  Map<String, Set<String>> getExistingImports(String file) { return myExistingImports.get(file); }
 
   private void forceFileAnnotation(@Nullable final VirtualFile file, final boolean clearCache) {
     if (file != null) {

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java
@@ -42,7 +42,7 @@ public class DartServerData {
   private final Map<String, List<DartRegion>> myImplementedMemberData = Collections.synchronizedMap(new THashMap<>());
   private final Map<String, Outline> myOutlineData = Collections.synchronizedMap(new THashMap<>());
   private final Map<Integer, AvailableSuggestionSet> myAvailableSuggestionSetMap = Collections.synchronizedMap(new THashMap<>());
-  private final Map<String, Map<String, Set<String>>> myExistingImports = Collections.synchronizedMap(new THashMap<>());
+  private final Map<String, Map<String, Map<String, Set<String>>>> myExistingImports = Collections.synchronizedMap(new THashMap<>());
 
   private final Set<String> myFilePathsWithUnsentChanges = Sets.newConcurrentHashSet();
 
@@ -142,13 +142,13 @@ public class DartServerData {
     }
   }
 
-  void computedExistingImports(@NotNull String file, @NotNull Map<String, Set<String>> uriToNames) {
-    if (uriToNames.isEmpty()) {
+  void computedExistingImports(@NotNull String file, @NotNull Map<String, Map<String, Set<String>>> existingImports) {
+    if (existingImports.isEmpty()) {
       myExistingImports.remove(file);
       return;
     }
 
-    myExistingImports.put(file, uriToNames);
+    myExistingImports.put(file, existingImports);
   }
 
   @NotNull
@@ -292,7 +292,7 @@ public class DartServerData {
   }
 
   @Nullable
-  Map<String, Set<String>> getExistingImports(String file) { return myExistingImports.get(file); }
+  Map<String, Map<String, Set<String>>> getExistingImports(String file) { return myExistingImports.get(file); }
 
   private void forceFileAnnotation(@Nullable final VirtualFile file, final boolean clearCache) {
     if (file != null) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -153,12 +153,14 @@ public class DartServerCompletionContributor extends CompletionContributor {
                    }
 
                    Set<String> importedLibraries = new HashSet<>();
-                   for (Map.Entry<String, Map<String, Set<String>>> entry : existingImports.entrySet()) {
-                     String importedLibraryUri = entry.getKey();
-                     Map<String, Set<String>> importedLibrary = entry.getValue();
-                     Set<String> names = importedLibrary.get(suggestion.getDeclaringLibraryUri());
-                     if (names != null && names.contains(suggestion.getLabel())) {
-                       importedLibraries.add(importedLibraryUri);
+                   if (existingImports != null) {
+                     for (Map.Entry<String, Map<String, Set<String>>> entry : existingImports.entrySet()) {
+                       String importedLibraryUri = entry.getKey();
+                       Map<String, Set<String>> importedLibrary = entry.getValue();
+                       Set<String> names = importedLibrary.get(suggestion.getDeclaringLibraryUri());
+                       if (names != null && names.contains(suggestion.getLabel())) {
+                         importedLibraries.add(importedLibraryUri);
+                       }
                      }
                    }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -156,9 +156,9 @@ public class DartServerCompletionContributor extends CompletionContributor {
                    for (Map.Entry<String, Map<String, Set<String>>> entry : existingImports.entrySet()) {
                      String importedLibraryUri = entry.getKey();
                      Map<String, Set<String>> importedLibrary = entry.getValue();
-                     // Checks whether any of the libraries exported by this import declares the same name as this suggestion.
-                     if (importedLibrary.entrySet().stream().anyMatch(
-                         importEntry -> doesImportSuggestion(importEntry, suggestionSet.getUri(), suggestion.getLabel()))) {
+                     // TODO: Use individual suggestion uris instead of suggestion set uri.
+                     Set<String> names = importedLibrary.get(suggestionSet.getUri());
+                     if (names != null && names.contains(suggestion.getLabel())) {
                        importedLibraries.add(importedLibraryUri);
                      }
                    }
@@ -179,11 +179,6 @@ public class DartServerCompletionContributor extends CompletionContributor {
                });
              }
            });
-  }
-
-  // Checks whether the uri and name of a completion suggestion match those of an existing import.
-  private boolean doesImportSuggestion(Map.Entry<String, Set<String>> importedElements, String uri, String label) {
-    return importedElements.getKey().equals(uri) && importedElements.getValue().contains(label);
   }
 
   private static boolean isRightAfterBadIdentifier(@NotNull CharSequence text, int offset) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -166,7 +166,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
 
                    if (!importedLibraries.isEmpty() && !importedLibraries.contains(suggestionSet.getUri())) {
                      // If some library exports this label but the current suggestion set does not, we should filter.
-                     return;
+                     continue;
                    }
 
                    CompletionSuggestion completionSuggestion =

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -156,8 +156,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
                    for (Map.Entry<String, Map<String, Set<String>>> entry : existingImports.entrySet()) {
                      String importedLibraryUri = entry.getKey();
                      Map<String, Set<String>> importedLibrary = entry.getValue();
-                     // TODO: Use individual suggestion uris instead of suggestion set uri.
-                     Set<String> names = importedLibrary.get(suggestionSet.getUri());
+                     Set<String> names = importedLibrary.get(suggestion.getDeclaringLibraryUri());
                      if (names != null && names.contains(suggestion.getLabel())) {
                        importedLibraries.add(importedLibraryUri);
                      }

--- a/Dart/testData/analysisServer/completion/ExistingImportLibrary.dart
+++ b/Dart/testData/analysisServer/completion/ExistingImportLibrary.dart
@@ -1,0 +1,4 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+import 'dart:io';
+
+export 'dart:io';

--- a/Dart/testData/analysisServer/completion/ExistingImportLibrary.dart
+++ b/Dart/testData/analysisServer/completion/ExistingImportLibrary.dart
@@ -1,4 +1,2 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
-import 'dart:io';
-
 export 'dart:io';

--- a/Dart/testData/analysisServer/completion/ExistingImports.after.dart
+++ b/Dart/testData/analysisServer/completion/ExistingImports.after.dart
@@ -1,0 +1,4 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+import 'ExistingImportLibrary.dart';
+
+class A extends Process

--- a/Dart/testData/analysisServer/completion/ExistingImports.dart
+++ b/Dart/testData/analysisServer/completion/ExistingImports.dart
@@ -1,0 +1,4 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+import 'ExistingImportLibrary.dart';
+
+class A extends Proce<caret>

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
@@ -18,6 +18,8 @@ import com.jetbrains.lang.dart.util.DartTestUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
   @Override
   public void setUp() throws Exception {
@@ -196,7 +198,14 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
       getTestName(false).replace("ExistingImports", "ExistingImportLibrary") + ".dart");
     myFixture.doHighlighting();
     myFixture.complete(CompletionType.BASIC);
-    selectLookup("Process", Lookup.NORMAL_SELECT_CHAR);
+    final LookupEx activeLookup = LookupManager.getActiveLookup(getEditor());
+    assertNotNull(activeLookup);
+    final List<LookupElement> matches = ContainerUtil.findAll(
+      activeLookup.getItems(), element -> element.getLookupString().equals("Process"));
+    // Since we've already imported ExistingImportLibrary.dart which re-exports Process, we should only have one suggestion for it.
+    assertEquals(matches.size(), 1);
+    activeLookup.setCurrentItem(matches.get(0));
+    myFixture.finishLookup(Lookup.NORMAL_SELECT_CHAR);
     myFixture.checkResultByFile(getTestName(false) + ".after.dart");
   }
 }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
@@ -190,6 +190,13 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
   }
 
   public void testExistingImports() {
-    doTest("Process");
+    String directory = getTestDirectoryName();
+    myFixture.configureByFiles(
+      getTestName(false) + ".dart",
+      getTestName(false).replace("ExistingImports", "ExistingImportLibrary") + ".dart");
+    myFixture.doHighlighting();
+    myFixture.complete(CompletionType.BASIC);
+    selectLookup("Process", Lookup.NORMAL_SELECT_CHAR);
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
   }
 }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
@@ -188,4 +188,8 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
   public void testNotYetImportedClass() {
     doTest("Process");
   }
+
+  public void testExistingImports() {
+    doTest("Process");
+  }
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -17,6 +17,7 @@ import com.google.dart.server.generated.AnalysisServer;
 import com.google.dart.server.internal.remote.utilities.ResponseUtilities;
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,7 @@ public interface AnalysisServerListener {
                                  List<String> includedElementKinds,
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast,
-                                 String libraryFile);
+                                 @Nullable String libraryFile);
 
   /**
    * Reports the errors associated with a given file.

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -216,9 +216,7 @@ public interface AnalysisServerListener {
 
   /**
    * Reports existing imports in a library.
-   *
-   * @param file       the absolute, normalized path of the importing file.
-   * @param uriToNames a map from imported library uri onto the names declared by the imported library.
-   */
-  void computedExistingImports(String file, Map<String, Set<String>> uriToNames);
+   *  @param file       the absolute, normalized path of the importing file.
+   * @param existingImports a map from imported library uri onto the names declared by the imported library.*/
+  void computedExistingImports(String file, Map<String, Map<String, Set<String>>> existingImports);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -19,6 +19,8 @@ import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The interface {@code AnalysisServerListener} defines the behavior of objects that listen for
@@ -54,6 +56,7 @@ public interface AnalysisServerListener {
    * @param completions       the completion suggestions being reported
    * @param isLast            {@code true} if this is the last set of results that will be returned for the
    *                          indicated completion
+   * @param libraryFile       The library file that contains the file where completion was requested.
    */
   public void computedCompletion(String completionId,
                                  int replacementOffset,
@@ -62,7 +65,8 @@ public interface AnalysisServerListener {
                                  List<IncludedSuggestionSet> includedSuggestionSets,
                                  List<String> includedElementKinds,
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
-                                 boolean isLast);
+                                 boolean isLast,
+                                 String libraryFile);
 
   /**
    * Reports the errors associated with a given file.
@@ -209,4 +213,12 @@ public interface AnalysisServerListener {
    *                       status
    */
   public void serverStatus(AnalysisStatus analysisStatus, PubStatus pubStatus);
+
+  /**
+   * Reports existing imports in a library.
+   *
+   * @param file       the absolute, normalized path of the importing file.
+   * @param uriToNames a map from imported library uri onto the names declared by the imported library.
+   */
+  void computedExistingImports(String file, Map<String, Set<String>> uriToNames);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -15,6 +15,7 @@ package com.google.dart.server;
 
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
                                  List<String> includedElementKinds,
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast,
-                                 String libraryFile) {
+                                 @Nullable String libraryFile) {
   }
 
   @Override

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -17,6 +17,8 @@ import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This adapter class provides default implementations for the methods described by the
@@ -41,7 +43,8 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
                                  List<IncludedSuggestionSet> includedSuggestionSets,
                                  List<String> includedElementKinds,
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
-                                 boolean isLast) {
+                                 boolean isLast,
+                                 String libraryFile) {
   }
 
   @Override
@@ -107,5 +110,9 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
 
   @Override
   public void serverStatus(AnalysisStatus analysisStatus, PubStatus pubStatus) {
+  }
+
+  @Override
+  public void computedExistingImports(String file, Map<String, Set<String>> uriToNames) {
   }
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -113,6 +113,6 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
   }
 
   @Override
-  public void computedExistingImports(String file, Map<String, Set<String>> uriToNames) {
+  public void computedExistingImports(String file, Map<String, Map<String, Set<String>>> existingImports) {
   }
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.dart.server.AnalysisServerListener;
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -71,7 +72,7 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
                                  List<String> includedElementKinds,
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast,
-                                 String libraryFile) {
+                                 @Nullable String libraryFile) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.computedCompletion(
         completionId,

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -20,6 +20,8 @@ import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * The class {@code BroadcastAnalysisServerListener} implements {@link AnalysisServerListener} that
@@ -68,7 +70,8 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
                                  List<IncludedSuggestionSet> includedSuggestionSets,
                                  List<String> includedElementKinds,
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
-                                 boolean isLast) {
+                                 boolean isLast,
+                                 String libraryFile) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.computedCompletion(
         completionId,
@@ -78,7 +81,8 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
         includedSuggestionSets,
         includedElementKinds,
         includedSuggestionRelevanceTags,
-        isLast);
+        isLast,
+        libraryFile);
     }
   }
 
@@ -204,6 +208,13 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
   public void serverStatus(AnalysisStatus analysisStatus, PubStatus pubStatus) {
     for (AnalysisServerListener listener : getListeners()) {
       listener.serverStatus(analysisStatus, pubStatus);
+    }
+  }
+
+  @Override
+  public void computedExistingImports(String file, Map<String, Set<String>> uriToNames) {
+    for (AnalysisServerListener listener : getListeners()) {
+      listener.computedExistingImports(file, uriToNames);
     }
   }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -212,9 +212,9 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
   }
 
   @Override
-  public void computedExistingImports(String file, Map<String, Set<String>> uriToNames) {
+  public void computedExistingImports(String file, Map<String, Map<String, Set<String>>> existingImports) {
     for (AnalysisServerListener listener : getListeners()) {
-      listener.computedExistingImports(file, uriToNames);
+      listener.computedExistingImports(file, existingImports);
     }
   }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -76,6 +76,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
 
   // Code Completion domain
   private static final String COMPLETION_AVAILABLE_SUGGESTIONS = "completion.availableSuggestions";
+  private static final String COMPLETION_EXISTING_IMPORTS = "completion.existingImports";
   private static final String COMPLETION_NOTIFICATION_RESULTS = "completion.results";
 
   // Search domain
@@ -668,6 +669,10 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     else if (event.equals(COMPLETION_AVAILABLE_SUGGESTIONS)) {
       // completion.results
       new NotificationCompletionAvailableSuggestionsProcessor(listener).process(response);
+    }
+    else if (event.equals(COMPLETION_EXISTING_IMPORTS)) {
+      // completion.existingImports
+      new NotificationCompletionExistingImportsProcessor(listener).process(response);
     }
     else if (event.equals(COMPLETION_NOTIFICATION_RESULTS)) {
       // completion.results

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionExistingImportsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionExistingImportsProcessor.java
@@ -1,0 +1,52 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.dart.server.AnalysisServerListener;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import java.util.*;
+
+public class NotificationCompletionExistingImportsProcessor extends NotificationProcessor {
+  public NotificationCompletionExistingImportsProcessor(AnalysisServerListener listener) { super(listener); }
+
+  /**
+   * Process the given {@link JsonObject} notification and notify {@link #listener}.
+   */
+  @Override
+  public void process(JsonObject response) throws Exception {
+    JsonObject paramsObject = response.get("params").getAsJsonObject();
+    String file = paramsObject.get("file").getAsString();
+    JsonObject existingImports = paramsObject.get("imports").getAsJsonObject();  // ExistingImports
+    Map<String, Set<String>> uriToNames = buildUriNamesMap(existingImports);
+    getListener().computedExistingImports(file, uriToNames);
+  }
+
+  private Map<String, Set<String>> buildUriNamesMap(JsonObject existingImports) {
+    JsonObject elements = existingImports.get("elements").getAsJsonObject();  // ImportedElementSet
+    List<String> strings = new ArrayList<>();
+    elements.getAsJsonArray("strings").forEach(item -> strings.add(item.getAsString()));
+    List<Integer> uris = new ArrayList<>();
+    elements.getAsJsonArray("uris").forEach(item -> uris.add(item.getAsInt()));
+    List<Integer> names = new ArrayList<>();
+    elements.getAsJsonArray("names").forEach(item -> names.add(item.getAsInt()));
+    Map<String, Set<String>> uriToNames = new HashMap<>();
+    existingImports.get("imports").getAsJsonArray().forEach(item -> {
+      JsonObject existingImport = item.getAsJsonObject();  // ExistingImport
+      existingImport.get("elements").getAsJsonArray().forEach(element -> {
+        int index = element.getAsInt();
+        String uri = strings.get(uris.get(index));
+        if (!uriToNames.containsKey(uri)) {
+          uriToNames.put(uri, new HashSet<>());
+        }
+
+        String name = strings.get(names.get(index));
+        uriToNames.get(uri).add(name);
+      });
+    });
+
+    return uriToNames;
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionExistingImportsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionExistingImportsProcessor.java
@@ -36,7 +36,7 @@ public class NotificationCompletionExistingImportsProcessor extends Notification
     Map<String, Map<String, Set<String>>> result = new HashMap<>();
     existingImports.get("imports").getAsJsonArray().forEach(item -> {
       JsonObject existingImport = item.getAsJsonObject();  // ExistingImport
-      String importedLibraryUri = uris.get(existingImport.get("uri").getAsInt());
+      String importedLibraryUri = strings.get(existingImport.get("uri").getAsInt());
       Map<String, Set<String>> importedLibrary = new HashMap<>();
       result.put(importedLibraryUri, importedLibrary);
       // These "elements" are exports from the imported library.

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
@@ -80,7 +80,7 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
     int replacementOffset = paramsObject.get("replacementOffset").getAsInt();
     int replacementLength = paramsObject.get("replacementLength").getAsInt();
     boolean isLast = paramsObject.get("isLast").getAsBoolean();
-    String libraryFile = paramsObject.get("libraryFile").getAsString();
+    String libraryFile = paramsObject.get("libraryFile") != null ? paramsObject.get("libraryFile").getAsString() : null;
     // compute outline and notify listener
     getListener().computedCompletion(
         completionId,

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationCompletionResultsProcessor.java
@@ -80,6 +80,7 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
     int replacementOffset = paramsObject.get("replacementOffset").getAsInt();
     int replacementLength = paramsObject.get("replacementLength").getAsInt();
     boolean isLast = paramsObject.get("isLast").getAsBoolean();
+    String libraryFile = paramsObject.get("libraryFile").getAsString();
     // compute outline and notify listener
     getListener().computedCompletion(
         completionId,
@@ -89,6 +90,7 @@ public class NotificationCompletionResultsProcessor extends NotificationProcesso
         includedSuggestionSets,
         includedElementKinds,
         includedSuggestionRelevanceTags,
-        isLast);
+        isLast,
+        libraryFile);
   }
 }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
@@ -42,6 +42,12 @@ public class AvailableSuggestion {
   private final String label;
 
   /**
+   * The URI of the library that declares the element being suggested, not the URI of the library
+   * associated with the enclosing AvailableSuggestionSet.
+   */
+  private final String declaringLibraryUri;
+
+  /**
    * Information about the element reference being suggested.
    */
   private final Element element;
@@ -96,8 +102,9 @@ public class AvailableSuggestion {
   /**
    * Constructor for {@link AvailableSuggestion}.
    */
-  public AvailableSuggestion(String label, Element element, String defaultArgumentListString, int[] defaultArgumentListTextRanges, String docComplete, String docSummary, List<String> parameterNames, List<String> parameterTypes, List<String> relevanceTags, Integer requiredParameterCount) {
+  public AvailableSuggestion(String label, String declaringLibraryUri, Element element, String defaultArgumentListString, int[] defaultArgumentListTextRanges, String docComplete, String docSummary, List<String> parameterNames, List<String> parameterTypes, List<String> relevanceTags, Integer requiredParameterCount) {
     this.label = label;
+    this.declaringLibraryUri = declaringLibraryUri;
     this.element = element;
     this.defaultArgumentListString = defaultArgumentListString;
     this.defaultArgumentListTextRanges = defaultArgumentListTextRanges;
@@ -115,6 +122,7 @@ public class AvailableSuggestion {
       AvailableSuggestion other = (AvailableSuggestion) obj;
       return
         ObjectUtilities.equals(other.label, label) &&
+        ObjectUtilities.equals(other.declaringLibraryUri, declaringLibraryUri) &&
         ObjectUtilities.equals(other.element, element) &&
         ObjectUtilities.equals(other.defaultArgumentListString, defaultArgumentListString) &&
         Arrays.equals(other.defaultArgumentListTextRanges, defaultArgumentListTextRanges) &&
@@ -130,6 +138,7 @@ public class AvailableSuggestion {
 
   public static AvailableSuggestion fromJson(JsonObject jsonObject) {
     String label = jsonObject.get("label").getAsString();
+    String declaringLibraryUri = jsonObject.get("declaringLibraryUri").getAsString();
     Element element = Element.fromJson(jsonObject.get("element").getAsJsonObject());
     String defaultArgumentListString = jsonObject.get("defaultArgumentListString") == null ? null : jsonObject.get("defaultArgumentListString").getAsString();
     int[] defaultArgumentListTextRanges = jsonObject.get("defaultArgumentListTextRanges") == null ? null : JsonUtilities.decodeIntArray(jsonObject.get("defaultArgumentListTextRanges").getAsJsonArray());
@@ -139,7 +148,7 @@ public class AvailableSuggestion {
     List<String> parameterTypes = jsonObject.get("parameterTypes") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("parameterTypes").getAsJsonArray());
     List<String> relevanceTags = jsonObject.get("relevanceTags") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("relevanceTags").getAsJsonArray());
     Integer requiredParameterCount = jsonObject.get("requiredParameterCount") == null ? null : jsonObject.get("requiredParameterCount").getAsInt();
-    return new AvailableSuggestion(label, element, defaultArgumentListString, defaultArgumentListTextRanges, docComplete, docSummary, parameterNames, parameterTypes, relevanceTags, requiredParameterCount);
+    return new AvailableSuggestion(label, declaringLibraryUri, element, defaultArgumentListString, defaultArgumentListTextRanges, docComplete, docSummary, parameterNames, parameterTypes, relevanceTags, requiredParameterCount);
   }
 
   public static List<AvailableSuggestion> fromJsonArray(JsonArray jsonArray) {
@@ -152,6 +161,14 @@ public class AvailableSuggestion {
       list.add(fromJson(iterator.next().getAsJsonObject()));
     }
     return list;
+  }
+
+  /**
+   * The URI of the library that declares the element being suggested, not the URI of the library
+   * associated with the enclosing AvailableSuggestionSet.
+   */
+  public String getDeclaringLibraryUri() {
+    return declaringLibraryUri;
   }
 
   /**
@@ -235,6 +252,7 @@ public class AvailableSuggestion {
   public int hashCode() {
     HashCodeBuilder builder = new HashCodeBuilder();
     builder.append(label);
+    builder.append(declaringLibraryUri);
     builder.append(element);
     builder.append(defaultArgumentListString);
     builder.append(defaultArgumentListTextRanges);
@@ -250,6 +268,7 @@ public class AvailableSuggestion {
   public JsonObject toJson() {
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("label", label);
+    jsonObject.addProperty("declaringLibraryUri", declaringLibraryUri);
     jsonObject.add("element", element.toJson());
     if (defaultArgumentListString != null) {
       jsonObject.addProperty("defaultArgumentListString", defaultArgumentListString);
@@ -300,6 +319,8 @@ public class AvailableSuggestion {
     builder.append("[");
     builder.append("label=");
     builder.append(label + ", ");
+    builder.append("declaringLibraryUri=");
+    builder.append(declaringLibraryUri + ", ");
     builder.append("element=");
     builder.append(element + ", ");
     builder.append("defaultArgumentListString=");

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AvailableSuggestion.java
@@ -138,7 +138,7 @@ public class AvailableSuggestion {
 
   public static AvailableSuggestion fromJson(JsonObject jsonObject) {
     String label = jsonObject.get("label").getAsString();
-    String declaringLibraryUri = jsonObject.get("declaringLibraryUri").getAsString();
+    String declaringLibraryUri = jsonObject.get("declaringLibraryUri") != null ? jsonObject.get("declaringLibraryUri").getAsString() : null;
     Element element = Element.fromJson(jsonObject.get("element").getAsJsonObject());
     String defaultArgumentListString = jsonObject.get("defaultArgumentListString") == null ? null : jsonObject.get("defaultArgumentListString").getAsString();
     int[] defaultArgumentListTextRanges = jsonObject.get("defaultArgumentListTextRanges") == null ? null : JsonUtilities.decodeIntArray(jsonObject.get("defaultArgumentListTextRanges").getAsJsonArray());


### PR DESCRIPTION
This CL processes `completion.existingImports` notifications and uses them to build and maintain a map from file onto import URI onto names exported from the import. Then, at completion time, `CompletionSuggestion.libraryFile` is used to lookup a map of all imported libraries and their declared names. Then only libraries which are already imported are allowed to suggest it if some library has already imported the name. This prevents the scenario where I've already imported 'package:foo/foo.dart' which provides `Foo` and not-yet-imported 'package:bar/bar' suggests `Foo` causing you to import a new package unnecessarily. 

Related to https://github.com/flutter/flutter-intellij/issues/3415.

/cc @alexander-doroshko @scheglov @jwren @devoncarew 