### PR TITLE
[Dart] Rename DASS.isDartSdkVersionForMoveFileRefactoring()

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -441,7 +441,7 @@ public class DartAnalysisServerService implements Disposable {
     return StringUtil.compareVersionNumbers(sdk.getVersion(), MIN_SDK_VERSION) >= 0;
   }
 
-  public static boolean isDartSdkVersionForMoveFileRefactoring(@NotNull final DartSdk sdk) {
+  public static boolean isDartSdkVersionSufficientForMoveFileRefactoring(@NotNull final DartSdk sdk) {
     return StringUtil.compareVersionNumbers(sdk.getVersion(), MIN_MOVE_FILE_SDK_VERSION) >= 0;
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/moveFile/DartServerMoveDartFileHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/moveFile/DartServerMoveDartFileHandler.java
@@ -35,7 +35,7 @@ public class DartServerMoveDartFileHandler extends MoveFileHandler {
     }
     final Project project = psiFile.getProject();
     final DartSdk dartSdk = DartSdk.getDartSdk(project);
-    if (dartSdk == null || !DartAnalysisServerService.isDartSdkVersionForMoveFileRefactoring(dartSdk)) {
+    if (dartSdk == null || !DartAnalysisServerService.isDartSdkVersionSufficientForMoveFileRefactoring(dartSdk)) {
       return false;
     }
     return DartAnalysisServerService.getInstance(project).isInIncludedRoots(psiFile.getVirtualFile());

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFileReference.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFileReference.java
@@ -91,7 +91,7 @@ public class DartFileReference implements PsiPolyVariantReference {
       final VirtualFile targetFile = DartResolveUtil.getRealVirtualFile(((PsiFile)element));
       final Project project = myUriElement.getProject();
       final DartSdk dartSdk = DartSdk.getDartSdk(project);
-      if (dartSdk != null && !DartAnalysisServerService.isDartSdkVersionForMoveFileRefactoring(dartSdk)) {
+      if (dartSdk != null && !DartAnalysisServerService.isDartSdkVersionSufficientForMoveFileRefactoring(dartSdk)) {
         if (contextFile != null && targetFile != null) {
           final String newUri = DartUrlResolver.getInstance(myUriElement.getProject(), contextFile).getDartUrlForFile(targetFile);
           if (newUri.startsWith(DartUrlResolver.PACKAGE_PREFIX)) {


### PR DESCRIPTION
Rename `DartAnalysisServerService.isDartSdkVersionForMoveFileRefactoring()` to `DartAnalysisServerService.isDartSdkVersionSufficientForMoveFileRefactoring()` to be consistent with the other API naming of the SDK Version "Sufficient" calls