### PR TITLE
Use the extension method icon in Dart code completions, that is used in the Structure view.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -642,6 +642,9 @@ public class DartServerCompletionContributor extends CompletionContributor {
     else if (elementKind.equals(ElementKind.TOP_LEVEL_VARIABLE)) {
       return AllIcons.Nodes.Variable;
     }
+    else if (elementKind.equals(ElementKind.EXTENSION)) {
+      return AllIcons.Nodes.AnonymousClass;
+    }
     else {
       return null;
     }


### PR DESCRIPTION
Any chance @alexander-doroshko that we could get an extension method icon?, i.e. the class `/nodes/class.svg` icon but with an `E` instead of a `C`.