### PR TITLE
Allow contributing literal completion suggestions like integral values

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -70,12 +70,6 @@ public class DartServerCompletionContributor extends CompletionContributor {
                                            @NotNull final CompletionResultSet originalResultSet) {
                final PsiFile originalFile = parameters.getOriginalFile();
                final Project project = originalFile.getProject();
-
-               if (originalResultSet.getPrefixMatcher().getPrefix().isEmpty() &&
-                   isRightAfterBadIdentifier(parameters.getEditor().getDocument().getImmutableCharSequence(), parameters.getOffset())) {
-                 return;
-               }
-
                final CompletionSorter sorter = createSorter(parameters, originalResultSet.getPrefixMatcher());
                final String uriPrefix = getPrefixIfCompletingUri(parameters);
                final CompletionResultSet resultSet = uriPrefix != null
@@ -180,19 +174,6 @@ public class DartServerCompletionContributor extends CompletionContributor {
                });
              }
            });
-  }
-
-  private static boolean isRightAfterBadIdentifier(@NotNull CharSequence text, int offset) {
-    if (offset == 0 || offset >= text.length()) return false;
-
-    int currentOffset = offset - 1;
-    if (!Character.isJavaIdentifierPart(text.charAt(currentOffset))) return false;
-
-    while (currentOffset > 0 && Character.isJavaIdentifierPart(text.charAt(currentOffset - 1))) {
-      currentOffset--;
-    }
-
-    return !Character.isJavaIdentifierStart(text.charAt(currentOffset));
   }
 
   private static void appendRuntimeCompletion(@NotNull final CompletionParameters parameters,


### PR DESCRIPTION
Now that ML completion is landing in Dart, analysis server can suggest literals like string and numeric values. Here is an example of this behavior in Dart's VS Code support:

<img width="646" alt="Screen Shot 2019-08-01 at 7 49 52 PM" src="https://user-images.githubusercontent.com/535859/62404500-8cbdcd80-b549-11e9-9422-be644f24a3df.png">

Removing this check which ensured historically that we would only complete tokens with lexemes that begin with alphabetic characters will allow this to work in Dart IntelliJ as well.