### PR TITLE
WEB-41425 Angular - implement duplicate selector and property binding inspection

### DIFF
--- a/AngularJS/resources/META-INF/plugin.xml
+++ b/AngularJS/resources/META-INF/plugin.xml
@@ -191,6 +191,9 @@
     <localInspection implementationClass="org.angular2.inspections.AngularMultipleStructuralDirectivesInspection"
                      displayName="Multiple structural directives on one element" groupName="Angular" enabledByDefault="true"
                      level="ERROR"/>
+    <localInspection implementationClass="org.angular2.inspections.AngularDuplicateAttributeInspection"
+                     displayName="Duplicate selectors and property bindings" groupName="Angular" enabledByDefault="true"
+                     level="ERROR" />
     <localInspection implementationClass="org.angular2.inspections.AngularInvalidAnimationTriggerAssignmentInspection"
                      alternativeId=""
                      displayName="Invalid animation trigger assignment" groupName="Angular" enabledByDefault="true"

--- a/AngularJS/resources/inspectionDescriptions/AngularDuplicateAttribute.html
+++ b/AngularJS/resources/inspectionDescriptions/AngularDuplicateAttribute.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Reports duplicate selectors and property bindings.
+<!-- tooltip end -->
+</body>
+</html>

--- a/AngularJS/resources/messages/Angular2Bundle.properties
+++ b/AngularJS/resources/messages/Angular2Bundle.properties
@@ -92,6 +92,8 @@ angular.inspection.template.empty-event-binding-handler=Event binding doesn't ha
 # suppress inspection "UnusedProperty"
 angular.inspection.template.event-not-emitted=Event {0} is not emitted by any applicable directives nor by {1} element
 angular.inspection.template.multiple-structural-directives=Only one structural directive can be applied
+angular.inspection.template.redundant-selector=Redundant match on {0} selector
+angular.inspection.template.duplicate-binding=Duplicate binding to {0}
 angular.inspection.template.ng-content-with-content=<ng-content> element cannot have content
 # suppress inspection "UnusedProperty"
 angular.inspection.template.property-not-provided=Property {0} is not provided by any applicable directives nor by {1} element

--- a/AngularJS/src/org/angular2/inspections/Angular2TemplateInspectionsProvider.java
+++ b/AngularJS/src/org/angular2/inspections/Angular2TemplateInspectionsProvider.java
@@ -23,6 +23,7 @@ public class Angular2TemplateInspectionsProvider implements InspectionToolProvid
       AngularInvalidExpressionResultTypeInspection.class,
       AngularInvalidTemplateReferenceVariableInspection.class,
       AngularMissingEventHandlerInspection.class,
+      AngularDuplicateAttributeInspection.class,
       AngularMultipleStructuralDirectivesInspection.class,
       AngularNonEmptyNgContentInspection.class,
       AngularUndefinedBindingInspection.class,

