### PR TITLE
Dart plugin NPE fix, check for a null from the parent.getTextRange() call

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/findUsages/DartServerFindUsagesHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/findUsages/DartServerFindUsagesHandler.java
@@ -128,7 +128,7 @@ public class DartServerFindUsagesHandler extends FindUsagesHandler {
     while ((parent = element.getParent()) != null) {
       final TextRange parentRange = parent.getTextRange();
       if (rangeOk) {
-        if (!parentRange.equals(previousRange)) {
+        if (parentRange == null || !parentRange.equals(previousRange)) {
           return element; // range became bigger, return previous that matched better
         }
 


### PR DESCRIPTION
@alexander-doroshko I've seen a dozen or so such NPE stack traces in the past week