### PR TITLE
Implement inline rename refactoring for local Dart declarations

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartInlineHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartInlineHandler.java
@@ -121,7 +121,7 @@ public class DartInlineHandler extends InlineActionHandler {
   }
 
   @Nullable
-  static private InlineRefactoringContext findContext(@Nullable Editor editor) {
+  public static InlineRefactoringContext findContext(@Nullable Editor editor) {
     if (editor == null) {
       return null;
     }

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartServerRenameHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartServerRenameHandler.java
@@ -50,14 +50,17 @@ public class DartServerRenameHandler implements RenameHandler, TitledHandler {
 
     PsiElement element = getElementForDataContext(context);
     InlineRefactoringContext refactoringContext = DartInlineHandler.findContext(editor);
-    if (!refactoringContext.kind.equals(ElementKind.LOCAL_VARIABLE) || !editor.getSettings().isVariableInplaceRenameEnabled()) {
+    final PsiNameIdentifierOwner nameOwner = element instanceof PsiNameIdentifierOwner ?
+                                             (PsiNameIdentifierOwner) element :
+                                             PsiTreeUtil.getParentOfType(element, PsiNameIdentifierOwner.class, true);
+    if (nameOwner == null ||
+        refactoringContext == null ||
+        !refactoringContext.kind.equals(ElementKind.LOCAL_VARIABLE) ||
+        !editor.getSettings().isVariableInplaceRenameEnabled()) {
       showRenameDialog(project, editor, context);
       return;
     }
 
-    final PsiNameIdentifierOwner nameOwner = element instanceof PsiNameIdentifierOwner ?
-                                             (PsiNameIdentifierOwner) element :
-                                             PsiTreeUtil.getParentOfType(element, PsiNameIdentifierOwner.class, true);
     new DartVariableInplaceRenamer(nameOwner, editor).performInplaceRename();
   }
 
@@ -76,10 +79,10 @@ public class DartServerRenameHandler implements RenameHandler, TitledHandler {
     final Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
     final PsiFile psiFile = CommonDataKeys.PSI_FILE.getData(dataContext);
     final PsiElement elementAtOffset = psiFile == null ? null : psiFile.findElementAt(editor.getCaretModel().getOffset());
-    return elementAtOffset.getLanguage() == DartLanguage.INSTANCE;
+    return elementAtOffset != null && elementAtOffset.getLanguage() == DartLanguage.INSTANCE;
   }
 
-  private PsiElement getElementForDataContext(DataContext dataContext) {
+  private static PsiElement getElementForDataContext(DataContext dataContext) {
     final Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
     if (editor == null) return null;
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartServerRenameHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartServerRenameHandler.java
@@ -50,7 +50,7 @@ public class DartServerRenameHandler implements RenameHandler, TitledHandler {
 
     PsiElement element = getElementForDataContext(context);
     InlineRefactoringContext refactoringContext = DartInlineHandler.findContext(editor);
-    if (!refactoringContext.kind.equals(ElementKind.LOCAL_VARIABLE)) {
+    if (!refactoringContext.kind.equals(ElementKind.LOCAL_VARIABLE) || !editor.getSettings().isVariableInplaceRenameEnabled()) {
       showRenameDialog(project, editor, context);
       return;
     }

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartVariableInplaceRenamer.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartVariableInplaceRenamer.java
@@ -4,8 +4,6 @@ package com.jetbrains.lang.dart.ide.refactoring;
 import com.intellij.find.findUsages.FindUsagesHandler;
 import com.intellij.find.findUsages.FindUsagesOptions;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.PsiReference;
@@ -14,12 +12,10 @@ import com.intellij.psi.search.SearchScope;
 import com.intellij.refactoring.rename.inplace.VariableInplaceRenamer;
 import com.intellij.usageView.UsageInfo;
 import com.intellij.util.CommonProcessors;
-import com.jetbrains.lang.dart.DartElementType;
 import com.jetbrains.lang.dart.ide.findUsages.DartServerFindUsagesHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.List;
 
 public class DartVariableInplaceRenamer extends VariableInplaceRenamer {
   public DartVariableInplaceRenamer(@NotNull PsiNamedElement elementToRename,
@@ -43,7 +39,10 @@ public class DartVariableInplaceRenamer extends VariableInplaceRenamer {
     options.isSearchForTextOccurrences = false;
     findUsages.processElementUsages(myElementToRename, processor, options);
     for (UsageInfo usageInfo : processor.getResults()) {
-      referenceProcessor.process(usageInfo.getElement().getReference());
+      PsiElement element = usageInfo.getElement();
+      if (element != null) {
+        referenceProcessor.process(element.getReference());
+      }
     }
 
     return referenceProcessor.getResults();

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartVariableInplaceRenamer.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/DartVariableInplaceRenamer.java
@@ -1,0 +1,61 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.refactoring;
+
+import com.intellij.find.findUsages.FindUsagesHandler;
+import com.intellij.find.findUsages.FindUsagesOptions;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.refactoring.rename.inplace.VariableInplaceRenamer;
+import com.intellij.usageView.UsageInfo;
+import com.intellij.util.CommonProcessors;
+import com.jetbrains.lang.dart.DartElementType;
+import com.jetbrains.lang.dart.ide.findUsages.DartServerFindUsagesHandler;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+public class DartVariableInplaceRenamer extends VariableInplaceRenamer {
+  public DartVariableInplaceRenamer(@NotNull PsiNamedElement elementToRename,
+                                    @NotNull Editor editor) {
+    super(elementToRename, editor);
+  }
+
+  @Override
+  protected Collection<PsiReference> collectRefs(SearchScope referencesSearchScope) {
+    final CommonProcessors.CollectProcessor<PsiReference> referenceProcessor = new CommonProcessors.CollectProcessor<PsiReference>() {
+      @Override
+      protected boolean accept(PsiReference reference) {
+        return acceptReference(reference);
+      }
+    };
+
+    FindUsagesHandler findUsages = new DartServerFindUsagesHandler(myElementToRename);
+    final CommonProcessors.CollectProcessor<UsageInfo> processor = new CommonProcessors.CollectProcessor<>();
+    FindUsagesOptions options = new FindUsagesOptions(GlobalSearchScope.projectScope(myElementToRename.getProject()));
+    options.isUsages = true;
+    options.isSearchForTextOccurrences = false;
+    findUsages.processElementUsages(myElementToRename, processor, options);
+    for (UsageInfo usageInfo : processor.getResults()) {
+      referenceProcessor.process(usageInfo.getElement().getReference());
+    }
+
+    return referenceProcessor.getResults();
+  }
+
+  @Override
+  protected PsiElement checkLocalScope() {
+    PsiElement element = myElementToRename;
+    while (element != null && element.getNode().getElementType().toString() != "FUNCTION_BODY") {
+      element = element.getParent();
+    }
+
+    return element;
+  }
+}


### PR DESCRIPTION
This change adds a new `DartVariableInplaceRenamer` which will take precedence over the dialog-based rename flow in the case of an `ElementKind.LOCAL_VARIABLE`. This is also how the [Python variable rename support](https://github.com/JetBrains/intellij-community/blob/master/python/src/com/jetbrains/python/inspections/quickfix/PyRenameElementQuickFix.java) works from what I can tell.

![ezgif-1-75014536c0f5](https://user-images.githubusercontent.com/535859/60058118-02599280-969c-11e9-8733-424186766138.gif)

/cc @alexander-doroshko