### PR TITLE
WEB-14127- add the “Go To Test” feature for Dart

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -103,6 +103,7 @@
                                     implementationClass="com.jetbrains.lang.dart.ide.marker.DartServerOverrideMarkerProvider"/>
 
     <codeInsight.gotoSuper language="Dart" implementationClass="com.jetbrains.lang.dart.ide.actions.DartServerGotoSuperHandler"/>
+    <testFinder implementation="com.jetbrains.lang.dart.ide.testIntegration.DartTestFinder"/>
     <definitionsScopedSearch implementation="com.jetbrains.lang.dart.ide.actions.DartInheritorsSearcher"/>
 
     <codeInsight.overrideMethod language="Dart"

--- a/Dart/src/com/jetbrains/lang/dart/ide/testIntegration/DartTestFinder.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/testIntegration/DartTestFinder.java
@@ -1,0 +1,134 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.testIntegration;
+
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.testIntegration.TestFinder;
+import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.util.PubspecYamlUtil;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This is a {@link TestFinder} contribution for Dart sources to navigate ./lib/foo.dart <--> ./test/foo_test.dart.
+ * Package layout for Dart described here: https://dart.dev/tools/pub/package-layout. See https://youtrack.jetbrains.com/issue/WEB-14127.
+ */
+public class DartTestFinder implements TestFinder {
+  @Nullable
+  @Override
+  public PsiElement findSourceElement(@NotNull final PsiElement from) {
+    return from.getContainingFile();
+  }
+
+  @NotNull
+  @Override
+  public Collection<PsiElement> findTestsForClass(@NotNull final PsiElement element) {
+    if (!isDartLibFile(element)) {
+      return Collections.emptySet();
+    }
+
+    final PsiFile file = element.getContainingFile();
+    final String fileName = file.getVirtualFile().getNameWithoutExtension();
+
+    final String grandParentPath = getGrandParentDirectoryPath(file);
+    if (grandParentPath == null || grandParentPath.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    final String needleFilePath = FileUtil.toSystemIndependentName(grandParentPath + "/test/" + fileName + "_test.dart");
+    return getElementCollectionFromPath(element.getManager(), needleFilePath);
+  }
+
+  @NotNull
+  @Override
+  public Collection<PsiElement> findClassesForTest(@NotNull final PsiElement element) {
+    if (!isDartTestFile(element)) {
+      return Collections.emptySet();
+    }
+    final PsiFile file = element.getContainingFile();
+    final String fileName = file.getVirtualFile().getNameWithoutExtension();
+
+    final String grandParentPath = getGrandParentDirectoryPath(file);
+    if (grandParentPath == null || grandParentPath.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    final String needleFilePath = FileUtil.toSystemIndependentName(grandParentPath +
+                                                                   "/" +
+                                                                   PubspecYamlUtil.LIB_DIR_NAME +
+                                                                   "/" +
+                                                                   fileName.substring(0, fileName.length() - 5) +
+                                                                   ".dart");
+    return getElementCollectionFromPath(element.getManager(), needleFilePath);
+  }
+
+  @NotNull
+  private static Collection<PsiElement> getElementCollectionFromPath(@NotNull final PsiManager psiManager,
+                                                                     @NotNull final String needleFilePath) {
+    final VirtualFile virtualFile =
+      LocalFileSystem.getInstance().findFileByPath(needleFilePath);
+    if (virtualFile != null) {
+      final PsiFile psiFile = psiManager.findFile(virtualFile);
+      if (psiFile != null) {
+        return Collections.singleton(psiFile);
+      }
+    }
+    return Collections.emptySet();
+  }
+
+  @Override
+  public boolean isTest(@NotNull final PsiElement element) {
+    return isDartTestFile(element);
+  }
+
+  /**
+   * Verify that the containing file for this {@link PsiElement} is:
+   * - a Dart file,
+   * - the file name matches "*_test.dart",
+   * - and that the file is in a parent directory named "test".
+   */
+  @Contract("null -> false")
+  public static boolean isDartTestFile(@Nullable final PsiElement element) {
+    if (element == null) {
+      return false;
+    }
+    final VirtualFile virtualFile = element.getContainingFile().getVirtualFile();
+    if (virtualFile == null || virtualFile.getFileType() != DartFileType.INSTANCE) {
+      return false;
+    }
+    return virtualFile.getNameWithoutExtension().endsWith("_test") &&
+           virtualFile.getParent().getName().equals("test");
+  }
+
+  /**
+   * Verify that the containing file for this {@link PsiElement} is:
+   * - a Dart file,
+   * - and that the file is in a parent directory named "lib".
+   */
+  @Contract("null -> false")
+  public static boolean isDartLibFile(@Nullable final PsiElement element) {
+    if (element == null) {
+      return false;
+    }
+    final VirtualFile vFile = element.getContainingFile().getVirtualFile();
+    return vFile != null &&
+           vFile.getFileType() == DartFileType.INSTANCE &&
+           vFile.getParent().getName().equals(PubspecYamlUtil.LIB_DIR_NAME);
+  }
+
+  @Contract("null -> null")
+  public static String getGrandParentDirectoryPath(@Nullable final PsiFile file) {
+    if (file != null && file.getParent() != null && file.getParent().getParent() != null) {
+      return file.getParent().getParent().getVirtualFile().getPath();
+    }
+    return null;
+  }
+}

--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/testIntegration/DartTestFinderTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/testIntegration/DartTestFinderTest.java
@@ -1,0 +1,52 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.testIntegration;
+
+import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
+
+public class DartTestFinderTest extends DartCodeInsightFixtureTestCase {
+
+  PsiFile libFile;
+  PsiFile testFile;
+  PsiFile badLibFile;
+  PsiFile badTestFile;
+  PsiFile badTestFile2;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    libFile = myFixture.addFileToProject("lib/foo.dart", "foo() {}");
+    testFile = myFixture.addFileToProject("test/foo_test.dart", "tests() {}");
+
+    badLibFile = myFixture.addFileToProject("lib2/foo.dart", "foo() {}");
+    badTestFile = myFixture.addFileToProject("test2/foo_test.dart", "tests() {}");
+    badTestFile2 = myFixture.addFileToProject("test/foo_tes2t.dart", "tests() {}");
+  }
+
+  public void testIsDartLibFile() {
+    assertFalse(DartTestFinder.isDartLibFile(null));
+    assertTrue(DartTestFinder.isDartLibFile(libFile));
+    assertFalse(DartTestFinder.isDartLibFile(testFile));
+
+    assertFalse(DartTestFinder.isDartLibFile(badLibFile));
+    assertFalse(DartTestFinder.isDartLibFile(badTestFile));
+    assertFalse(DartTestFinder.isDartLibFile(badTestFile2));
+  }
+
+  public void testIsDartTestFile() {
+    assertFalse(DartTestFinder.isDartTestFile(null));
+    assertFalse(DartTestFinder.isDartTestFile(libFile));
+    assertTrue(DartTestFinder.isDartTestFile(testFile));
+
+    assertFalse(DartTestFinder.isDartTestFile(badLibFile));
+    assertFalse(DartTestFinder.isDartTestFile(badTestFile));
+    assertFalse(DartTestFinder.isDartTestFile(badTestFile2));
+  }
+
+  public void testGetGrandParentDirectoryPath() {
+    assertNull(null);
+    assertEquals("/src", DartTestFinder.getGrandParentDirectoryPath(libFile));
+    assertEquals("/src", DartTestFinder.getGrandParentDirectoryPath(testFile));
+  }
+}


### PR DESCRIPTION
@alexander-doroshko  This extension point should either have a language attribute attached in the XML, or an additional required method to override for the file type so the Java provider isn't called for Dart, and vise versa.