### PR TITLE
Handle LibraryPathSet JSON serialization

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -188,6 +188,9 @@ public class RequestUtilities {
     else if (object instanceof ImportedElements) {
       return ((ImportedElements)object).toJson();
     }
+    else if (object instanceof LibraryPathSet) {
+      return ((LibraryPathSet)object).toJson();
+    }
     throw new IllegalArgumentException("Unable to convert to JSON: " + object);
   }
 


### PR DESCRIPTION
We ran into the issue when trying to set paths for analysis server code completion that our serialization logic needs to handle the new case of `LibraryPathSet` in order to issue `completion.registerLibraryPaths` requests.

/cc @alexander-doroshko 