### PR TITLE
Dart refactoring- verify SourceChange object returned in the ServerRefactoringDialog is not null before calling applySourceChange

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoringDialog.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoringDialog.java
@@ -105,14 +105,14 @@ public abstract class ServerRefactoringDialog<T extends ServerRefactoring> exten
     // Apply the change.
     final String error = WriteAction.compute(() -> {
       final SourceChange change = myRefactoring.getChange();
-      assert change != null;
-      try {
-        AssistUtils.applySourceChange(myProject, change, false, excludedIds);
+      if (change != null) {
+        try {
+          AssistUtils.applySourceChange(myProject, change, false, excludedIds);
+        }
+        catch (DartSourceEditException e) {
+          return e.getMessage();
+        }
       }
-      catch (DartSourceEditException e) {
-        return e.getMessage();
-      }
-
       return null;
     });
 


### PR DESCRIPTION
I have seen a few reports of nulls coming back from the DAS in this refactoring dialog only.