### PR TITLE
adjust the size of the 'copy' button in the dart remote debug config

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/ui/DartRemoteDebugConfigurationEditor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/ui/DartRemoteDebugConfigurationEditor.java
@@ -88,7 +88,7 @@ public class DartRemoteDebugConfigurationEditor extends SettingsEditor<DartRemot
       }
     );
 
-    myCopyButton.setSize(22);
+    myCopyButton.setSize(ActionToolbar.DEFAULT_MINIMUM_BUTTON_SIZE);
     myCopyButton.setIcon(PlatformIcons.COPY_ICON);
     myCopyButton.addActionListener(e -> CopyPasteManager.getInstance().setContents(new StringSelection(myVMArgsArea.getText().trim())));
   }


### PR DESCRIPTION
- adjust the size of the 'copy' button in the dart remote debug config

<img width="172" alt="Screen Shot 2019-07-01 at 9 19 46 AM" src="https://user-images.githubusercontent.com/1269969/60451791-c4032c80-9be1-11e9-8653-fbec4fadc10f.png">

@alexander-doroshko 