### PR TITLE
Switch to HTTPS for maven dependency

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -8,6 +8,6 @@
     <item url="https://repo1.maven.org/maven2/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.jar"/>
 
     <!-- this is a workaround missing dependency in error_prone_core-with-dependencies: https://github.com/google/error-prone/issues/1238 -->
-    <item url="http://central.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"/>
+    <item url="https://repo1.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
I started seeing the following error when attempting to use the `error-prone` plugin:

>Error:Failed to download error-prone compiler JARs: Failed to download 'http://central.maven.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar':
Request failed with status code 501

It looks like they switched over to HTTPS-only on 1/15/2020. 

* https://support.sonatype.com/hc/en-us/articles/360041287334
* https://stackoverflow.com/questions/59763531/maven-dependencies-are-failing-with-a-501-error
