### PR TITLE
Improvements in the Dart hover documentation results, WEB-9993

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
@@ -180,14 +180,14 @@ public class DartDocUtil {
     builder.append("<br>");
     builder.append("</code>\n");
     if (docText != null) {
-      final MarkdownProcessor processor = new MarkdownProcessor();
-      final String markdownProcessorOutput = processor.markdown(docText);
-      List<String> lines = Arrays.asList(StringUtil.splitByLines(markdownProcessorOutput));
+      List<String> lines = StringUtil.split(docText, "\n");
       MarkdownUtil.replaceCodeBlock(lines);
       MarkdownUtil.removeImages(lines);
       MarkdownUtil.replaceHeaders(lines);
       MarkdownUtil.generateLists(lines);
-      builder.append(StringUtil.join(lines, "\n"));
+
+      MarkdownProcessor processor = new MarkdownProcessor();
+      builder.append(processor.markdown(StringUtil.join(lines, "\n")));
     }
     // done
     return builder.toString().trim();

--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
@@ -181,7 +181,7 @@ public class DartDocUtil {
     builder.append("</code>\n");
     if (docText != null) {
       final MarkdownProcessor processor = new MarkdownProcessor();
-      final String markdownProcessorOutput = processor.markdown(docText.trim());
+      final String markdownProcessorOutput = processor.markdown(docText);
       List<String> lines = Arrays.asList(StringUtil.splitByLines(markdownProcessorOutput));
       MarkdownUtil.replaceCodeBlock(lines);
       MarkdownUtil.removeImages(lines);

--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocUtil.java
@@ -10,6 +10,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.SmartList;
+import com.intellij.util.text.MarkdownUtil;
 import com.jetbrains.lang.dart.DartTokenTypesSets;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartGenericSpecialization;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -31,6 +33,7 @@ public class DartDocUtil {
   private static final String GT = "&gt;";
   private static final String LT = "&lt;";
 
+  @Nullable
   public static String generateDoc(final PsiElement element) {
     if (!(element instanceof DartComponent) && !(element.getParent() instanceof DartComponent)) {
       return null;
@@ -69,6 +72,7 @@ public class DartDocUtil {
     return generateDoc(signatureHtml, true, docText, containingLibraryName, containingClassDescription, null, false);
   }
 
+  @NotNull
   private static String formatSignature(@NotNull final String signature) {
     // Match the first open paren, "(", but ignore a starting "(new)" or "(const)" patterns.
     final int offsetToOpenParen = signature.indexOf('(', 1);
@@ -97,6 +101,7 @@ public class DartDocUtil {
   /**
    * Split around the ", " pattern, when not in a generic or function parameter (inside a nested parenthesize.)
    */
+  @NotNull
   private static String[] signatureSplit(@NotNull final String str) {
     List<String> result = new SmartList<>();
 
@@ -176,7 +181,13 @@ public class DartDocUtil {
     builder.append("</code>\n");
     if (docText != null) {
       final MarkdownProcessor processor = new MarkdownProcessor();
-      builder.append(processor.markdown(docText.trim()));
+      final String markdownProcessorOutput = processor.markdown(docText.trim());
+      List<String> lines = Arrays.asList(StringUtil.splitByLines(markdownProcessorOutput));
+      MarkdownUtil.replaceCodeBlock(lines);
+      MarkdownUtil.removeImages(lines);
+      MarkdownUtil.replaceHeaders(lines);
+      MarkdownUtil.generateLists(lines);
+      builder.append(StringUtil.join(lines, "\n"));
     }
     // done
     return builder.toString().trim();

--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -86,19 +86,19 @@ public class DartDocumentationProvider implements DocumentationProvider {
 
   @NotNull
   public static String buildHoverTextServer(@NotNull final HoverInformation hover) {
-    final String elementDescription = hover.getElementDescription();
+    final String elementDescription = StringUtil.trim(hover.getElementDescription());
     final String staticType = elementDescription == null || elementDescription.equals(hover.getStaticType()) ? null : hover.getStaticType();
-    final String containingLibraryName = hover.getContainingLibraryName();
+    final String containingLibraryName = StringUtil.trim(hover.getContainingLibraryName());
     return DartDocUtil.generateDoc(elementDescription, false, null, containingLibraryName, null, staticType, true);
   }
 
   @NotNull
   public static String generateDocServer(@NotNull final HoverInformation hover) {
-    final String elementDescription = hover.getElementDescription();
-    final String containingLibraryName = hover.getContainingLibraryName();
-    final String containingClassDescription = hover.getContainingClassDescription();
-    final String staticType = hover.getStaticType();
-    final String docText = hover.getDartdoc();
+    final String elementDescription = StringUtil.trim(hover.getElementDescription());
+    final String containingLibraryName = StringUtil.trim(hover.getContainingLibraryName());
+    final String containingClassDescription = StringUtil.trim(hover.getContainingClassDescription());
+    final String staticType = StringUtil.trim(hover.getStaticType());
+    final String docText = StringUtil.trim(hover.getDartdoc());
     return DartDocUtil
       .generateDoc(elementDescription, false, docText, containingLibraryName, containingClassDescription, staticType, false);
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
@@ -17,18 +17,16 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testAbstractClassSig() {
-    doTest("<code><b>test.dart</b><br>abstract class Foo extends Bar<br><br></code>",
+    doTest("<code><b>test.dart</b><br>abstract class Foo extends Bar<br><br><b>Containing class:</b> Foo<br><br></code>",
            "abstract class <caret>Foo extends Bar { }\nclass Bar { }");
   }
 
   public void testClassMultilineDoc1() {
-    doTest("<code><b>test.dart</b><br>class A<br><br></code>\n" +
+    doTest("<code><b>test.dart</b><br>class A<br><br><b>Containing class:</b> A<br><br></code>\n" +
            "<p>doc1\n" +
            "doc2\n" +
-           " doc3</p>\n" +
-           "\n" +
+           "doc3</p>\n" +
            "<p>   doc4</p>\n" +
-           "\n" +
            "<pre><code>    code\n" +
            "</code></pre>",
 
@@ -47,12 +45,12 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc2() {
-    doTest("<code><b>test.dart</b><br>abstract class A<br><br></code>\n<p>doc1\n" +
+    doTest("<code><b>test.dart</b><br>abstract class A<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
            "doc2\n" +
-           " doc3\n" +
+           "doc3\n" +
            "doc4\n" +
            "doc5\n" +
-           " doc6</p>",
+           "doc6</p>",
 
            "@deprecated\n" +
            "/**\n" +
@@ -67,7 +65,7 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs1() {
-    doTest("<code><b>test.dart</b><br>class A<br><br></code>\n<p>doc1\n" +
+    doTest("<code><b>test.dart</b><br>class A<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
            "doc2</p>",
 
            "// not doc \n" +
@@ -79,7 +77,7 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testClassSingleLineDocs2() {
-    doTest("<code><b>test.dart</b><br>class A<br><br></code>\n<p>doc1\n" +
+    doTest("<code><b>test.dart</b><br>class A<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
            "doc2</p>",
 
            "@deprecated" +
@@ -148,7 +146,7 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testEnumSig() {
-    doTest("<code><b>test.dart</b><br>enum Foo<br><br></code>", "enum <caret>Foo { BAR }");
+    doTest("<code><b>test.dart</b><br>enum Foo<br><br><b>Containing class:</b> Foo<br><br></code>", "enum <caret>Foo { BAR }");
   }
 
   public void testFieldSig1() {
@@ -168,7 +166,6 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
 
   public void testFunctionDoc2() {
     doTest("<code><b>test.dart</b><br>void foo(int x)<br><br></code>\n<p>Good for:</p>\n" +
-           "\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
            "<li>that</li>\n" +
@@ -263,26 +260,24 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testImplementsSig1() {
-    doTest("<code><b>test.dart</b><br>abstract class Foo implements Bar<br><br></code>",
+    doTest("<code><b>test.dart</b><br>abstract class Foo implements Bar<br><br><b>Containing class:</b> Foo<br><br></code>",
            "abstract class <caret>Foo implements Bar<T> { }\nclass Bar { }");
   }
 
   public void testLibraryClassDoc() {
-    doTest("<code><b>test.dart</b><br>class A<br><br></code>", "library c.b.a;\nclass <caret>A {}");
+    doTest("<code><b>test.dart</b><br>class A<br><br><b>Containing class:</b> A<br><br></code>", "library c.b.a;\nclass <caret>A {}");
   }
 
   public void testMetaClassSig1() {
-    doTest("<code><b>test.dart</b><br>class A<br><br></code>", " @deprecated class <caret>A {}");
+    doTest("<code><b>test.dart</b><br>class A<br><br><b>Containing class:</b> A<br><br></code>", " @deprecated class <caret>A {}");
   }
 
   public void testMethodMultilineDoc() {
     doTest("<code><b>test.dart</b><br>dynamic foo()<br><br><b>Containing class:</b> A<br><br></code>\n" +
            "<p>doc1\n" +
            "doc2\n" +
-           " doc3</p>\n" +
-           "\n" +
+           "doc3</p>\n" +
            "<p>   doc4</p>\n" +
-           "\n" +
            "<pre><code>    code\n" +
            "</code></pre>",
 
@@ -319,12 +314,12 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testMixinSig1() {
-    doTest("<code><b>test.dart</b><br>class Foo2 extends Bar1 with Baz1, Baz2<br><br></code>",
+    doTest("<code><b>test.dart</b><br>class Foo2 extends Bar1 with Baz1, Baz2<br><br><b>Containing class:</b> Foo2<br><br></code>",
            "class Bar1 {} class Baz1{} class Baz2 {} class <caret>Foo2 = Bar1<E> with Baz1<K>, Baz2");
   }
 
   public void testMixinSig2() {
-    doTest("<code><b>test.dart</b><br>class X extends Y with Z<br><br></code>",
+    doTest("<code><b>test.dart</b><br>class X extends Y with Z<br><br><b>Containing class:</b> X<br><br></code>",
            "class Y {} class Z {} class <caret>X extends Y with Z { }");
   }
 
@@ -333,24 +328,24 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testParamClassSig() {
-    doTest("<code><b>test.dart</b><br>class Foo&lt;T&gt;<br><br></code>", "class <caret>Foo<T>{ }");
+    doTest("<code><b>test.dart</b><br>class Foo&lt;T&gt;<br><br><b>Containing class:</b> Foo<br><br></code>", "class <caret>Foo<T>{ }");
   }
 
   public void testParamClassSig2() {
-    doTest("<code><b>test.dart</b><br>class Foo&lt;T, Z&gt;<br><br></code>", "class <caret>Foo<T,Z>{ }");
+    doTest("<code><b>test.dart</b><br>class Foo&lt;T, Z&gt;<br><br><b>Containing class:</b> Foo<br><br></code>", "class <caret>Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() {
-    doTest("<code><b>test.dart</b><br>class Foo implements Bar<br><br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
+    doTest("<code><b>test.dart</b><br>class Foo implements Bar<br><br><b>Containing class:</b> Foo<br><br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() {
-    doTest("<code><b>test.dart</b><br>class Foo implements Bar, Baz<br><br></code>",
+    doTest("<code><b>test.dart</b><br>class Foo implements Bar, Baz<br><br><b>Containing class:</b> Foo<br><br></code>",
            "class <caret>Foo implements Bar, Baz { }<br/>class Bar { }<br/>class Baz { }");
   }
 
   public void testParamClassSig5() {
-    doTest("<code><b>test.dart</b><br>class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br><br></code>",
+    doTest("<code><b>test.dart</b><br>class Foo&lt;A, B&gt; extends Bar&lt;A, B&gt;<br><br><b>Containing class:</b> Foo<br><br></code>",
            "class <caret>Foo<A,B> extends Bar<A,B> { }<br/>class Bar<A,B> { }");
   }
 

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerDocUtilTest.java
@@ -25,10 +25,10 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
     doTest("<code><b>test.dart</b><br>class A<br><br><b>Containing class:</b> A<br><br></code>\n" +
            "<p>doc1\n" +
            "doc2\n" +
-           "doc3</p>\n" +
-           "<p>   doc4</p>\n" +
-           "<pre><code>    code\n" +
-           "</code></pre>",
+           " doc3\n" +
+           "   doc4</p>\n" +
+           "\n" +
+           "<pre><code>    code</code></pre>",
 
            "/** 1 */\n" +
            "/**\n" +
@@ -47,10 +47,10 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   public void testClassMultilineDoc2() {
     doTest("<code><b>test.dart</b><br>abstract class A<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
            "doc2\n" +
-           "doc3\n" +
+           " doc3\n" +
            "doc4\n" +
            "doc5\n" +
-           "doc6</p>",
+           " doc6</p>",
 
            "@deprecated\n" +
            "/**\n" +
@@ -165,15 +165,13 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testFunctionDoc2() {
-    doTest("<code><b>test.dart</b><br>void foo(int x)<br><br></code>\n<p>Good for:</p>\n" +
-           "<ul>\n" +
-           "<li>this</li>\n" +
-           "<li>that</li>\n" +
-           "</ul>", "/** Good for:\n\n" +
-                    " * * this\n" +
-                    " * * that\n" +
-                    "*/\n" +
-                    "\nvoid <caret>foo(int x) { }");
+    doTest("<code><b>test.dart</b><br>void foo(int x)<br><br></code>\n<p>Good for:</p>\n\n" +
+           "<ul><li>this</li>\n" +
+           "<li>that</li></ul>", "/** Good for:\n\n" +
+                                 " * * this\n" +
+                                 " * * that\n" +
+                                 "*/\n" +
+                                 "\nvoid <caret>foo(int x) { }");
   }
 
   public void testFunctionSig1() {
@@ -276,10 +274,10 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
     doTest("<code><b>test.dart</b><br>dynamic foo()<br><br><b>Containing class:</b> A<br><br></code>\n" +
            "<p>doc1\n" +
            "doc2\n" +
-           "doc3</p>\n" +
-           "<p>   doc4</p>\n" +
-           "<pre><code>    code\n" +
-           "</code></pre>",
+           " doc3\n" +
+           "   doc4</p>\n" +
+           "\n" +
+           "<pre><code>    code</code></pre>",
 
            "class A{\n" +
            "/** 1 */\n" +
@@ -332,11 +330,13 @@ public class DartServerDocUtilTest extends CodeInsightFixtureTestCase {
   }
 
   public void testParamClassSig2() {
-    doTest("<code><b>test.dart</b><br>class Foo&lt;T, Z&gt;<br><br><b>Containing class:</b> Foo<br><br></code>", "class <caret>Foo<T,Z>{ }");
+    doTest("<code><b>test.dart</b><br>class Foo&lt;T, Z&gt;<br><br><b>Containing class:</b> Foo<br><br></code>",
+           "class <caret>Foo<T,Z>{ }");
   }
 
   public void testParamClassSig3() {
-    doTest("<code><b>test.dart</b><br>class Foo implements Bar<br><br><b>Containing class:</b> Foo<br><br></code>", "class <caret>Foo implements Bar { }<br/>class Bar { }");
+    doTest("<code><b>test.dart</b><br>class Foo implements Bar<br><br><b>Containing class:</b> Foo<br><br></code>",
+           "class <caret>Foo implements Bar { }<br/>class Bar { }");
   }
 
   public void testParamClassSig4() {

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
@@ -225,7 +225,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   public void testFunctionDoc2() {
     doTest("<code><b>test.dart</b><br><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br></code>\n" +
-           "<p>Good for:</p>\n\n" +
+           "<p> Good for:</p>\n" +
            "<ul>\n" +
            "<li>this</li>\n" +
            "<li>that</li>\n" +
@@ -238,12 +238,10 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc1() {
-    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n<p>doc1\n" +
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n<p>     doc1\n" +
            "doc2\n" +
-           " doc3</p>\n" +
-           "\n" +
+           "doc3</p>\n" +
            "<p>   doc4</p>\n" +
-           "\n" +
            "<pre><code>    code\n" +
            "</code></pre>",
 
@@ -264,10 +262,10 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   public void testClassMultilineDoc2() {
     doTest("<code><b>test.dart</b><br>abstract class <b>A</b><br><br></code>\n<p>doc1\n" +
            "doc2\n" +
-           " doc3\n" +
+           "doc3\n" +
            "doc4\n" +
            "doc5\n" +
-           " doc6</p>",
+           "doc6</p>",
 
            "@deprecated\n" +
            "/**\n" +
@@ -283,8 +281,8 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   public void testClassSingleLineDocs1() {
     doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n" +
-           "<p>doc1 <br />\n" +
-           "doc2</p>",
+           "<p>  doc1 <br />\n" +
+           "doc2   </p>",
 
            "// not doc \n" +
            "///   doc1  \n" +
@@ -296,8 +294,8 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   public void testClassSingleLineDocs2() {
     doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n" +
-           "<p>doc1 <br />\n" +
-           "doc2</p>",
+           "<p>  doc1 <br />\n" +
+           "doc2   </p>",
 
            "@deprecated" +
            "// not doc \n" +
@@ -310,12 +308,10 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   public void testMethodMultilineDoc() {
     doTest(
-      "<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing class:</b> A<br><br></code>\n<p>doc1\n" +
+      "<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing class:</b> A<br><br></code>\n<p>     doc1\n" +
       "doc2\n" +
-      " doc3</p>\n" +
-      "\n" +
+      "doc3</p>\n" +
       "<p>   doc4</p>\n" +
-      "\n" +
       "<pre><code>    code\n" +
       "</code></pre>",
 
@@ -337,8 +333,7 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   public void testMethodSingleLineDocs() {
     doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br>" +
-           "<b>Containing class:</b> A<br><br></code>\n<p>doc1  </p>\n" +
-           "\n" +
+           "<b>Containing class:</b> A<br><br></code>\n<p>  doc1  </p>\n" +
            "<pre><code>    doc2\n" +
            "</code></pre>",
 

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
@@ -226,10 +226,9 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   public void testFunctionDoc2() {
     doTest("<code><b>test.dart</b><br><b>foo</b>(int x) " + RIGHT_ARROW + " void<br><br></code>\n" +
            "<p> Good for:</p>\n" +
-           "<ul>\n" +
-           "<li>this</li>\n" +
-           "<li>that</li>\n" +
-           "</ul>",
+           "\n" +
+           "<ul><li>this</li>\n" +
+           "<li>that</li></ul>",
            "/** Good for:\n\n" +
            " * * this\n" +
            " * * that\n" +
@@ -238,12 +237,14 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testClassMultilineDoc1() {
-    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n<p>     doc1\n" +
-           "doc2\n" +
-           "doc3</p>\n" +
-           "<p>   doc4</p>\n" +
-           "<pre><code>    code\n" +
-           "</code></pre>",
+    doTest("<code><b>test.dart</b><br>class <b>A</b><br><br></code>\n" +
+           "<pre><code>     doc1</code></pre>\n" +
+           "\n" +
+           "<p>doc2\n" +
+           " doc3\n" +
+           "   doc4</p>\n" +
+           "\n" +
+           "<pre><code>    code</code></pre>",
 
            "/** 1 */\n" +
            "/**\n" +
@@ -262,10 +263,10 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   public void testClassMultilineDoc2() {
     doTest("<code><b>test.dart</b><br>abstract class <b>A</b><br><br></code>\n<p>doc1\n" +
            "doc2\n" +
-           "doc3\n" +
+           " doc3\n" +
            "doc4\n" +
            "doc5\n" +
-           "doc6</p>",
+           " doc6</p>",
 
            "@deprecated\n" +
            "/**\n" +
@@ -308,12 +309,14 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   public void testMethodMultilineDoc() {
     doTest(
-      "<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing class:</b> A<br><br></code>\n<p>     doc1\n" +
-      "doc2\n" +
-      "doc3</p>\n" +
-      "<p>   doc4</p>\n" +
-      "<pre><code>    code\n" +
-      "</code></pre>",
+      "<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing class:</b> A<br><br></code>\n" +
+      "<pre><code>     doc1</code></pre>\n" +
+      "\n" +
+      "<p>doc2\n" +
+      " doc3\n" +
+      "   doc4</p>\n" +
+      "\n" +
+      "<pre><code>    code</code></pre>",
 
       "class A{\n" +
       "/** 1 */\n" +
@@ -332,10 +335,10 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
   }
 
   public void testMethodSingleLineDocs() {
-    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br>" +
-           "<b>Containing class:</b> A<br><br></code>\n<p>  doc1  </p>\n" +
-           "<pre><code>    doc2\n" +
-           "</code></pre>",
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br><b>Containing class:</b> A<br><br></code>\n" +
+           "<p>  doc1  </p>\n" +
+           "\n" +
+           "<pre><code>    doc2   </code></pre>",
 
            "class A{\n" +
            "// not doc \n" +
@@ -360,5 +363,66 @@ public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
            "<p>my <a href=\"www.cheese.com\">fancy\n" +
            "link</a></p>",
            "/// my [fancy\n/// link](www.cheese.com)\nvoid <caret>foo() => null;\n");
+  }
+
+  public void testMarkdownUtil_testReplaceCodeBlock() {
+    doTest("<code><b>test.dart</b><br><b>foo</b>() → dynamic<br><br></code>\n" +
+           "<p>   text</p>\n" +
+           "\n" +
+           "<pre><code>    code block</code></pre>\n" +
+           "\n" +
+           "<pre><code>\n" +
+           " code block too\n" +
+           "</code></pre>\n" +
+           "\n" +
+           "<p>simple text</p>\n" +
+           "\n" +
+           "<pre><code>    $ code\n" +
+           "    $ code continues</code></pre>\n" +
+           "\n" +
+           "<p>code done</p>",
+           "///    text\n" +
+           "///     code block\n" +
+           "/// ```\n" +
+           "///  code block too\n" +
+           "/// ```\n" +
+           "/// simple text\n" +
+           "///     $ code\n" +
+           "/// \t$ code continues\n" +
+           "/// code done\n" +
+           "<caret>foo(){}");
+  }
+
+  public void testMarkdownUtil_testRemoveImages() {
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br></code>\n" +
+           "<p>, \n" +
+           "Hello, <a href=\"http://www.google.com\">Google</a></p>",
+           "/// ![logo](http://localhost/logo.png), \n" +
+           "/// Hello, [Google](http://www.google.com)\n" +
+           "<caret>foo(){}");
+  }
+
+  public void testMarkdownUtil_testReplaceHeaders() {
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br></code>\n" +
+           "<h1>Hello1</h1>\n" +
+           "\n" +
+           "<h2>Hello2</h2>\n" +
+           "\n" +
+           "<h2>Hello3</h2>",
+           "/// # Hello1\n" +
+           "/// ## Hello2##\n" +
+           "/// ## Hello3#\n" +
+           "<caret>foo(){}");
+  }
+
+  public void testMarkdownUtil_testGenerateLists() {
+    doTest("<code><b>test.dart</b><br><b>foo</b>() " + RIGHT_ARROW + " dynamic<br><br></code>\n" +
+           "<ul><li>red</li>\n" +
+           "<li>green</li>\n" +
+           "<li>blue</li></ul>",
+           "/// *   red\n" +
+           "/// *   green\n" +
+           "/// *   blue\n" +
+           "<caret>foo(){}");
   }
 }


### PR DESCRIPTION
I almost gave up looking for a solution before proposing we write our own little markdown processor or importing a different java library when I found `MarkdownUtil`.  See the comment on the method `MarkdownUtil.replaceHeaders()`.

The `MarkdownProcessor` is providing value, we just need additional changes for things code blocks, headers and lists.

Further improvements here probably mean additions and bug fixes to `MarkdownUtil`:

- `<pre><code>` are being inserted, but not all of the ``` are being removed, also in the popup I don't see the text in a different mono-space font.  Is there some other html block that the hover popup expects?
- Headers work better, but are not perfect.  See screenshot below, this shows that not all headers are created equal.

- `[ref]` and `[: some code :]` are not respected yet.  We probably want these formatted with `<code></code>` blocks?  The fix here is probably a new utility method on `MarkdownUtil`.  We should be careful not to modify if the `[]` symbols are in source code being documented.

![step_one](https://user-images.githubusercontent.com/1533520/70826966-135aa500-1d9d-11ea-8ffe-17affdd89964.png)