--- a/AngularJS/src/org/angular2/inspections/AngularDuplicateAttributeInspection.java
+++ b/AngularJS/src/org/angular2/inspections/AngularDuplicateAttributeInspection.java
@@ -1,0 +1,164 @@
+// Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package org.angular2.inspections;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.angular2.codeInsight.attributes.Angular2AttributeDescriptor;
+import org.angular2.entities.Angular2Directive;
+import org.angular2.lang.Angular2Bundle;
+import org.angular2.lang.html.parser.Angular2AttributeType;
+import org.angular2.lang.selector.Angular2DirectiveSimpleSelector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.lang.javascript.psi.JSElement;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlElement;
+import com.intellij.psi.xml.XmlTag;
+
+import one.util.streamex.StreamEx;
+
+public class AngularDuplicateAttributeInspection extends AngularHtmlLikeTemplateLocalInspectionTool {
+   @Override
+   protected void visitXmlTag(
+         @NotNull final ProblemsHolder problemsHolder,
+         @NotNull final XmlTag xmlTag) {
+      StreamEx.of(xmlTag.getAttributes())
+              .mapToEntry(XmlAttribute::getDescriptor, Function.identity())
+              .selectKeys(Angular2AttributeDescriptor.class)
+              .filterKeys(AngularDuplicateAttributeInspection::isInspectable)
+              .flatMapKeyValue(AngularDuplicateAttributeInspection::toDuplicateAttribute)
+              .collect(Collectors.groupingBy(duplicateAttribute -> duplicateAttribute.targetName))
+              .values()
+              .forEach(duplicateAttributes -> {
+                 if (duplicateAttributes.size() > 1) {
+                    registerProblems(problemsHolder, duplicateAttributes);
+                 }
+              });
+   }
+
+   private static boolean isInspectable(@NotNull final Angular2AttributeDescriptor descriptor) {
+      final Angular2AttributeType type = descriptor.getInfo().type;
+      return type == Angular2AttributeType.REGULAR
+            || type == Angular2AttributeType.PROPERTY_BINDING
+            || type == Angular2AttributeType.BANANA_BOX_BINDING;
+   }
+
+   private static Stream<DuplicateAttribute> toDuplicateAttribute(
+         @NotNull final Angular2AttributeDescriptor descriptor,
+         @NotNull final XmlAttribute xmlAttribute) {
+      final String attributeName = descriptor.getInfo().name;
+
+      // Check if the attribute name represents a Directive selector.
+      // If it represents a Directive (or more than one) then enhance the Stream
+      // with an item per each Directive name.
+      // If it matches none, then a single item will be returned, using the name of the attribute
+      return StreamEx.of(descriptor.getSourceDirectives())
+                     .filter(directive -> matchesAttributeName(directive, attributeName))
+                     .map(Angular2Directive::getName)
+                     .distinct()
+                     .ifEmpty(attributeName)
+                     .map(targetName -> {
+                        final boolean isBinding =
+                              descriptor.getDeclarations()
+                                        .stream()
+                                        .anyMatch(d -> d instanceof JSElement);
+                        return new DuplicateAttribute(
+                              isBinding,
+                              targetName,
+                              isBinding ? descriptor.getInfo().name : targetName,
+                              xmlAttribute.getNameElement()
+                        );
+                     });
+   }
+
+   private static boolean matchesAttributeName(
+         @NotNull final Angular2Directive directive,
+         @NotNull final String attributeName) {
+      return StreamEx.of(directive.getSelector().getSimpleSelectors())
+                     .flatCollection(Angular2DirectiveSimpleSelector::getAttrNames)
+                     .anyMatch(a -> a.equalsIgnoreCase(attributeName));
+   }
+
+   private static void registerProblems(
+         @NotNull final ProblemsHolder problemsHolder,
+         @NotNull final List<DuplicateAttribute> duplicateAttributes) {
+      final int size = duplicateAttributes.size();
+      final boolean uniform =
+            duplicateAttributes.stream().map(a -> a.isBinding).distinct().count() == 1;
+
+      // All bindings            -> problem on all of them
+      // All selectors           -> problem only for last one
+      // Selectors and bindings  -> problem on all but last
+      if (uniform) {
+         final DuplicateAttribute first = duplicateAttributes.get(0);
+         doRegisterProblems(
+               problemsHolder,
+               first.isBinding
+                     ? duplicateAttributes
+                     : duplicateAttributes.subList(size - 1, size),
+               null,
+               first.isBinding
+                     ? "angular.inspection.template.duplicate-binding"
+                     : "angular.inspection.template.redundant-selector"
+         );
+      } else {
+         final Collection<DuplicateAttribute> subList = duplicateAttributes.subList(0, size - 1);
+         doRegisterProblems(
+               problemsHolder,
+               subList,
+               getFirstDirectivePresentableName(subList),
+               "angular.inspection.template.redundant-selector"
+         );
+      }
+   }
+
+   private static void doRegisterProblems(
+         @NotNull final ProblemsHolder problemsHolder,
+         @NotNull final Collection<DuplicateAttribute> duplicateAttributes,
+         @Nullable final String presentableName,
+         @NotNull final String messageKey) {
+      for (final DuplicateAttribute a : duplicateAttributes) {
+         final String message = Angular2Bundle.message(
+               messageKey,
+               presentableName != null ? presentableName : a.presentableName
+         );
+         problemsHolder.registerProblem(a.xmlElement, message);
+      }
+   }
+
+   private static String getFirstDirectivePresentableName(
+         @NotNull final Collection<DuplicateAttribute> duplicateAttributes) {
+      for (final DuplicateAttribute a : duplicateAttributes) {
+         if (!a.isBinding) {
+            return a.presentableName;
+         }
+      }
+
+      // This should never happen
+      throw new RuntimeException("Expected a Directive selector but found none");
+   }
+
+   private static class DuplicateAttribute {
+      final boolean isBinding;
+      final String targetName;
+      final String presentableName;
+      final XmlElement xmlElement;
+
+      DuplicateAttribute(
+            final boolean isBinding,
+            final String targetName,
+            final String presentableName,
+            final XmlElement xmlElement) {
+         this.isBinding = isBinding;
+         this.targetName = targetName;
+         this.presentableName = presentableName;
+         this.xmlElement = xmlElement;
+      }
+   }
+}

--- a/AngularJS/test/org/angular2/inspections/Angular2TemplateInspectionsTest.java
+++ b/AngularJS/test/org/angular2/inspections/Angular2TemplateInspectionsTest.java
@@ -71,6 +71,14 @@ public class Angular2TemplateInspectionsTest extends Angular2CodeInsightFixtureT
            "template-reference-variable-with-module.html", "component.ts", "template-reference-variable-module.ts");
   }
 
+  public void testDuplicateAttributeBinding() {
+    doTest(
+          AngularDuplicateAttributeInspection.class,
+          "duplicate-attribute.html",
+          "component.ts"
+    );
+  }
+
   public void testMatchingComponents() {
     doTest(AngularAmbiguousComponentTagInspection.class,
            "matching-components.html", "component.ts");

--- a/AngularJS/test/org/angular2/inspections/data/template/duplicate-attribute.html
+++ b/AngularJS/test/org/angular2/inspections/data/template/duplicate-attribute.html
@@ -1,0 +1,6 @@
+<my-comp
+  <error descr="The selector foo-dir is already specified">foo-dir</error>
+  <error descr="The selector foo-dir is already specified">foo-dir</error>
+  <error descr="The property binding for onFoo is already specified">[onFoo]</error>="'test'"
+  <error descr="The property binding for onFoo is already specified">onFoo</error>="test"
+></my-comp>


### PR DESCRIPTION
This PR implements an inspection that reports duplicate selectors and property bindings.
While they might work, it's better to have a visual error/warning.

Example
```
<my-comp
  foo-bar        // The selector foo-bar is already specified
  foo-bar        // The selector foo-bar is already specified
  foo="bar"      // The property binding for foo is already specified
  [foo]="'baz'"  // The property binding for foo is already specified
></my-comp>
```

The relevant issue is https://youtrack.jetbrains.com/issue/WEB-41425