### PR TITLE
Invoke RequestListener.onRequest for every request, not just those that use LocalConsumer

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -874,7 +874,6 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
    */
   public void sendRequestToServer(String id, JsonObject request) {
     sendRequestToServer(id, request, new LocalConsumer(request));
-    notifyRequestListeners(request);
   }
 
   /**
@@ -885,6 +884,7 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
    * @param consumer the {@link Consumer} to process a response
    */
   public void sendRequestToServer(String id, JsonObject request, Consumer consumer) {
+    notifyRequestListeners(request);
     synchronized (consumerMapLock) {
       consumerMap.put(id, consumer);
     }


### PR DESCRIPTION
We're seeing that `RequestListener.onRequest` is only being invoked for the `analysis.*` methods of analysis server. We should issue this at the beginning of the request across all requests though (e.g. code completion, fixes, etc.)

/cc @alexander-doroshko @jwren 