### PR TITLE
Include `analysis_options.yaml` as a valid analysis options file name in DartServerCompletionContributor

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -62,7 +62,9 @@ public class DartServerCompletionContributor extends CompletionContributor {
     extend(CompletionType.BASIC,
            or(psiElement().withLanguage(DartLanguage.INSTANCE),
               psiElement().inFile(psiFile().withLanguage(HTMLLanguage.INSTANCE)),
-              psiElement().inFile(psiFile().withName(".analysis_options"))),
+              psiElement().inFile(psiFile().withName(".analysis_options")),
+              psiElement().inFile(psiFile().withName("analysis_options.yaml"))
+           ),
            new CompletionProvider<CompletionParameters>() {
              @Override
              protected void addCompletions(@NotNull final CompletionParameters parameters,


### PR DESCRIPTION
See documentation at [dart.dev](https://dart.dev) showing this change: [dart.dev/guides/language/analysis-options](https://dart.dev/guides/language/analysis-options)