### PR TITLE
Follow up on Dart Parameter Info action, https://github.com/JetBrains/intellij-plugins/pull/676

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/info/DartFunctionDescription.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/info/DartFunctionDescription.java
@@ -38,6 +38,11 @@ public class DartFunctionDescription {
     return myParameters;
   }
 
+  @NotNull
+  public DartOptionalParameterDescription[] getOptionalParameters() {
+    return myOptionalParameters;
+  }
+
   public String getParametersListPresentableText() {
     final StringBuilder result = new StringBuilder();
     for (DartParameterDescription parameterDescription : myParameters) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/info/DartOptionalParameterDescription.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/info/DartOptionalParameterDescription.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class DartOptionalParameterDescription {
+  @NotNull
   private final String myText;
   @Nullable
   private final String myValue;
@@ -54,6 +55,11 @@ public class DartOptionalParameterDescription {
 
     final PsiElement firstChild = formalParameters.getFirstChild();
     return firstChild != null && "[".equals(firstChild.getText());
+  }
+
+  @NotNull
+  public String getText() {
+    return myText;
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/info/DartParameterDescription.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/info/DartParameterDescription.java
@@ -31,6 +31,11 @@ public class DartParameterDescription {
     return result;
   }
 
+  @NotNull
+  public String getText() {
+    return myText;
+  }
+
   @Override
   public String toString() {
     return myText;

--- a/Dart/src/com/jetbrains/lang/dart/ide/info/DartParameterInfoHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/info/DartParameterInfoHandler.java
@@ -97,7 +97,12 @@ public class DartParameterInfoHandler implements ParameterInfoHandler<PsiElement
 
   @Override
   public void updateParameterInfo(@NotNull PsiElement place, @NotNull UpdateParameterInfoContext context) {
-    int parameterIndex = DartResolveUtil.getArgumentIndex(place);
+    DartFunctionDescription functionDescription =
+      context.getObjectsToView().length > 0 && context.getObjectsToView()[0] instanceof DartFunctionDescription
+      ? (DartFunctionDescription)context.getObjectsToView()[0]
+      : null;
+
+    int parameterIndex = DartResolveUtil.getArgumentIndex(place, functionDescription);
     context.setCurrentParameter(parameterIndex);
 
     if (context.getParameterOwner() == null) {

--- a/Dart/testData/paramInfo/ParamInfo25.dart
+++ b/Dart/testData/paramInfo/ParamInfo25.dart
@@ -1,5 +1,0 @@
-foo({String str1= '1', String str2= '2'}) { }
-
-main() {
-  foo(str<caret>2: '', str1: '');
-}

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartParameterInfoTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartParameterInfoTest.java
@@ -152,10 +152,6 @@ public class DartParameterInfoTest extends CodeInsightFixtureTestCase {
     doTest("{String str}", 0);
   }
 
-  public void _testParamInfo25() {
-    doTest("{String str1: '1', String str2: '2'}", 1);
-  }
-
   public void testParamInfo_call_localVariable() {
     doTest("int a, double b", 0);
   }


### PR DESCRIPTION
@alexander-doroshko 

I did not update the tests as both my Linux box and Mac book are having problems running any of the tests (I'll continue to iterate).  I thought it was close enough in implementation to get your thoughts.  I wasn't able to convinced myself that `functionDescription` will always be the same as `functionDescription2`, so I left the distinction (again, can't run tests.)

```
foo({String str1= '1', String str2= '2'}) { }

main() {
  foo(str2: '', str1: ''); // caret in each parameter, Parameter Info works even though str2 is before str1 :)
}
```