### PR TITLE
fix a null param issue from DartDocumentationProvider.java

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
@@ -28,8 +28,6 @@ public class DartDocUtil {
 
   public static final String SINGLE_LINE_DOC_COMMENT = "///";
   private static final String NBSP = "&nbsp;";
-  private static final String GREATER_THAN = "&gt;";
-  private static final String LESS_THAN = "&lt;";
 
   public static String generateDoc(final PsiElement element) {
     if (!(element instanceof DartComponent) && !(element.getParent() instanceof DartComponent)) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -177,7 +177,11 @@ public class DartDocumentationProvider implements DocumentationProvider {
   @Nullable
   private static HoverInformation getSingleHover(final PsiElement element) {
     if (element != null) {
-      final PsiFile psiFile = element.getContainingFile();
+      @Nullable final PsiFile psiFile = element.getContainingFile();
+      // PsiElement.getContainingFile() can return null if the PSI element is a directory or package.
+      if (psiFile == null) {
+        return null;
+      }
       final int offset = element.getTextOffset();
       return getSingleHover(psiFile, offset);
     }

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.lang.dart.documentation;
 
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -54,6 +55,15 @@ public class DartDocumentationProviderTest extends DartCodeInsightFixtureTestCas
 
   public void testEnumRef() {
     doTestQuickNavigateInfo("E <b>E1</b>", "enum E { <caret>E1 } var e = E.E1;");
+  }
+
+  public void testPsiDirectoryRef() {
+    final PsiFile psiFile = myFixture.addFileToProject(
+      "test.dart", "/// test docs\nvoid() main() {}");
+    final PsiDirectory psiDirectory = psiFile.getContainingDirectory();
+
+    String generatedDocs = myProvider.generateDoc(psiDirectory, null);
+    assertNull("expected no docs for directory", generatedDocs);
   }
 
   public void testDocUrls() {


### PR DESCRIPTION
- fix a null param issue from DartDocumentationProvider.java
- unrelated, but remove two unused fields from `DartDocUtil.java`

It looks like it's possible to get a null value for a PSI element's containing file if the element is a directory or package.

Here's the exception we're seeing:

```
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'psiFile' of com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.getSingleHover must not be null
    com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider.$$$reportNull$$$0(), DartDocumentationProvider.java:-1
    com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider.getSingleHover(), DartDocumentationProvider.java:-1
    com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider.getSingleHover(), DartDocumentationProvider.java:182
    com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider.generateDoc(), DartDocumentationProvider.java:33
    com.intellij.lang.documentation.CompositeDocumentationProvider.generateDoc(), CompositeDocumentationProvider.java:136
    com.intellij.codeInsight.documentation.DocumentationManager$MyCollector.lambda$getDocumentation$2(), DocumentationManager.java:1176
    com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(), ApplicationImpl.java:1106
    ...
```

@alexander-doroshko @jwren 