### PR TITLE
Add Dart DiagnosticMessage action support in the Dart Analysis window

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -14,10 +14,12 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.util.DartBuildFileUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.dartlang.analysis.server.protocol.AnalysisError;
+import org.dartlang.analysis.server.protocol.DiagnosticMessage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.util.List;
 
 public class DartProblem {
 
@@ -49,6 +51,11 @@ public class DartProblem {
   @Nullable
   public String getUrl() {
     return myAnalysisError.getUrl();
+  }
+
+  @Nullable
+  public List<DiagnosticMessage> getDiagnosticMessages() {
+    return myAnalysisError.getContextMessages();
   }
 
   @NotNull
@@ -166,7 +173,7 @@ public class DartProblem {
   }
 
   @NotNull
-  public static String generateTooltipText(@NotNull String message, @Nullable String correction, @Nullable String url) {
+  public static String generateTooltipText(@NotNull final String message, @Nullable final String correction, @Nullable final String url) {
     final StringBuilder tooltip = new StringBuilder("<html><p>").append(XmlStringUtil.escapeString(message)).append("</p>");
     if (StringUtil.isNotEmpty(correction)) {
       tooltip.append("<br/><p>").append(XmlStringUtil.escapeString(correction)).append("</p>");


### PR DESCRIPTION
This adds support for jumping to source locations indicated by Dart errors and warnings via the optional `List<DiagnosticMessage>` to see an example, include this function in a Dart file:

```
void f() {
  print(x);
  int x = 3;
}
```