### PR TITLE
Find Usages bug fix for Dart cascades

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartResolveUtil.java
@@ -78,6 +78,9 @@ public class DartResolveUtil {
     if (nextSibling instanceof LeafPsiElement) {
       return DartTokenTypesSets.ASSIGNMENT_OPERATORS.contains(((LeafPsiElement)nextSibling).getElementType());
     }
+    else if (nextSibling instanceof DartVarInit) {
+      return true;
+    }
     return nextSibling instanceof DartAssignmentOperator;
   }
 

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerFindUsagesTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerFindUsagesTest.java
@@ -1,4 +1,4 @@
-// Copyright 2000-2018 JetBrains s.r.o.
+// Copyright 2000-2019 JetBrains s.r.o.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,9 +28,11 @@ import com.intellij.psi.search.SearchScope;
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
 import com.intellij.usageView.UsageInfo;
+import com.intellij.usages.impl.rules.UsageType;
 import com.intellij.util.CommonProcessors;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.ide.findUsages.DartServerFindUsagesHandler;
+import com.jetbrains.lang.dart.ide.findUsages.DartUsageTypeProvider;
 import com.jetbrains.lang.dart.psi.impl.DartFileReference;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 import org.jetbrains.annotations.NotNull;
@@ -68,15 +70,19 @@ public class DartServerFindUsagesTest extends CodeInsightFixtureTestCase {
       assertNotNull(range);
       final int startOffset = element.getTextRange().getStartOffset() + range.getStartOffset();
       final int endOffset = element.getTextRange().getStartOffset() + range.getEndOffset();
+      assert (startOffset >= 0);
+      assert (endOffset > startOffset);
+      final UsageType usageType = new DartUsageTypeProvider().getUsageType(element);
       return element.getClass().getSimpleName() + " in " + element.getContainingFile().getName() + "@" + startOffset + ":" + endOffset +
              (info.isDynamicUsage() ? " (dynamic usage)" : "") +
-             (info.isNonCodeUsage() ? " (non-code usage)" : "");
+             (info.isNonCodeUsage() ? " (non-code usage)" : "") +
+             (usageType != null ? " [" + usageType.toString() + "]" : " [<null> usage type]");
     });
 
     assertSameElements(actualResult, expected);
   }
 
-  public void testBoolUsagesWithScope() throws Exception {
+  public void testBoolUsagesWithScope() {
     final PsiFile psiFile1 = myFixture.configureByText("file.dart", "/// [bool]\n" +
                                                                     "<caret>bool foo() {\n" +
                                                                     "  var bool = #bool;\n" +
@@ -85,20 +91,21 @@ public class DartServerFindUsagesTest extends CodeInsightFixtureTestCase {
 
     myFixture.doHighlighting(); // warm up
 
-    final String[] allProjectUsages = {"PsiCommentImpl in " + psiFile1.getName() + "@5:9 (non-code usage)",
-      "DartReferenceExpressionImpl in " + psiFile1.getName() + "@11:15",
-      "DartReferenceExpressionImpl in file1.dart@0:4"};
+    final String[] allProjectUsages = {"PsiCommentImpl in " + psiFile1.getName() + "@5:9 (non-code usage) [<null> usage type]",
+      "DartReferenceExpressionImpl in " + psiFile1.getName() + "@11:15 [Value read]",
+      "DartReferenceExpressionImpl in file1.dart@0:4 [Value read]"};
 
     checkUsages(new LocalSearchScope(psiFile1),
-                "PsiCommentImpl in " + psiFile1.getName() + "@5:9 (non-code usage)",
-                "DartReferenceExpressionImpl in " + psiFile1.getName() + "@11:15");
+                "PsiCommentImpl in " + psiFile1.getName() + "@5:9 (non-code usage) [<null> usage type]",
+                "DartReferenceExpressionImpl in " + psiFile1.getName() + "@11:15 [Value read]");
     checkUsages(new LocalSearchScope(psiFile2),
-                "DartReferenceExpressionImpl in file1.dart@0:4");
+                "DartReferenceExpressionImpl in file1.dart@0:4 [Value read]");
     checkUsages(new LocalSearchScope(new PsiFile[]{psiFile1, psiFile2}), allProjectUsages);
     checkUsages(GlobalSearchScope.fileScope(getProject(), psiFile1.getVirtualFile()),
-                "PsiCommentImpl in " + psiFile1.getName() + "@5:9 (non-code usage)",
-                "DartReferenceExpressionImpl in " + psiFile1.getName() + "@11:15");
-    checkUsages(GlobalSearchScope.fileScope(getProject(), psiFile2.getVirtualFile()), "DartReferenceExpressionImpl in file1.dart@0:4");
+                "PsiCommentImpl in " + psiFile1.getName() + "@5:9 (non-code usage) [<null> usage type]",
+                "DartReferenceExpressionImpl in " + psiFile1.getName() + "@11:15 [Value read]");
+    checkUsages(GlobalSearchScope.fileScope(getProject(), psiFile2.getVirtualFile()),
+                "DartReferenceExpressionImpl in file1.dart@0:4 [Value read]");
     checkUsages(GlobalSearchScope.filesScope(getProject(), Arrays.asList(psiFile1.getVirtualFile(), psiFile2.getVirtualFile())),
                 allProjectUsages);
     checkUsages(GlobalSearchScope.projectScope(getProject()), allProjectUsages);
@@ -122,9 +129,37 @@ public class DartServerFindUsagesTest extends CodeInsightFixtureTestCase {
                                            "}\n");
     myFixture.doHighlighting(); // warm up
     checkUsages(GlobalSearchScope.projectScope(getProject()),
-                "LeafPsiElement in " + getFile().getName() + "@24:27 (non-code usage)",
-                "DartReferenceExpressionImpl in " + getFile().getName() + "@93:96",
-                "DartReferenceExpressionImpl in " + getFile().getName() + "@122:125 (dynamic usage)");
+                "LeafPsiElement in " + getFile().getName() + "@24:27 (non-code usage) [<null> usage type]",
+                "DartReferenceExpressionImpl in " + getFile().getName() + "@93:96 [Value read]",
+                "DartReferenceExpressionImpl in " + getFile().getName() + "@122:125 (dynamic usage) [Value read]");
+  }
+
+  public void testCascadeReadUsage() {
+    myFixture.configureByText("file.dart", "class Foo {\n" +
+                                           "  int someInt;\n" +
+                                           "}\n" +
+                                           "\n" +
+                                           "bar (Foo foo) {\n" +
+                                           "  foo\n" +
+                                           "  ..someInt<caret>;\n" +
+                                           "}\n");
+    myFixture.doHighlighting(); // warm up
+    checkUsages(GlobalSearchScope.projectScope(getProject()),
+                "DartReferenceExpressionImpl in file.dart@56:63 [Value read]");
+  }
+
+  public void testCascadeWriteUsage() {
+    myFixture.configureByText("file.dart", "class Foo {\n" +
+                                           "  int someInt;\n" +
+                                           "}\n" +
+                                           "\n" +
+                                           "bar (Foo foo) {\n" +
+                                           "  foo\n" +
+                                           "  ..someInt<caret> = 1;\n" +
+                                           "}\n");
+    myFixture.doHighlighting(); // warm up
+    checkUsages(GlobalSearchScope.projectScope(getProject()),
+                "DartReferenceExpressionImpl in file.dart@56:63 [Value write]");
   }
 
   public void testFileUsage() {


### PR DESCRIPTION
@alexander-doroshko 

Bug fix to distinguish between the cascade operations foo..x; and foo..x = 1; as a read and write types in the Find Usages action for Dart, tests updated and added to cover this case.