### PR TITLE
Insert parens in case of (CONSTRUCTOR|FUNCTION)_INVOCATION

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -471,7 +471,10 @@ public class DartServerCompletionContributor extends CompletionContributor {
         }
 
         if (element != null &&
-            (ElementKind.FUNCTION.equals(element.getKind()) || ElementKind.CONSTRUCTOR.equals(element.getKind())) &&
+            (ElementKind.FUNCTION.equals(element.getKind()) ||
+             ElementKind.FUNCTION_INVOCATION.equals(element.getKind()) ||
+             ElementKind.CONSTRUCTOR.equals(element.getKind()) ||
+             ElementKind.CONSTRUCTOR_INVOCATION.equals(element.getKind())) &&
             suggestion.getParameterNames() != null) {
           handleFunctionInvocationInsertion(context, item, suggestion);
         }


### PR DESCRIPTION
This is a follow-up from #678 addressing https://github.com/dart-lang/sdk/issues/37593. Flutter widget invocations do indeed have a `CONSTRUCTOR_INVOCATION` so we need to make sure to call `handleFunctionInvocationInsertion` for this case.

/cc @alexander-doroshko 