### PR TITLE
Completion of constructors should insert parentheses

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -471,10 +471,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
         }
 
         if (element != null &&
-            (element.getKind().equals(ElementKind.FUNCTION) ||
-             element.getKind().equals(ElementKind.FUNCTION_INVOCATION) ||
-             element.getKind().equals(ElementKind.CONSTRUCTOR) ||
-             element.getKind().equals(ElementKind.CONSTRUCTOR_INVOCATION)) &&
+            (element.getKind().equals(ElementKind.CONSTRUCTOR)|| element.getKind().equals(ElementKind.FUNCTION)) &&
             suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -470,9 +470,8 @@ public class DartServerCompletionContributor extends CompletionContributor {
           return;
         }
 
-        ElementKind elementKind = element.getKind();
         if (element != null &&
-            (elementKind.equals(ElementKind.FUNCTION_INVOCATION) || elementKind.equals(ElementKind.CONSTRUCTOR_INVOCATION)) &&
+            (element.getKind().equals(ElementKind.FUNCTION_INVOCATION) || element.getKind().equals(ElementKind.CONSTRUCTOR_INVOCATION)) &&
             suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -471,7 +471,10 @@ public class DartServerCompletionContributor extends CompletionContributor {
         }
 
         if (element != null &&
-            (element.getKind().equals(ElementKind.FUNCTION_INVOCATION) || element.getKind().equals(ElementKind.CONSTRUCTOR_INVOCATION)) &&
+            (element.getKind().equals(ElementKind.FUNCTION) ||
+             element.getKind().equals(ElementKind.FUNCTION_INVOCATION) ||
+             element.getKind().equals(ElementKind.CONSTRUCTOR) ||
+             element.getKind().equals(ElementKind.CONSTRUCTOR_INVOCATION)) &&
             suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -470,7 +470,10 @@ public class DartServerCompletionContributor extends CompletionContributor {
           return;
         }
 
-        if (CompletionSuggestionKind.INVOCATION.equals(suggestion.getKind()) && suggestion.getParameterNames() != null) {
+        ElementKind elementKind = element.getKind();
+        if (element != null &&
+            (elementKind.equals(ElementKind.FUNCTION_INVOCATION) || elementKind.equals(ElementKind.CONSTRUCTOR_INVOCATION)) &&
+            suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }
       });

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -470,7 +470,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
           return;
         }
 
-        if (element != null && ElementKind.FUNCTION.equals(element.getKind()) && suggestion.getParameterNames() != null) {
+        if (CompletionSuggestionKind.INVOCATION.equals(suggestion.getKind()) && suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }
       });

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -471,7 +471,7 @@ public class DartServerCompletionContributor extends CompletionContributor {
         }
 
         if (element != null &&
-            (element.getKind().equals(ElementKind.CONSTRUCTOR)|| element.getKind().equals(ElementKind.FUNCTION)) &&
+            (element.getKind().equals(ElementKind.CONSTRUCTOR) || element.getKind().equals(ElementKind.FUNCTION)) &&
             suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }

--- a/Dart/testData/analysisServer/completion/ConstructorParens.after.dart
+++ b/Dart/testData/analysisServer/completion/ConstructorParens.after.dart
@@ -1,4 +1,6 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+import 'dart:io';
+
 void main() {
-  new ProcessInfo()
+  new ProcessInfo()<caret>
 }

--- a/Dart/testData/analysisServer/completion/ConstructorParens.after.dart
+++ b/Dart/testData/analysisServer/completion/ConstructorParens.after.dart
@@ -1,0 +1,4 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+void main() {
+  new ProcessInfo()
+}

--- a/Dart/testData/analysisServer/completion/ConstructorParens.dart
+++ b/Dart/testData/analysisServer/completion/ConstructorParens.dart
@@ -1,0 +1,4 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+void main() {
+  new ProcessInf^
+}

--- a/Dart/testData/analysisServer/completion/ConstructorParens.dart
+++ b/Dart/testData/analysisServer/completion/ConstructorParens.dart
@@ -1,4 +1,4 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 void main() {
-  new ProcessInf^
+  new ProcessInf<caret>
 }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
@@ -205,4 +205,6 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
     myFixture.finishLookup(Lookup.NORMAL_SELECT_CHAR);
     myFixture.checkResultByFile(getTestName(false) + ".after.dart");
   }
+
+  public void testConstructorParens() { doTest(); }
 }


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/37563. We were using a different test (see https://github.com/JetBrains/intellij-plugins/pull/678/files#diff-b788dc0bc2f2b9f218821dc4d4802bfaR443) for whether `handleFunctionInvocationInsertion` should be applied in normal vs client-cached suggestions that made it so that constructors didn't trigger it.

/cc @alexander-doroshko  @bwilkerson @scheglov