### PR TITLE
Support non-Dart files in the Dart analyzer

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/DartFileListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/DartFileListener.java
@@ -53,9 +53,7 @@ public class DartFileListener implements VirtualFileListener {
     if (VirtualFile.PROP_NAME.equals(event.getPropertyName())) {
       fileChanged(myProject, event.getFile());
 
-      if (event.getFile().isInLocalFileSystem() &&
-          (DartAnalysisServerService.isFileNameRespectedByAnalysisServer(event.getOldValue().toString()) ||
-           DartAnalysisServerService.isFileNameRespectedByAnalysisServer(event.getFileName()))) {
+      if (event.getFile().isInLocalFileSystem()) {
         updateVisibleFilesIfNeeded();
       }
     }

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -836,13 +836,10 @@ public class DartAnalysisServerService implements Disposable {
    */
   @Contract("null->false")
   public static boolean isLocalAnalyzableFile(@Nullable final VirtualFile file) {
-    if (file != null && file.isInLocalFileSystem()) {
-      return isFileNameRespectedByAnalysisServer(file.getName());
-    }
-    return false;
+    return file != null && file.isInLocalFileSystem();
   }
 
-  public static boolean isFileNameRespectedByAnalysisServer(@NotNull String _fileName) {
+  public static boolean isFileNameRespectedByAnalysisServerWithoutPlugins(@NotNull String _fileName) {
     // see https://github.com/dart-lang/sdk/blob/master/pkg/analyzer/lib/src/generated/engine.dart (class AnalysisEngine)
     // and AbstractAnalysisServer.analyzableFilePatterns
     String fileName = _fileName.toLowerCase(Locale.US);

--- a/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
+++ b/Dart/src/com/jetbrains/lang/dart/highlight/DartSyntaxHighlighterColors.java
@@ -8,9 +8,9 @@ import com.intellij.openapi.editor.colors.TextAttributesKey;
 import static com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey;
 
 public class DartSyntaxHighlighterColors {
-  public static final String DART_ERROR = "DART_ERROR";
-  public static final String DART_WARNING = "DART_WARNING";
-  public static final String DART_HINT = "DART_HINT";
+  private static final String DART_ERROR = "DART_ERROR";
+  private static final String DART_WARNING = "DART_WARNING";
+  private static final String DART_HINT = "DART_HINT";
 
   public static final String DART_ANNOTATION = "DART_ANNOTATION";
   public static final String DART_CLASS = "DART_CLASS";
@@ -68,14 +68,14 @@ public class DartSyntaxHighlighterColors {
   public static final String DART_TYPE_PARAMETER = "DART_TYPE_PARAMETER";
   public static final String DART_UNRESOLVED_INSTANCE_MEMBER_REFERENCE = "DART_UNRESOLVED_INSTANCE_MEMBER_REFERENCE";
 
-  private static final String DART_BLOCK_COMMENT = "DART_BLOCK_COMMENT";
-  private static final String DART_DOC_COMMENT = "DART_DOC_COMMENT";
-  private static final String DART_LINE_COMMENT = "DART_LINE_COMMENT";
+  public static final String DART_BLOCK_COMMENT = "DART_BLOCK_COMMENT";
+  public static final String DART_DOC_COMMENT = "DART_DOC_COMMENT";
+  public static final String DART_LINE_COMMENT = "DART_LINE_COMMENT";
 
-  private static final String DART_NUMBER = "DART_NUMBER";
-  private static final String DART_STRING = "DART_STRING";
-  private static final String DART_VALID_STRING_ESCAPE = "DART_VALID_STRING_ESCAPE";
-  private static final String DART_INVALID_STRING_ESCAPE = "DART_INVALID_STRING_ESCAPE";
+  public static final String DART_NUMBER = "DART_NUMBER";
+  public static final String DART_STRING = "DART_STRING";
+  public static final String DART_VALID_STRING_ESCAPE = "DART_VALID_STRING_ESCAPE";
+  public static final String DART_INVALID_STRING_ESCAPE = "DART_INVALID_STRING_ESCAPE";
   private static final String DART_OPERATION_SIGN = "DART_OPERATION_SIGN";
   private static final String DART_PARENTH = "DART_PARENTH";
   private static final String DART_BRACKETS = "DART_BRACKETS";


### PR DESCRIPTION
This PR adds support for non-Dart files in the Dart plugin. When assigning the custom file ending to Dart, the analysis server is still used. It looks like outline, autocomplete, quickfixes, highlights and errors are all working (see screenshot, which comes from an analyzer plugin).

![grafik](https://user-images.githubusercontent.com/5738860/70655309-50694f00-1c58-11ea-9e05-ac0caecc4028.png)

Fixes [WEB-41424](https://youtrack.jetbrains.com/issue/WEB-41424).