### PR TITLE
Update the Dart Analysis Server generated files and protocol to the latest version 1.27.3

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1555,7 +1555,7 @@ public class DartAnalysisServerService implements Disposable {
     final Ref<List<SourceFileEdit>> resultRef = new Ref<>();
 
     final CountDownLatch latch = new CountDownLatch(1);
-    server.edit_dartfix(filePaths, includedFixes, false, Collections.emptyList(), new DartfixConsumer() {
+    server.edit_dartfix(filePaths, includedFixes, false, false, Collections.emptyList(), null, new DartfixConsumer() {
       @Override
       public void computedDartfix(List<DartFixSuggestion> suggestions,
                                   List<DartFixSuggestion> otherSuggestions,

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetWidgetDescriptionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetWidgetDescriptionConsumer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server;
+
+import org.dartlang.analysis.server.protocol.FlutterWidgetProperty;
+import org.dartlang.analysis.server.protocol.RequestError;
+
+import java.util.List;
+
+/**
+ * The interface {@code GetWidgetDescriptionConsumer} defines the behavior of objects that consume a getWidgetDescription request.
+ *
+ * @coverage dart.server
+ */
+public interface GetWidgetDescriptionConsumer extends Consumer {
+  /**
+   * @param properties The list of properties of the widget. Some of the properties might be
+   *                   read only, when their editor is not set. This might be
+   *                   because they have type that we don't know how to edit, or for
+   *                   compound properties that work as containers for sub-properties.
+   */
+  public void computedGetWidgetDescription(List<FlutterWidgetProperty> properties);
+
+  /**
+   * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
+   * instead.
+   *
+   * @param requestError the reason why a result was not passed back
+   */
+  public void onError(RequestError requestError);
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SetWidgetPropertyValueConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SetWidgetPropertyValueConsumer.java
@@ -17,16 +17,15 @@ import org.dartlang.analysis.server.protocol.RequestError;
 import org.dartlang.analysis.server.protocol.SourceChange;
 
 /**
- * The interface {@code GetChangeAddForDesignTimeConstructorConsumer} defines the behavior of objects that consume
- * a getChangeAddForDesignTimeConstructor request.
+ * The interface {@code SetWidgetPropertyValueConsumer} defines the behavior of objects that consume a setWidgetPropertyValue request.
  *
  * @coverage dart.server
  */
-public interface GetChangeAddForDesignTimeConstructorConsumer extends Consumer {
+public interface SetWidgetPropertyValueConsumer extends Consumer {
   /**
-   * @param change The change that adds the forDesignTime() constructor. If the change cannot be produced, an error is returned.
+   * @param change The change that should be applied.
    */
-  public void computedChangeAddForDesignTimeConstructor(SourceChange change);
+  public void computedSetWidgetPropertyValue(SourceChange change);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -32,7 +32,7 @@ public interface AnalysisServer {
 
   /**
    * Add the given listener to the list of listeners that will receive notification when
-   * requests are made by an analysis server client.
+     * requests are made by an analysis server client.
    *
    * @param listener the listener to be added
    */
@@ -493,12 +493,23 @@ public interface AnalysisServer {
    * @param includedFixes A list of names indicating which fixes should be applied. If a name is
    *         specified that does not match the name of a known fix, an error of type UNKNOWN_FIX will
    *         be generated.
+   * @param includePedanticFixes A flag indicating that "pedantic" fixes should be applied.
    * @param includeRequiredFixes A flag indicating that "required" fixes should be applied.
    * @param excludedFixes A list of names indicating which fixes should not be applied. If a name is
    *         specified that does not match the name of a known fix, an error of type UNKNOWN_FIX will
    *         be generated.
+   * @param outputDir The absolute and normalized path to a directory to which non-nullability
+   *         migration output will be written. The output is only produced if the non-nullable fix is
+   *         included. Files in the directory might be overwritten, but no previously existing files
+   *         will be deleted.
    */
-  public void edit_dartfix(List<String> included, List<String> includedFixes, boolean includeRequiredFixes, List<String> excludedFixes, DartfixConsumer consumer);
+  public void edit_dartfix(List<String> included,
+                           List<String> includedFixes,
+                           boolean includePedanticFixes,
+                           boolean includeRequiredFixes,
+                           List<String> excludedFixes,
+                           String outputDir,
+                           DartfixConsumer consumer);
 
   /**
    * {@code edit.format}
@@ -596,7 +607,13 @@ public interface AnalysisServer {
    *         omitted if the refactoring does not require any options or if the values of those
    *         options are not known.
    */
-  public void edit_getRefactoring(String kind, String file, int offset, int length, boolean validateOnly, RefactoringOptions options, GetRefactoringConsumer consumer);
+  public void edit_getRefactoring(String kind,
+                                  String file,
+                                  int offset,
+                                  int length,
+                                  boolean validateOnly,
+                                  RefactoringOptions options,
+                                  GetRefactoringConsumer consumer);
 
   /**
    * {@code edit.getStatementCompletion}
@@ -733,7 +750,13 @@ public interface AnalysisServer {
    *         interesting sub-expressions in the given code. The client may provide an empty list, in
    *         this case the server will return completion suggestions.
    */
-  public void execution_getSuggestions(String code, int offset, String contextFile, int contextOffset, List<RuntimeCompletionVariable> variables, List<RuntimeCompletionExpression> expressions, GetRuntimeCompletionConsumer consumer);
+  public void execution_getSuggestions(String code,
+                                       int offset,
+                                       String contextFile,
+                                       int contextOffset,
+                                       List<RuntimeCompletionVariable> variables,
+                                       List<RuntimeCompletionExpression> expressions,
+                                       GetRuntimeCompletionConsumer consumer);
 
   /**
    * {@code execution.mapUri}
@@ -779,15 +802,17 @@ public interface AnalysisServer {
   public void execution_setSubscriptions(List<String> subscriptions);
 
   /**
-   * {@code flutter.getChangeAddForDesignTimeConstructor}
+   * {@code flutter.getWidgetDescription}
    *
-   * Return the change that adds the forDesignTime() constructor for the widget class at the given
-   * offset.
+   * Return the description of the widget instance at the given location.
    *
-   * @param file The file containing the code of the class.
-   * @param offset The offset of the class in the code.
+   * If the location does not have a support widget, an error of type
+   * FLUTTER_GET_WIDGET_DESCRIPTION_NO_WIDGET will be generated.
+   *
+   * @param file The file where the widget instance is created.
+   * @param offset The offset in the file where the widget instance is created.
    */
-  public void flutter_getChangeAddForDesignTimeConstructor(String file, int offset, GetChangeAddForDesignTimeConstructorConsumer consumer);
+  public void flutter_getWidgetDescription(String file, int offset, GetWidgetDescriptionConsumer consumer);
 
   /**
    * {@code flutter.setSubscriptions}
@@ -819,6 +844,26 @@ public interface AnalysisServer {
   public void flutter_setSubscriptions(Map<String, List<String>> subscriptions);
 
   /**
+   * {@code flutter.setWidgetPropertyValue}
+   *
+   * Set the value of a property, or remove it.
+   *
+   * The server will generate a change that the client should apply to the project to get the value
+   * of the property set to the new value. The complexity of the change might be from updating a
+   * single literal value in the code, to updating multiple files to get libraries imported, and new
+   * intermediate widgets instantiated.
+   *
+   * @param id The identifier of the property, previously returned as a part of a
+   *         FlutterWidgetProperty. An error of type FLUTTER_SET_WIDGET_PROPERTY_VALUE_INVALID_ID is
+   *         generated if the identifier is not valid.
+   * @param value The new value to set for the property. If absent, indicates that the property
+   *         should be removed. If the property corresponds to an optional parameter, the
+   *         corresponding named argument is removed. If the property isRequired is true,
+   *         FLUTTER_SET_WIDGET_PROPERTY_VALUE_IS_REQUIRED error is generated.
+   */
+  public void flutter_setWidgetPropertyValue(int id, FlutterWidgetPropertyValue value, SetWidgetPropertyValueConsumer consumer);
+
+  /**
    * Return {@code true} if the socket is open.
    */
   public boolean isSocketOpen();
@@ -839,7 +884,7 @@ public interface AnalysisServer {
 
   /**
    * Remove the given listener from the list of listeners that will receive notification when new
-   * analysis results become available.
+     * analysis results become available.
    *
    * @param listener the listener to be removed
    */
@@ -847,7 +892,7 @@ public interface AnalysisServer {
 
   /**
    * Remove the given listener from the list of listeners that will receive notification when
-   * requests are made by an analysis server client.
+     * requests are made by an analysis server client.
    *
    * @param listener the listener to be removed
    */
@@ -855,7 +900,7 @@ public interface AnalysisServer {
 
   /**
    * Remove the given listener from the list of listeners that will receive notification when
-   * responses are received by an analysis server client.
+     * responses are received by an analysis server client.
    *
    * @param listener the listener to be removed
    */

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -356,11 +356,15 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   @Override
   public void edit_dartfix(List<String> included,
                            List<String> includedFixes,
+                           boolean includePedanticFixes,
                            boolean includeRequiredFixes,
                            List<String> excludedFixes,
+                           String outputDir,
                            DartfixConsumer consumer) {
     String id = generateUniqueId();
-    sendRequestToServer(id, RequestUtilities.generateEditDartfix(id, included, includedFixes, false, includeRequiredFixes, excludedFixes), consumer);
+    sendRequestToServer(id, RequestUtilities
+                          .generateEditDartfix(id, included, includedFixes, includePedanticFixes, includeRequiredFixes, excludedFixes, outputDir),
+                        consumer);
   }
 
   @Override
@@ -489,12 +493,12 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
   }
 
   @Override
-  public void flutter_getChangeAddForDesignTimeConstructor(String file, int offset, GetChangeAddForDesignTimeConstructorConsumer consumer) {
-  }
+  public void flutter_getWidgetDescription(String file, int offset, GetWidgetDescriptionConsumer consumer) {}
 
   @Override
-  public void flutter_setSubscriptions(Map<String, List<String>> subscriptions) {
-  }
+  public void flutter_setSubscriptions(Map<String, List<String>> subscriptions) {}
+
+  public void flutter_setWidgetPropertyValue(int id, FlutterWidgetPropertyValue value, SetWidgetPropertyValueConsumer consumer) {}
 
   @Override
   public boolean isSocketOpen() {

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -48,6 +48,7 @@ public class RequestUtilities {
   private static final String LINE_LENGTH = "lineLength";
   private static final String METHOD = "method";
   private static final String OFFSET = "offset";
+  private static final String OUTPUT_DIR = "outputDir";
   private static final String PARAMS = "params";
   private static final String CLIENT_REQUEST_TIME = "clientRequestTime";
   private static final String SELECTION_LENGTH = "selectionLength";
@@ -521,7 +522,8 @@ public class RequestUtilities {
    *     "includedFixes": optional List&lt;String&gt;
    *     "includePedanticFixes": optional boolean
    *     "includeRequiredFixes": optional boolean
-   *     "excludedFixes": List&lt;FilePath&gt;
+   *     "excludedFixes": optional List&lt;FilePath&gt;
+   *     "outputDir": optional String
    *   }
    * }
    * </pre>
@@ -531,7 +533,8 @@ public class RequestUtilities {
                                                List<String> includedFixes,
                                                boolean includePedanticFixes,
                                                boolean includeRequiredFixes,
-                                               List<String> excludedFixes) {
+                                               List<String> excludedFixes,
+                                               String outputDir) {
     JsonObject params = new JsonObject();
     params.add(INCLUDED, buildJsonElement(included));
     if (includedFixes != null) {
@@ -541,6 +544,9 @@ public class RequestUtilities {
     params.addProperty(INCLUDED_REQUIRED_FIXES, includeRequiredFixes);
     if (excludedFixes != null) {
       params.add(EXCLUDED_FIXES, buildJsonElement(excludedFixes));
+    }
+    if (outputDir != null) {
+      params.addProperty(OUTPUT_DIR, outputDir);
     }
     return buildJsonObjectRequest(idValue, METHOD_EDIT_DARTFIX, params);
   }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AnalysisError.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/AnalysisError.java
@@ -74,6 +74,12 @@ public class AnalysisError {
   private final String url;
 
   /**
+   * Additional messages associated with this diagnostic that provide context to help the user
+   * understand the diagnostic.
+   */
+  private final List<DiagnosticMessage> contextMessages;
+
+  /**
    * A hint to indicate to interested clients that this error has an associated fix (or fixes). The
    * absence of this field implies there are not known to be fixes. Note that since the operation to
    * calculate whether fixes apply needs to be performant it is possible that complicated tests will
@@ -87,7 +93,7 @@ public class AnalysisError {
   /**
    * Constructor for {@link AnalysisError}.
    */
-  public AnalysisError(String severity, String type, Location location, String message, String correction, String code, String url, Boolean hasFix) {
+  public AnalysisError(String severity, String type, Location location, String message, String correction, String code, String url, List<DiagnosticMessage> contextMessages, Boolean hasFix) {
     this.severity = severity;
     this.type = type;
     this.location = location;
@@ -95,6 +101,7 @@ public class AnalysisError {
     this.correction = correction;
     this.code = code;
     this.url = url;
+    this.contextMessages = contextMessages;
     this.hasFix = hasFix;
   }
 
@@ -110,6 +117,7 @@ public class AnalysisError {
         ObjectUtilities.equals(other.correction, correction) &&
         ObjectUtilities.equals(other.code, code) &&
         ObjectUtilities.equals(other.url, url) &&
+        ObjectUtilities.equals(other.contextMessages, contextMessages) &&
         ObjectUtilities.equals(other.hasFix, hasFix);
     }
     return false;
@@ -121,10 +129,11 @@ public class AnalysisError {
     Location location = Location.fromJson(jsonObject.get("location").getAsJsonObject());
     String message = jsonObject.get("message").getAsString();
     String correction = jsonObject.get("correction") == null ? null : jsonObject.get("correction").getAsString();
-    String code = jsonObject.get("code") == null ? null : jsonObject.get("code").getAsString();
+    String code = jsonObject.get("code").getAsString();
     String url = jsonObject.get("url") == null ? null : jsonObject.get("url").getAsString();
+    List<DiagnosticMessage> contextMessages = jsonObject.get("contextMessages") == null ? null : DiagnosticMessage.fromJsonArray(jsonObject.get("contextMessages").getAsJsonArray());
     Boolean hasFix = jsonObject.get("hasFix") == null ? null : jsonObject.get("hasFix").getAsBoolean();
-    return new AnalysisError(severity, type, location, message, correction, code, url, hasFix);
+    return new AnalysisError(severity, type, location, message, correction, code, url, contextMessages, hasFix);
   }
 
   public static List<AnalysisError> fromJsonArray(JsonArray jsonArray) {
@@ -144,6 +153,14 @@ public class AnalysisError {
    */
   public String getCode() {
     return code;
+  }
+
+  /**
+   * Additional messages associated with this diagnostic that provide context to help the user
+   * understand the diagnostic.
+   */
+  public List<DiagnosticMessage> getContextMessages() {
+    return contextMessages;
   }
 
   /**
@@ -214,6 +231,7 @@ public class AnalysisError {
     builder.append(correction);
     builder.append(code);
     builder.append(url);
+    builder.append(contextMessages);
     builder.append(hasFix);
     return builder.toHashCode();
   }
@@ -230,6 +248,13 @@ public class AnalysisError {
     jsonObject.addProperty("code", code);
     if (url != null) {
       jsonObject.addProperty("url", url);
+    }
+    if (contextMessages != null) {
+      JsonArray jsonArrayContextMessages = new JsonArray();
+      for (DiagnosticMessage elt : contextMessages) {
+        jsonArrayContextMessages.add(elt.toJson());
+      }
+      jsonObject.add("contextMessages", jsonArrayContextMessages);
     }
     if (hasFix != null) {
       jsonObject.addProperty("hasFix", hasFix);
@@ -255,6 +280,8 @@ public class AnalysisError {
     builder.append(code + ", ");
     builder.append("url=");
     builder.append(url + ", ");
+    builder.append("contextMessages=");
+    builder.append(StringUtils.join(contextMessages, ", ") + ", ");
     builder.append("hasFix=");
     builder.append(hasFix);
     builder.append("]");

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionService.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/CompletionService.java
@@ -16,10 +16,12 @@ package org.dartlang.analysis.server.protocol;
 public class CompletionService {
 
   /**
-   * The client will receive notifications once subscribed with completion suggestion sets from the
-   * libraries of interest. The client should keep an up-to-date record of these in memory so that it
-   * will be able to union these candidates with other completion suggestions when applicable at
-   * completion time.
+   * The client will receive availableSuggestions notifications once subscribed with completion
+   * suggestion sets from the libraries of interest. The client should keep an up-to-date record of
+   * these in memory so that it will be able to union these candidates with other completion
+   * suggestions when applicable at completion time.
+   *
+   * The client will also receive existingImports notifications.
    */
   public static final String AVAILABLE_SUGGESTION_SETS = "AVAILABLE_SUGGESTION_SETS";
 

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/DiagnosticMessage.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/DiagnosticMessage.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A message associated with a diagnostic.
+ *
+ * For example, if the diagnostic is reporting that a variable has been referenced before it was
+ * declared, it might have a diagnostic message that indicates where the variable is declared.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class DiagnosticMessage {
+
+  public static final DiagnosticMessage[] EMPTY_ARRAY = new DiagnosticMessage[0];
+
+  public static final List<DiagnosticMessage> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The message to be displayed to the user.
+   */
+  private final String message;
+
+  /**
+   * The location associated with or referenced by the message. Clients should provide the ability to
+   * navigate to the location.
+   */
+  private final Location location;
+
+  /**
+   * Constructor for {@link DiagnosticMessage}.
+   */
+  public DiagnosticMessage(String message, Location location) {
+    this.message = message;
+    this.location = location;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof DiagnosticMessage) {
+      DiagnosticMessage other = (DiagnosticMessage) obj;
+      return
+        ObjectUtilities.equals(other.message, message) &&
+        ObjectUtilities.equals(other.location, location);
+    }
+    return false;
+  }
+
+  public static DiagnosticMessage fromJson(JsonObject jsonObject) {
+    String message = jsonObject.get("message").getAsString();
+    Location location = Location.fromJson(jsonObject.get("location").getAsJsonObject());
+    return new DiagnosticMessage(message, location);
+  }
+
+  public static List<DiagnosticMessage> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<DiagnosticMessage> list = new ArrayList<DiagnosticMessage>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The location associated with or referenced by the message. Clients should provide the ability to
+   * navigate to the location.
+   */
+  public Location getLocation() {
+    return location;
+  }
+
+  /**
+   * The message to be displayed to the user.
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(message);
+    builder.append(location);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("message", message);
+    jsonObject.add("location", location.toJson());
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("message=");
+    builder.append(message + ", ");
+    builder.append("location=");
+    builder.append(location);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ExistingImport.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ExistingImport.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Information about an existing import, with elements that it provides.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class ExistingImport {
+
+  public static final ExistingImport[] EMPTY_ARRAY = new ExistingImport[0];
+
+  public static final List<ExistingImport> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The URI of the imported library. It is an index in the strings field, in the enclosing
+   * ExistingImports and its ImportedElementSet object.
+   */
+  private final int uri;
+
+  /**
+   * The list of indexes of elements, in the enclosing ExistingImports object.
+   */
+  private final int[] elements;
+
+  /**
+   * Constructor for {@link ExistingImport}.
+   */
+  public ExistingImport(int uri, int[] elements) {
+    this.uri = uri;
+    this.elements = elements;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof ExistingImport) {
+      ExistingImport other = (ExistingImport) obj;
+      return
+        other.uri == uri &&
+        Arrays.equals(other.elements, elements);
+    }
+    return false;
+  }
+
+  public static ExistingImport fromJson(JsonObject jsonObject) {
+    int uri = jsonObject.get("uri").getAsInt();
+    int[] elements = JsonUtilities.decodeIntArray(jsonObject.get("elements").getAsJsonArray());
+    return new ExistingImport(uri, elements);
+  }
+
+  public static List<ExistingImport> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<ExistingImport> list = new ArrayList<ExistingImport>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The list of indexes of elements, in the enclosing ExistingImports object.
+   */
+  public int[] getElements() {
+    return elements;
+  }
+
+  /**
+   * The URI of the imported library. It is an index in the strings field, in the enclosing
+   * ExistingImports and its ImportedElementSet object.
+   */
+  public int getUri() {
+    return uri;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(uri);
+    builder.append(elements);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("uri", uri);
+    JsonArray jsonArrayElements = new JsonArray();
+    for (int elt : elements) {
+      jsonArrayElements.add(new JsonPrimitive(elt));
+    }
+    jsonObject.add("elements", jsonArrayElements);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("uri=");
+    builder.append(uri + ", ");
+    builder.append("elements=");
+    builder.append(StringUtils.join(elements, ", "));
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ExistingImports.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ExistingImports.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Information about all existing imports in a library.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class ExistingImports {
+
+  public static final ExistingImports[] EMPTY_ARRAY = new ExistingImports[0];
+
+  public static final List<ExistingImports> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The set of all unique imported elements for all imports.
+   */
+  private final ImportedElementSet elements;
+
+  /**
+   * The list of imports in the library.
+   */
+  private final List<ExistingImport> imports;
+
+  /**
+   * Constructor for {@link ExistingImports}.
+   */
+  public ExistingImports(ImportedElementSet elements, List<ExistingImport> imports) {
+    this.elements = elements;
+    this.imports = imports;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof ExistingImports) {
+      ExistingImports other = (ExistingImports) obj;
+      return
+        ObjectUtilities.equals(other.elements, elements) &&
+        ObjectUtilities.equals(other.imports, imports);
+    }
+    return false;
+  }
+
+  public static ExistingImports fromJson(JsonObject jsonObject) {
+    ImportedElementSet elements = ImportedElementSet.fromJson(jsonObject.get("elements").getAsJsonObject());
+    List<ExistingImport> imports = ExistingImport.fromJsonArray(jsonObject.get("imports").getAsJsonArray());
+    return new ExistingImports(elements, imports);
+  }
+
+  public static List<ExistingImports> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<ExistingImports> list = new ArrayList<ExistingImports>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The set of all unique imported elements for all imports.
+   */
+  public ImportedElementSet getElements() {
+    return elements;
+  }
+
+  /**
+   * The list of imports in the library.
+   */
+  public List<ExistingImport> getImports() {
+    return imports;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(elements);
+    builder.append(imports);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.add("elements", elements.toJson());
+    JsonArray jsonArrayImports = new JsonArray();
+    for (ExistingImport elt : imports) {
+      jsonArrayImports.add(elt.toJson());
+    }
+    jsonObject.add("imports", jsonArrayImports);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("elements=");
+    builder.append(elements + ", ");
+    builder.append("imports=");
+    builder.append(StringUtils.join(imports, ", "));
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterOutline.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterOutline.java
@@ -104,46 +104,9 @@ public class FlutterOutline {
   private final List<FlutterOutline> children;
 
   /**
-   * If the node is a widget, and it is instrumented, the unique identifier of this widget, that can
-   * be used to associate rendering information with this node.
-   */
-  private final Integer id;
-
-  /**
-   * True if the node is a widget class, so it can potentially be rendered, even if it does not yet
-   * have the rendering constructor. This field is omitted if the node is not a widget class.
-   */
-  private final Boolean isWidgetClass;
-
-  /**
-   * If the node is a widget class that can be rendered for IDE, the name of the constructor that
-   * should be used to instantiate the widget. Empty string for default constructor. Absent if the
-   * node is not a widget class that can be rendered.
-   */
-  private final String renderConstructor;
-
-  /**
-   * If the node is a StatefulWidget, and its state class is defined in the same file, the name of
-   * the state class.
-   */
-  private final String stateClassName;
-
-  /**
-   * If the node is a StatefulWidget that can be rendered, and its state class is defined in the same
-   * file, the offset of the state class code in the file.
-   */
-  private final Integer stateOffset;
-
-  /**
-   * If the node is a StatefulWidget that can be rendered, and its state class is defined in the same
-   * file, the length of the state class code in the file.
-   */
-  private final Integer stateLength;
-
-  /**
    * Constructor for {@link FlutterOutline}.
    */
-  public FlutterOutline(String kind, int offset, int length, int codeOffset, int codeLength, String label, Element dartElement, List<FlutterOutlineAttribute> attributes, String className, String parentAssociationLabel, String variableName, List<FlutterOutline> children, Integer id, Boolean isWidgetClass, String renderConstructor, String stateClassName, Integer stateOffset, Integer stateLength) {
+  public FlutterOutline(String kind, int offset, int length, int codeOffset, int codeLength, String label, Element dartElement, List<FlutterOutlineAttribute> attributes, String className, String parentAssociationLabel, String variableName, List<FlutterOutline> children) {
     this.kind = kind;
     this.offset = offset;
     this.length = length;
@@ -156,12 +119,6 @@ public class FlutterOutline {
     this.parentAssociationLabel = parentAssociationLabel;
     this.variableName = variableName;
     this.children = children;
-    this.id = id;
-    this.isWidgetClass = isWidgetClass;
-    this.renderConstructor = renderConstructor;
-    this.stateClassName = stateClassName;
-    this.stateOffset = stateOffset;
-    this.stateLength = stateLength;
   }
 
   @Override
@@ -180,13 +137,7 @@ public class FlutterOutline {
         ObjectUtilities.equals(other.className, className) &&
         ObjectUtilities.equals(other.parentAssociationLabel, parentAssociationLabel) &&
         ObjectUtilities.equals(other.variableName, variableName) &&
-        ObjectUtilities.equals(other.children, children) &&
-        ObjectUtilities.equals(other.id, id) &&
-        ObjectUtilities.equals(other.isWidgetClass, isWidgetClass) &&
-        ObjectUtilities.equals(other.renderConstructor, renderConstructor) &&
-        ObjectUtilities.equals(other.stateClassName, stateClassName) &&
-        ObjectUtilities.equals(other.stateOffset, stateOffset) &&
-        ObjectUtilities.equals(other.stateLength, stateLength);
+        ObjectUtilities.equals(other.children, children);
     }
     return false;
   }
@@ -204,13 +155,7 @@ public class FlutterOutline {
     String parentAssociationLabel = jsonObject.get("parentAssociationLabel") == null ? null : jsonObject.get("parentAssociationLabel").getAsString();
     String variableName = jsonObject.get("variableName") == null ? null : jsonObject.get("variableName").getAsString();
     List<FlutterOutline> children = jsonObject.get("children") == null ? null : FlutterOutline.fromJsonArray(jsonObject.get("children").getAsJsonArray());
-    Integer id = jsonObject.get("id") == null ? null : jsonObject.get("id").getAsInt();
-    Boolean isWidgetClass = jsonObject.get("isWidgetClass") == null ? null : jsonObject.get("isWidgetClass").getAsBoolean();
-    String renderConstructor = jsonObject.get("renderConstructor") == null ? null : jsonObject.get("renderConstructor").getAsString();
-    String stateClassName = jsonObject.get("stateClassName") == null ? null : jsonObject.get("stateClassName").getAsString();
-    Integer stateOffset = jsonObject.get("stateOffset") == null ? null : jsonObject.get("stateOffset").getAsInt();
-    Integer stateLength = jsonObject.get("stateLength") == null ? null : jsonObject.get("stateLength").getAsInt();
-    return new FlutterOutline(kind, offset, length, codeOffset, codeLength, label, dartElement, attributes, className, parentAssociationLabel, variableName, children, id, isWidgetClass, renderConstructor, stateClassName, stateOffset, stateLength);
+    return new FlutterOutline(kind, offset, length, codeOffset, codeLength, label, dartElement, attributes, className, parentAssociationLabel, variableName, children);
   }
 
   public static List<FlutterOutline> fromJsonArray(JsonArray jsonArray) {
@@ -272,22 +217,6 @@ public class FlutterOutline {
   }
 
   /**
-   * If the node is a widget, and it is instrumented, the unique identifier of this widget, that can
-   * be used to associate rendering information with this node.
-   */
-  public Integer getId() {
-    return id;
-  }
-
-  /**
-   * True if the node is a widget class, so it can potentially be rendered, even if it does not yet
-   * have the rendering constructor. This field is omitted if the node is not a widget class.
-   */
-  public Boolean getIsWidgetClass() {
-    return isWidgetClass;
-  }
-
-  /**
    * The kind of the node.
    */
   public String getKind() {
@@ -327,39 +256,6 @@ public class FlutterOutline {
   }
 
   /**
-   * If the node is a widget class that can be rendered for IDE, the name of the constructor that
-   * should be used to instantiate the widget. Empty string for default constructor. Absent if the
-   * node is not a widget class that can be rendered.
-   */
-  public String getRenderConstructor() {
-    return renderConstructor;
-  }
-
-  /**
-   * If the node is a StatefulWidget, and its state class is defined in the same file, the name of
-   * the state class.
-   */
-  public String getStateClassName() {
-    return stateClassName;
-  }
-
-  /**
-   * If the node is a StatefulWidget that can be rendered, and its state class is defined in the same
-   * file, the length of the state class code in the file.
-   */
-  public Integer getStateLength() {
-    return stateLength;
-  }
-
-  /**
-   * If the node is a StatefulWidget that can be rendered, and its state class is defined in the same
-   * file, the offset of the state class code in the file.
-   */
-  public Integer getStateOffset() {
-    return stateOffset;
-  }
-
-  /**
    * If FlutterOutlineKind.VARIABLE, the name of the variable.
    */
   public String getVariableName() {
@@ -381,12 +277,6 @@ public class FlutterOutline {
     builder.append(parentAssociationLabel);
     builder.append(variableName);
     builder.append(children);
-    builder.append(id);
-    builder.append(isWidgetClass);
-    builder.append(renderConstructor);
-    builder.append(stateClassName);
-    builder.append(stateOffset);
-    builder.append(stateLength);
     return builder.toHashCode();
   }
 
@@ -426,24 +316,6 @@ public class FlutterOutline {
       }
       jsonObject.add("children", jsonArrayChildren);
     }
-    if (id != null) {
-      jsonObject.addProperty("id", id);
-    }
-    if (isWidgetClass != null) {
-      jsonObject.addProperty("isWidgetClass", isWidgetClass);
-    }
-    if (renderConstructor != null) {
-      jsonObject.addProperty("renderConstructor", renderConstructor);
-    }
-    if (stateClassName != null) {
-      jsonObject.addProperty("stateClassName", stateClassName);
-    }
-    if (stateOffset != null) {
-      jsonObject.addProperty("stateOffset", stateOffset);
-    }
-    if (stateLength != null) {
-      jsonObject.addProperty("stateLength", stateLength);
-    }
     return jsonObject;
   }
 
@@ -474,19 +346,7 @@ public class FlutterOutline {
     builder.append("variableName=");
     builder.append(variableName + ", ");
     builder.append("children=");
-    builder.append(StringUtils.join(children, ", ") + ", ");
-    builder.append("id=");
-    builder.append(id + ", ");
-    builder.append("isWidgetClass=");
-    builder.append(isWidgetClass + ", ");
-    builder.append("renderConstructor=");
-    builder.append(renderConstructor + ", ");
-    builder.append("stateClassName=");
-    builder.append(stateClassName + ", ");
-    builder.append("stateOffset=");
-    builder.append(stateOffset + ", ");
-    builder.append("stateLength=");
-    builder.append(stateLength);
+    builder.append(StringUtils.join(children, ", "));
     builder.append("]");
     return builder.toString();
   }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterOutlineAttribute.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterOutlineAttribute.java
@@ -65,14 +65,29 @@ public class FlutterOutlineAttribute {
   private final String literalValueString;
 
   /**
+   * If the attribute is a named argument, the location of the name, without the colon.
+   */
+  private final Location nameLocation;
+
+  /**
+   * The location of the value.
+   *
+   * This field is always available, but marked optional for backward compatibility between new
+   * clients with older servers.
+   */
+  private final Location valueLocation;
+
+  /**
    * Constructor for {@link FlutterOutlineAttribute}.
    */
-  public FlutterOutlineAttribute(String name, String label, Boolean literalValueBoolean, Integer literalValueInteger, String literalValueString) {
+  public FlutterOutlineAttribute(String name, String label, Boolean literalValueBoolean, Integer literalValueInteger, String literalValueString, Location nameLocation, Location valueLocation) {
     this.name = name;
     this.label = label;
     this.literalValueBoolean = literalValueBoolean;
     this.literalValueInteger = literalValueInteger;
     this.literalValueString = literalValueString;
+    this.nameLocation = nameLocation;
+    this.valueLocation = valueLocation;
   }
 
   @Override
@@ -84,7 +99,9 @@ public class FlutterOutlineAttribute {
         ObjectUtilities.equals(other.label, label) &&
         ObjectUtilities.equals(other.literalValueBoolean, literalValueBoolean) &&
         ObjectUtilities.equals(other.literalValueInteger, literalValueInteger) &&
-        ObjectUtilities.equals(other.literalValueString, literalValueString);
+        ObjectUtilities.equals(other.literalValueString, literalValueString) &&
+        ObjectUtilities.equals(other.nameLocation, nameLocation) &&
+        ObjectUtilities.equals(other.valueLocation, valueLocation);
     }
     return false;
   }
@@ -95,7 +112,9 @@ public class FlutterOutlineAttribute {
     Boolean literalValueBoolean = jsonObject.get("literalValueBoolean") == null ? null : jsonObject.get("literalValueBoolean").getAsBoolean();
     Integer literalValueInteger = jsonObject.get("literalValueInteger") == null ? null : jsonObject.get("literalValueInteger").getAsInt();
     String literalValueString = jsonObject.get("literalValueString") == null ? null : jsonObject.get("literalValueString").getAsString();
-    return new FlutterOutlineAttribute(name, label, literalValueBoolean, literalValueInteger, literalValueString);
+    Location nameLocation = jsonObject.get("nameLocation") == null ? null : Location.fromJson(jsonObject.get("nameLocation").getAsJsonObject());
+    Location valueLocation = jsonObject.get("valueLocation") == null ? null : Location.fromJson(jsonObject.get("valueLocation").getAsJsonObject());
+    return new FlutterOutlineAttribute(name, label, literalValueBoolean, literalValueInteger, literalValueString, nameLocation, valueLocation);
   }
 
   public static List<FlutterOutlineAttribute> fromJsonArray(JsonArray jsonArray) {
@@ -149,6 +168,23 @@ public class FlutterOutlineAttribute {
     return name;
   }
 
+  /**
+   * If the attribute is a named argument, the location of the name, without the colon.
+   */
+  public Location getNameLocation() {
+    return nameLocation;
+  }
+
+  /**
+   * The location of the value.
+   *
+   * This field is always available, but marked optional for backward compatibility between new
+   * clients with older servers.
+   */
+  public Location getValueLocation() {
+    return valueLocation;
+  }
+
   @Override
   public int hashCode() {
     HashCodeBuilder builder = new HashCodeBuilder();
@@ -157,6 +193,8 @@ public class FlutterOutlineAttribute {
     builder.append(literalValueBoolean);
     builder.append(literalValueInteger);
     builder.append(literalValueString);
+    builder.append(nameLocation);
+    builder.append(valueLocation);
     return builder.toHashCode();
   }
 
@@ -172,6 +210,12 @@ public class FlutterOutlineAttribute {
     }
     if (literalValueString != null) {
       jsonObject.addProperty("literalValueString", literalValueString);
+    }
+    if (nameLocation != null) {
+      jsonObject.add("nameLocation", nameLocation.toJson());
+    }
+    if (valueLocation != null) {
+      jsonObject.add("valueLocation", valueLocation.toJson());
     }
     return jsonObject;
   }
@@ -189,7 +233,11 @@ public class FlutterOutlineAttribute {
     builder.append("literalValueInteger=");
     builder.append(literalValueInteger + ", ");
     builder.append("literalValueString=");
-    builder.append(literalValueString);
+    builder.append(literalValueString + ", ");
+    builder.append("nameLocation=");
+    builder.append(nameLocation + ", ");
+    builder.append("valueLocation=");
+    builder.append(valueLocation);
     builder.append("]");
     return builder.toString();
   }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetProperty.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetProperty.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A property of a Flutter widget.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class FlutterWidgetProperty {
+
+  public static final FlutterWidgetProperty[] EMPTY_ARRAY = new FlutterWidgetProperty[0];
+
+  public static final List<FlutterWidgetProperty> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The documentation of the property to show to the user. Omitted if the server does not know the
+   * documentation, e.g. because the corresponding field is not documented.
+   */
+  private final String documentation;
+
+  /**
+   * If the value of this property is set, the Dart code of the expression of this property.
+   */
+  private final String expression;
+
+  /**
+   * The unique identifier of the property, must be passed back to the server when updating the
+   * property value. Identifiers become invalid on any source code change.
+   */
+  private final int id;
+
+  /**
+   * True if the property is required, e.g. because it corresponds to a required parameter of a
+   * constructor.
+   */
+  private final boolean isRequired;
+
+  /**
+   * If the property expression is a concrete value (e.g. a literal, or an enum constant), then it is
+   * safe to replace the expression with another concrete value. In this case this field is true.
+   * Otherwise, for example when the expression is a reference to a field, so that its value is
+   * provided from outside, this field is false.
+   */
+  private final boolean isSafeToUpdate;
+
+  /**
+   * The name of the property to display to the user.
+   */
+  private final String name;
+
+  /**
+   * The list of children properties, if any. For example any property of type EdgeInsets will have
+   * four children properties of type double - left / top / right / bottom.
+   */
+  private final List<FlutterWidgetProperty> children;
+
+  /**
+   * The editor that should be used by the client. This field is omitted if the server does not know
+   * the editor for this property, for example because it does not have one of the supported types.
+   */
+  private final FlutterWidgetPropertyEditor editor;
+
+  /**
+   * If the expression is set, and the server knows the value of the expression, this field is set.
+   */
+  private final FlutterWidgetPropertyValue value;
+
+  /**
+   * Constructor for {@link FlutterWidgetProperty}.
+   */
+  public FlutterWidgetProperty(String documentation, String expression, int id, boolean isRequired, boolean isSafeToUpdate, String name, List<FlutterWidgetProperty> children, FlutterWidgetPropertyEditor editor, FlutterWidgetPropertyValue value) {
+    this.documentation = documentation;
+    this.expression = expression;
+    this.id = id;
+    this.isRequired = isRequired;
+    this.isSafeToUpdate = isSafeToUpdate;
+    this.name = name;
+    this.children = children;
+    this.editor = editor;
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof FlutterWidgetProperty) {
+      FlutterWidgetProperty other = (FlutterWidgetProperty) obj;
+      return
+        ObjectUtilities.equals(other.documentation, documentation) &&
+        ObjectUtilities.equals(other.expression, expression) &&
+        other.id == id &&
+        other.isRequired == isRequired &&
+        other.isSafeToUpdate == isSafeToUpdate &&
+        ObjectUtilities.equals(other.name, name) &&
+        ObjectUtilities.equals(other.children, children) &&
+        ObjectUtilities.equals(other.editor, editor) &&
+        ObjectUtilities.equals(other.value, value);
+    }
+    return false;
+  }
+
+  public static FlutterWidgetProperty fromJson(JsonObject jsonObject) {
+    String documentation = jsonObject.get("documentation") == null ? null : jsonObject.get("documentation").getAsString();
+    String expression = jsonObject.get("expression") == null ? null : jsonObject.get("expression").getAsString();
+    int id = jsonObject.get("id").getAsInt();
+    boolean isRequired = jsonObject.get("isRequired").getAsBoolean();
+    boolean isSafeToUpdate = jsonObject.get("isSafeToUpdate").getAsBoolean();
+    String name = jsonObject.get("name").getAsString();
+    List<FlutterWidgetProperty> children = jsonObject.get("children") == null ? null : FlutterWidgetProperty.fromJsonArray(jsonObject.get("children").getAsJsonArray());
+    FlutterWidgetPropertyEditor editor = jsonObject.get("editor") == null ? null : FlutterWidgetPropertyEditor.fromJson(jsonObject.get("editor").getAsJsonObject());
+    FlutterWidgetPropertyValue value = jsonObject.get("value") == null ? null : FlutterWidgetPropertyValue.fromJson(jsonObject.get("value").getAsJsonObject());
+    return new FlutterWidgetProperty(documentation, expression, id, isRequired, isSafeToUpdate, name, children, editor, value);
+  }
+
+  public static List<FlutterWidgetProperty> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<FlutterWidgetProperty> list = new ArrayList<FlutterWidgetProperty>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The list of children properties, if any. For example any property of type EdgeInsets will have
+   * four children properties of type double - left / top / right / bottom.
+   */
+  public List<FlutterWidgetProperty> getChildren() {
+    return children;
+  }
+
+  /**
+   * The documentation of the property to show to the user. Omitted if the server does not know the
+   * documentation, e.g. because the corresponding field is not documented.
+   */
+  public String getDocumentation() {
+    return documentation;
+  }
+
+  /**
+   * The editor that should be used by the client. This field is omitted if the server does not know
+   * the editor for this property, for example because it does not have one of the supported types.
+   */
+  public FlutterWidgetPropertyEditor getEditor() {
+    return editor;
+  }
+
+  /**
+   * If the value of this property is set, the Dart code of the expression of this property.
+   */
+  public String getExpression() {
+    return expression;
+  }
+
+  /**
+   * The unique identifier of the property, must be passed back to the server when updating the
+   * property value. Identifiers become invalid on any source code change.
+   */
+  public int getId() {
+    return id;
+  }
+
+  /**
+   * True if the property is required, e.g. because it corresponds to a required parameter of a
+   * constructor.
+   */
+  public boolean isRequired() {
+    return isRequired;
+  }
+
+  /**
+   * If the property expression is a concrete value (e.g. a literal, or an enum constant), then it is
+   * safe to replace the expression with another concrete value. In this case this field is true.
+   * Otherwise, for example when the expression is a reference to a field, so that its value is
+   * provided from outside, this field is false.
+   */
+  public boolean isSafeToUpdate() {
+    return isSafeToUpdate;
+  }
+
+  /**
+   * The name of the property to display to the user.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * If the expression is set, and the server knows the value of the expression, this field is set.
+   */
+  public FlutterWidgetPropertyValue getValue() {
+    return value;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(documentation);
+    builder.append(expression);
+    builder.append(id);
+    builder.append(isRequired);
+    builder.append(isSafeToUpdate);
+    builder.append(name);
+    builder.append(children);
+    builder.append(editor);
+    builder.append(value);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    if (documentation != null) {
+      jsonObject.addProperty("documentation", documentation);
+    }
+    if (expression != null) {
+      jsonObject.addProperty("expression", expression);
+    }
+    jsonObject.addProperty("id", id);
+    jsonObject.addProperty("isRequired", isRequired);
+    jsonObject.addProperty("isSafeToUpdate", isSafeToUpdate);
+    jsonObject.addProperty("name", name);
+    if (children != null) {
+      JsonArray jsonArrayChildren = new JsonArray();
+      for (FlutterWidgetProperty elt : children) {
+        jsonArrayChildren.add(elt.toJson());
+      }
+      jsonObject.add("children", jsonArrayChildren);
+    }
+    if (editor != null) {
+      jsonObject.add("editor", editor.toJson());
+    }
+    if (value != null) {
+      jsonObject.add("value", value.toJson());
+    }
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("documentation=");
+    builder.append(documentation + ", ");
+    builder.append("expression=");
+    builder.append(expression + ", ");
+    builder.append("id=");
+    builder.append(id + ", ");
+    builder.append("isRequired=");
+    builder.append(isRequired + ", ");
+    builder.append("isSafeToUpdate=");
+    builder.append(isSafeToUpdate + ", ");
+    builder.append("name=");
+    builder.append(name + ", ");
+    builder.append("children=");
+    builder.append(StringUtils.join(children, ", ") + ", ");
+    builder.append("editor=");
+    builder.append(editor + ", ");
+    builder.append("value=");
+    builder.append(value);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyEditor.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyEditor.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * An editor for a property of a Flutter widget.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class FlutterWidgetPropertyEditor {
+
+  public static final FlutterWidgetPropertyEditor[] EMPTY_ARRAY = new FlutterWidgetPropertyEditor[0];
+
+  public static final List<FlutterWidgetPropertyEditor> EMPTY_LIST = Lists.newArrayList();
+
+  private final String kind;
+
+  private final List<FlutterWidgetPropertyValueEnumItem> enumItems;
+
+  /**
+   * Constructor for {@link FlutterWidgetPropertyEditor}.
+   */
+  public FlutterWidgetPropertyEditor(String kind, List<FlutterWidgetPropertyValueEnumItem> enumItems) {
+    this.kind = kind;
+    this.enumItems = enumItems;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof FlutterWidgetPropertyEditor) {
+      FlutterWidgetPropertyEditor other = (FlutterWidgetPropertyEditor) obj;
+      return
+        ObjectUtilities.equals(other.kind, kind) &&
+        ObjectUtilities.equals(other.enumItems, enumItems);
+    }
+    return false;
+  }
+
+  public static FlutterWidgetPropertyEditor fromJson(JsonObject jsonObject) {
+    String kind = jsonObject.get("kind").getAsString();
+    List<FlutterWidgetPropertyValueEnumItem> enumItems = jsonObject.get("enumItems") == null ? null : FlutterWidgetPropertyValueEnumItem.fromJsonArray(jsonObject.get("enumItems").getAsJsonArray());
+    return new FlutterWidgetPropertyEditor(kind, enumItems);
+  }
+
+  public static List<FlutterWidgetPropertyEditor> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<FlutterWidgetPropertyEditor> list = new ArrayList<FlutterWidgetPropertyEditor>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  public List<FlutterWidgetPropertyValueEnumItem> getEnumItems() {
+    return enumItems;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(kind);
+    builder.append(enumItems);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("kind", kind);
+    if (enumItems != null) {
+      JsonArray jsonArrayEnumItems = new JsonArray();
+      for (FlutterWidgetPropertyValueEnumItem elt : enumItems) {
+        jsonArrayEnumItems.add(elt.toJson());
+      }
+      jsonObject.add("enumItems", jsonArrayEnumItems);
+    }
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("kind=");
+    builder.append(kind + ", ");
+    builder.append("enumItems=");
+    builder.append(StringUtils.join(enumItems, ", "));
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyEditorKind.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyEditorKind.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+/**
+ * An enumeration of the kinds of property editors.
+ *
+ * @coverage dart.server.generated.types
+ */
+public class FlutterWidgetPropertyEditorKind {
+
+  /**
+   * The editor for a property of type bool.
+   */
+  public static final String BOOL = "BOOL";
+
+  /**
+   * The editor for a property of the type double.
+   */
+  public static final String DOUBLE = "DOUBLE";
+
+  /**
+   * The editor for choosing an item of an enumeration, see the enumItems field of
+   * FlutterWidgetPropertyEditor.
+   */
+  public static final String ENUM = "ENUM";
+
+  /**
+   * The editor for either choosing a pre-defined item from a list of provided static field
+   * references (like ENUM), or specifying a free-form expression.
+   */
+  public static final String ENUM_LIKE = "ENUM_LIKE";
+
+  /**
+   * The editor for a property of type int.
+   */
+  public static final String INT = "INT";
+
+  /**
+   * The editor for a property of the type String.
+   */
+  public static final String STRING = "STRING";
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyValue.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyValue.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A value of a property of a Flutter widget.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class FlutterWidgetPropertyValue {
+
+  public static final FlutterWidgetPropertyValue[] EMPTY_ARRAY = new FlutterWidgetPropertyValue[0];
+
+  public static final List<FlutterWidgetPropertyValue> EMPTY_LIST = Lists.newArrayList();
+
+  private final Boolean boolValue;
+
+  private final Double doubleValue;
+
+  private final Integer intValue;
+
+  private final String stringValue;
+
+  private final FlutterWidgetPropertyValueEnumItem enumValue;
+
+  /**
+   * A free-form expression, which will be used as the value as is.
+   */
+  private final String expression;
+
+  /**
+   * Constructor for {@link FlutterWidgetPropertyValue}.
+   */
+  public FlutterWidgetPropertyValue(Boolean boolValue, Double doubleValue, Integer intValue, String stringValue, FlutterWidgetPropertyValueEnumItem enumValue, String expression) {
+    this.boolValue = boolValue;
+    this.doubleValue = doubleValue;
+    this.intValue = intValue;
+    this.stringValue = stringValue;
+    this.enumValue = enumValue;
+    this.expression = expression;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof FlutterWidgetPropertyValue) {
+      FlutterWidgetPropertyValue other = (FlutterWidgetPropertyValue) obj;
+      return
+        ObjectUtilities.equals(other.boolValue, boolValue) &&
+        ObjectUtilities.equals(other.doubleValue, doubleValue) &&
+        ObjectUtilities.equals(other.intValue, intValue) &&
+        ObjectUtilities.equals(other.stringValue, stringValue) &&
+        ObjectUtilities.equals(other.enumValue, enumValue) &&
+        ObjectUtilities.equals(other.expression, expression);
+    }
+    return false;
+  }
+
+  public static FlutterWidgetPropertyValue fromJson(JsonObject jsonObject) {
+    Boolean boolValue = jsonObject.get("boolValue") == null ? null : jsonObject.get("boolValue").getAsBoolean();
+    Double doubleValue = jsonObject.get("doubleValue") == null ? null : jsonObject.get("doubleValue").getAsDouble();
+    Integer intValue = jsonObject.get("intValue") == null ? null : jsonObject.get("intValue").getAsInt();
+    String stringValue = jsonObject.get("stringValue") == null ? null : jsonObject.get("stringValue").getAsString();
+    FlutterWidgetPropertyValueEnumItem enumValue = jsonObject.get("enumValue") == null ? null : FlutterWidgetPropertyValueEnumItem.fromJson(jsonObject.get("enumValue").getAsJsonObject());
+    String expression = jsonObject.get("expression") == null ? null : jsonObject.get("expression").getAsString();
+    return new FlutterWidgetPropertyValue(boolValue, doubleValue, intValue, stringValue, enumValue, expression);
+  }
+
+  public static List<FlutterWidgetPropertyValue> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<FlutterWidgetPropertyValue> list = new ArrayList<FlutterWidgetPropertyValue>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  public Boolean getBoolValue() {
+    return boolValue;
+  }
+
+  public Double getDoubleValue() {
+    return doubleValue;
+  }
+
+  public FlutterWidgetPropertyValueEnumItem getEnumValue() {
+    return enumValue;
+  }
+
+  /**
+   * A free-form expression, which will be used as the value as is.
+   */
+  public String getExpression() {
+    return expression;
+  }
+
+  public Integer getIntValue() {
+    return intValue;
+  }
+
+  public String getStringValue() {
+    return stringValue;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(boolValue);
+    builder.append(doubleValue);
+    builder.append(intValue);
+    builder.append(stringValue);
+    builder.append(enumValue);
+    builder.append(expression);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    if (boolValue != null) {
+      jsonObject.addProperty("boolValue", boolValue);
+    }
+    if (doubleValue != null) {
+      jsonObject.addProperty("doubleValue", doubleValue);
+    }
+    if (intValue != null) {
+      jsonObject.addProperty("intValue", intValue);
+    }
+    if (stringValue != null) {
+      jsonObject.addProperty("stringValue", stringValue);
+    }
+    if (enumValue != null) {
+      jsonObject.add("enumValue", enumValue.toJson());
+    }
+    if (expression != null) {
+      jsonObject.addProperty("expression", expression);
+    }
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("boolValue=");
+    builder.append(boolValue + ", ");
+    builder.append("doubleValue=");
+    builder.append(doubleValue + ", ");
+    builder.append("intValue=");
+    builder.append(intValue + ", ");
+    builder.append("stringValue=");
+    builder.append(stringValue + ", ");
+    builder.append("enumValue=");
+    builder.append(enumValue + ", ");
+    builder.append("expression=");
+    builder.append(expression);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyValueEnumItem.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyValueEnumItem.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * An item of an enumeration in a general sense - actual enum value, or a static field in a class.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class FlutterWidgetPropertyValueEnumItem {
+
+  public static final FlutterWidgetPropertyValueEnumItem[] EMPTY_ARRAY = new FlutterWidgetPropertyValueEnumItem[0];
+
+  public static final List<FlutterWidgetPropertyValueEnumItem> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The URI of the library containing the className. When the enum item is passed back, this will
+   * allow the server to import the corresponding library if necessary.
+   */
+  private final String libraryUri;
+
+  /**
+   * The name of the class or enum.
+   */
+  private final String className;
+
+  /**
+   * The name of the field in the enumeration, or the static field in the class.
+   */
+  private final String name;
+
+  /**
+   * The documentation to show to the user. Omitted if the server does not know the documentation,
+   * e.g. because the corresponding field is not documented.
+   */
+  private final String documentation;
+
+  /**
+   * Constructor for {@link FlutterWidgetPropertyValueEnumItem}.
+   */
+  public FlutterWidgetPropertyValueEnumItem(String libraryUri, String className, String name, String documentation) {
+    this.libraryUri = libraryUri;
+    this.className = className;
+    this.name = name;
+    this.documentation = documentation;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof FlutterWidgetPropertyValueEnumItem) {
+      FlutterWidgetPropertyValueEnumItem other = (FlutterWidgetPropertyValueEnumItem) obj;
+      return
+        ObjectUtilities.equals(other.libraryUri, libraryUri) &&
+        ObjectUtilities.equals(other.className, className) &&
+        ObjectUtilities.equals(other.name, name) &&
+        ObjectUtilities.equals(other.documentation, documentation);
+    }
+    return false;
+  }
+
+  public static FlutterWidgetPropertyValueEnumItem fromJson(JsonObject jsonObject) {
+    String libraryUri = jsonObject.get("libraryUri").getAsString();
+    String className = jsonObject.get("className").getAsString();
+    String name = jsonObject.get("name").getAsString();
+    String documentation = jsonObject.get("documentation") == null ? null : jsonObject.get("documentation").getAsString();
+    return new FlutterWidgetPropertyValueEnumItem(libraryUri, className, name, documentation);
+  }
+
+  public static List<FlutterWidgetPropertyValueEnumItem> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<FlutterWidgetPropertyValueEnumItem> list = new ArrayList<FlutterWidgetPropertyValueEnumItem>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The name of the class or enum.
+   */
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * The documentation to show to the user. Omitted if the server does not know the documentation,
+   * e.g. because the corresponding field is not documented.
+   */
+  public String getDocumentation() {
+    return documentation;
+  }
+
+  /**
+   * The URI of the library containing the className. When the enum item is passed back, this will
+   * allow the server to import the corresponding library if necessary.
+   */
+  public String getLibraryUri() {
+    return libraryUri;
+  }
+
+  /**
+   * The name of the field in the enumeration, or the static field in the class.
+   */
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(libraryUri);
+    builder.append(className);
+    builder.append(name);
+    builder.append(documentation);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("libraryUri", libraryUri);
+    jsonObject.addProperty("className", className);
+    jsonObject.addProperty("name", name);
+    if (documentation != null) {
+      jsonObject.addProperty("documentation", documentation);
+    }
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("libraryUri=");
+    builder.append(libraryUri + ", ");
+    builder.append("className=");
+    builder.append(className + ", ");
+    builder.append("name=");
+    builder.append(name + ", ");
+    builder.append("documentation=");
+    builder.append(documentation);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/HoverInformation.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/HoverInformation.java
@@ -55,8 +55,9 @@ public class HoverInformation {
   private final String containingLibraryPath;
 
   /**
-   * The name of the library in which the referenced element is declared. This data is omitted if
-   * there is no referenced element, or if the element is declared inside an HTML file.
+   * The URI of the containing library, examples here include "dart:core", "package:.." and file uris
+   * represented by the path on disk, "/..". The data is omitted if the element is declared inside an
+   * HTML file.
    */
   private final String containingLibraryName;
 
@@ -185,8 +186,9 @@ public class HoverInformation {
   }
 
   /**
-   * The name of the library in which the referenced element is declared. This data is omitted if
-   * there is no referenced element, or if the element is declared inside an HTML file.
+   * The URI of the containing library, examples here include "dart:core", "package:.." and file uris
+   * represented by the path on disk, "/..". The data is omitted if the element is declared inside an
+   * HTML file.
    */
   public String getContainingLibraryName() {
     return containingLibraryName;

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ImportedElementSet.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ImportedElementSet.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * The set of top-level elements encoded as pairs of the defining library URI and the name, and
+ * stored in the parallel lists elementUris and elementNames.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class ImportedElementSet {
+
+  public static final ImportedElementSet[] EMPTY_ARRAY = new ImportedElementSet[0];
+
+  public static final List<ImportedElementSet> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The list of unique strings in this object.
+   */
+  private final List<String> strings;
+
+  /**
+   * The library URI part of the element. It is an index in the strings field.
+   */
+  private final int[] uris;
+
+  /**
+   * The name part of a the element. It is an index in the strings field.
+   */
+  private final int[] names;
+
+  /**
+   * Constructor for {@link ImportedElementSet}.
+   */
+  public ImportedElementSet(List<String> strings, int[] uris, int[] names) {
+    this.strings = strings;
+    this.uris = uris;
+    this.names = names;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof ImportedElementSet) {
+      ImportedElementSet other = (ImportedElementSet) obj;
+      return
+        ObjectUtilities.equals(other.strings, strings) &&
+        Arrays.equals(other.uris, uris) &&
+        Arrays.equals(other.names, names);
+    }
+    return false;
+  }
+
+  public static ImportedElementSet fromJson(JsonObject jsonObject) {
+    List<String> strings = JsonUtilities.decodeStringList(jsonObject.get("strings").getAsJsonArray());
+    int[] uris = JsonUtilities.decodeIntArray(jsonObject.get("uris").getAsJsonArray());
+    int[] names = JsonUtilities.decodeIntArray(jsonObject.get("names").getAsJsonArray());
+    return new ImportedElementSet(strings, uris, names);
+  }
+
+  public static List<ImportedElementSet> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<ImportedElementSet> list = new ArrayList<ImportedElementSet>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The name part of a the element. It is an index in the strings field.
+   */
+  public int[] getNames() {
+    return names;
+  }
+
+  /**
+   * The list of unique strings in this object.
+   */
+  public List<String> getStrings() {
+    return strings;
+  }
+
+  /**
+   * The library URI part of the element. It is an index in the strings field.
+   */
+  public int[] getUris() {
+    return uris;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(strings);
+    builder.append(uris);
+    builder.append(names);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    JsonArray jsonArrayStrings = new JsonArray();
+    for (String elt : strings) {
+      jsonArrayStrings.add(new JsonPrimitive(elt));
+    }
+    jsonObject.add("strings", jsonArrayStrings);
+    JsonArray jsonArrayUris = new JsonArray();
+    for (int elt : uris) {
+      jsonArrayUris.add(new JsonPrimitive(elt));
+    }
+    jsonObject.add("uris", jsonArrayUris);
+    JsonArray jsonArrayNames = new JsonArray();
+    for (int elt : names) {
+      jsonArrayNames.add(new JsonPrimitive(elt));
+    }
+    jsonObject.add("names", jsonArrayNames);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("strings=");
+    builder.append(StringUtils.join(strings, ", ") + ", ");
+    builder.append("uris=");
+    builder.append(StringUtils.join(uris, ", ") + ", ");
+    builder.append("names=");
+    builder.append(StringUtils.join(names, ", "));
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/Outline.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/Outline.java
@@ -8,16 +8,20 @@
  */
 package org.dartlang.analysis.server.protocol;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
 import com.google.dart.server.utilities.general.ObjectUtilities;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.StringUtils;
+import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * An node in the outline structure of a file.
@@ -99,8 +103,8 @@ public class Outline {
     Element element = Element.fromJson(elementObject);
     int offset = outlineObject.get("offset").getAsInt();
     int length = outlineObject.get("length").getAsInt();
-    int codeOffset = outlineObject.get("codeOffset") == null ? offset : outlineObject.get("codeOffset").getAsInt();
-    int codeLength = outlineObject.get("codeLength") == null ? length : outlineObject.get("codeLength").getAsInt();
+    int codeOffset = outlineObject.get("codeOffset").getAsInt();
+    int codeLength = outlineObject.get("codeLength").getAsInt();
 
     // create outline object
     Outline outline = new Outline(parent, element, offset, length, codeOffset, codeLength);

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RequestErrorCode.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/RequestErrorCode.java
@@ -33,6 +33,23 @@ public class RequestErrorCode {
   public static final String FILE_NOT_ANALYZED = "FILE_NOT_ANALYZED";
 
   /**
+   * The given location does not have a supported widget.
+   */
+  public static final String FLUTTER_GET_WIDGET_DESCRIPTION_NO_WIDGET = "FLUTTER_GET_WIDGET_DESCRIPTION_NO_WIDGET";
+
+  /**
+   * The given property identifier is not valid. It might have never been valid, or a change to code
+   * invalidated it, or its TTL was exceeded.
+   */
+  public static final String FLUTTER_SET_WIDGET_PROPERTY_VALUE_INVALID_ID = "FLUTTER_SET_WIDGET_PROPERTY_VALUE_INVALID_ID";
+
+  /**
+   * The value of the property cannot be removed, for example because the corresponding constructor
+   * argument is required, and the server does not know what default value to use.
+   */
+  public static final String FLUTTER_SET_WIDGET_PROPERTY_VALUE_IS_REQUIRED = "FLUTTER_SET_WIDGET_PROPERTY_VALUE_IS_REQUIRED";
+
+  /**
    * An "edit.format" request specified a FilePath which does not match a Dart file in an analysis
    * root.
    */

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ServerLogEntry.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ServerLogEntry.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import com.google.common.collect.Lists;
+import com.google.dart.server.utilities.general.JsonUtilities;
+import com.google.dart.server.utilities.general.ObjectUtilities;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A log entry from the server.
+ *
+ * @coverage dart.server.generated.types
+ */
+@SuppressWarnings("unused")
+public class ServerLogEntry {
+
+  public static final ServerLogEntry[] EMPTY_ARRAY = new ServerLogEntry[0];
+
+  public static final List<ServerLogEntry> EMPTY_LIST = Lists.newArrayList();
+
+  /**
+   * The time (milliseconds since epoch) at which the server created this log entry.
+   */
+  private final int time;
+
+  /**
+   * The kind of the entry, used to determine how to interpret the "data" field.
+   */
+  private final String kind;
+
+  /**
+   * The payload of the entry, the actual format is determined by the "kind" field.
+   */
+  private final String data;
+
+  /**
+   * Constructor for {@link ServerLogEntry}.
+   */
+  public ServerLogEntry(int time, String kind, String data) {
+    this.time = time;
+    this.kind = kind;
+    this.data = data;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof ServerLogEntry) {
+      ServerLogEntry other = (ServerLogEntry) obj;
+      return
+        other.time == time &&
+        ObjectUtilities.equals(other.kind, kind) &&
+        ObjectUtilities.equals(other.data, data);
+    }
+    return false;
+  }
+
+  public static ServerLogEntry fromJson(JsonObject jsonObject) {
+    int time = jsonObject.get("time").getAsInt();
+    String kind = jsonObject.get("kind").getAsString();
+    String data = jsonObject.get("data").getAsString();
+    return new ServerLogEntry(time, kind, data);
+  }
+
+  public static List<ServerLogEntry> fromJsonArray(JsonArray jsonArray) {
+    if (jsonArray == null) {
+      return EMPTY_LIST;
+    }
+    ArrayList<ServerLogEntry> list = new ArrayList<ServerLogEntry>(jsonArray.size());
+    Iterator<JsonElement> iterator = jsonArray.iterator();
+    while (iterator.hasNext()) {
+      list.add(fromJson(iterator.next().getAsJsonObject()));
+    }
+    return list;
+  }
+
+  /**
+   * The payload of the entry, the actual format is determined by the "kind" field.
+   */
+  public String getData() {
+    return data;
+  }
+
+  /**
+   * The kind of the entry, used to determine how to interpret the "data" field.
+   */
+  public String getKind() {
+    return kind;
+  }
+
+  /**
+   * The time (milliseconds since epoch) at which the server created this log entry.
+   */
+  public int getTime() {
+    return time;
+  }
+
+  @Override
+  public int hashCode() {
+    HashCodeBuilder builder = new HashCodeBuilder();
+    builder.append(time);
+    builder.append(kind);
+    builder.append(data);
+    return builder.toHashCode();
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("time", time);
+    jsonObject.addProperty("kind", kind);
+    jsonObject.addProperty("data", data);
+    return jsonObject;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("[");
+    builder.append("time=");
+    builder.append(time + ", ");
+    builder.append("kind=");
+    builder.append(kind + ", ");
+    builder.append("data=");
+    builder.append(data);
+    builder.append("]");
+    return builder.toString();
+  }
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ServerLogEntryKind.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ServerLogEntryKind.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ *
+ * This file has been automatically generated. Please do not edit it manually.
+ * To regenerate the file, use the script "pkg/analysis_server/tool/spec/generate_files".
+ */
+package org.dartlang.analysis.server.protocol;
+
+/**
+ * An enumeration of the kinds of server long entries.
+ *
+ * @coverage dart.server.generated.types
+ */
+public class ServerLogEntryKind {
+
+  /**
+   * A notification from the server, such as "analysis.highlights". The "data" field contains a JSON
+   * object with abbreviated notification.
+   */
+  public static final String NOTIFICATION = "NOTIFICATION";
+
+  /**
+   * Arbitrary string, describing some event that happened in the server, e.g. starting a file
+   * analysis, and details which files were accessed. These entries are not structured, but provide
+   * context information about requests and notification, and can be related by "time" for further
+   * manual analysis.
+   */
+  public static final String RAW = "RAW";
+
+  /**
+   * A request from the client, as the server views it, e.g. "edit.getAssists". The "data" field
+   * contains a JSON object with abbreviated request.
+   */
+  public static final String REQUEST = "REQUEST";
+
+  /**
+   * Various counters and measurements related to execution of a request. The "data" field contains a
+   * JSON object with following fields:
+   *
+   * - "id" - the id of the request - copied from the request.
+   * - "method" - the method of the request, e.g. "edit.getAssists".
+   * - "clientRequestTime" - the time (milliseconds since epoch) at which the client made the request
+   *   - copied from the request.
+   * - "serverRequestTime" - the time (milliseconds since epoch) at which the server received and
+   *   decoded the JSON request.
+   * - "responseTime" - the time (milliseconds since epoch) at which the server created the response
+   *   to be encoded into JSON and sent to the client.
+   */
+  public static final String RESPONSE = "RESPONSE";
+
+}

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ServerService.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/ServerService.java
@@ -15,6 +15,8 @@ package org.dartlang.analysis.server.protocol;
  */
 public class ServerService {
 
+  public static final String LOG = "LOG";
+
   public static final String STATUS = "STATUS";
 
 }

--- a/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/TokenDetails.java
+++ b/Dart/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/TokenDetails.java
@@ -54,12 +54,18 @@ public class TokenDetails {
   private final List<String> validElementKinds;
 
   /**
+   * The offset of the first character of the token in the file which it originated from.
+   */
+  private final int offset;
+
+  /**
    * Constructor for {@link TokenDetails}.
    */
-  public TokenDetails(String lexeme, String type, List<String> validElementKinds) {
+  public TokenDetails(String lexeme, String type, List<String> validElementKinds, int offset) {
     this.lexeme = lexeme;
     this.type = type;
     this.validElementKinds = validElementKinds;
+    this.offset = offset;
   }
 
   @Override
@@ -69,7 +75,8 @@ public class TokenDetails {
       return
         ObjectUtilities.equals(other.lexeme, lexeme) &&
         ObjectUtilities.equals(other.type, type) &&
-        ObjectUtilities.equals(other.validElementKinds, validElementKinds);
+        ObjectUtilities.equals(other.validElementKinds, validElementKinds) &&
+        other.offset == offset;
     }
     return false;
   }
@@ -78,7 +85,8 @@ public class TokenDetails {
     String lexeme = jsonObject.get("lexeme").getAsString();
     String type = jsonObject.get("type") == null ? null : jsonObject.get("type").getAsString();
     List<String> validElementKinds = jsonObject.get("validElementKinds") == null ? null : JsonUtilities.decodeStringList(jsonObject.get("validElementKinds").getAsJsonArray());
-    return new TokenDetails(lexeme, type, validElementKinds);
+    int offset = jsonObject.get("offset").getAsInt();
+    return new TokenDetails(lexeme, type, validElementKinds, offset);
   }
 
   public static List<TokenDetails> fromJsonArray(JsonArray jsonArray) {
@@ -98,6 +106,13 @@ public class TokenDetails {
    */
   public String getLexeme() {
     return lexeme;
+  }
+
+  /**
+   * The offset of the first character of the token in the file which it originated from.
+   */
+  public int getOffset() {
+    return offset;
   }
 
   /**
@@ -123,6 +138,7 @@ public class TokenDetails {
     builder.append(lexeme);
     builder.append(type);
     builder.append(validElementKinds);
+    builder.append(offset);
     return builder.toHashCode();
   }
 
@@ -139,6 +155,7 @@ public class TokenDetails {
       }
       jsonObject.add("validElementKinds", jsonArrayValidElementKinds);
     }
+    jsonObject.addProperty("offset", offset);
     return jsonObject;
   }
 
@@ -151,7 +168,9 @@ public class TokenDetails {
     builder.append("type=");
     builder.append(type + ", ");
     builder.append("validElementKinds=");
-    builder.append(StringUtils.join(validElementKinds, ", "));
+    builder.append(StringUtils.join(validElementKinds, ", ") + ", ");
+    builder.append("offset=");
+    builder.append(offset);
     builder.append("]");
     return builder.toString();
   }


### PR DESCRIPTION
This ensures that the Dart Plugin 2019.3.0 will have the latest recent DAS protocol.

I was not able to run the Dart tests due to a platform exception on each test:

`ERROR: Cannot create ServiceAdapter(descriptor=ServiceDescriptor(interface=com.intellij.ide.projectView.ProjectView, implementation=com.intellij.ide.projectView.impl.ProjectViewImpl),...`