### PR TITLE
Add a comment in the dialog that appears when running the Dart Remote debugger

### DIFF
--- a/Dart/resources/messages/DartBundle.properties
+++ b/Dart/resources/messages/DartBundle.properties
@@ -226,6 +226,8 @@ warning.no.projects.selected.dart.support.will.be.disabled=Warning\: no projects
 debugger.trying.to.connect=Trying to connect
 enter.url.to.running.dart.app=Enter a URL to a running Dart or Flutter application
 connect.to.running.app.title=Connect to a Running App
+connect.to.running.app.comment=Running Dart processes have a VM service that can be connected to via a URL, the URL to connect to the VM \
+  can be found after a Dart process is started on the command line or at the top of the Observatory page.
 dart.line.breakpoints.title=Dart Line Breakpoints
 test.0.in.1={0} in {1}
 all.tests.in.0=tests in {0}

--- a/Dart/resources/messages/DartBundle.properties
+++ b/Dart/resources/messages/DartBundle.properties
@@ -226,8 +226,8 @@ warning.no.projects.selected.dart.support.will.be.disabled=Warning\: no projects
 debugger.trying.to.connect=Trying to connect
 enter.url.to.running.dart.app=Enter a URL to a running Dart or Flutter application
 connect.to.running.app.title=Connect to a Running App
-connect.to.running.app.comment=Running Dart processes have a VM service that can be connected to via a URL, the URL to connect to the VM \
-  can be found after a Dart process is started on the command line or at the top of the Observatory page.
+connect.to.running.app.comment=Running Dart processes have a VM debugger service that can be connected to via a URL; the URL is printed \
+  after a process is started on the command line.
 dart.line.breakpoints.title=Dart Line Breakpoints
 test.0.in.1={0} in {1}
 all.tests.in.0=tests in {0}

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -192,7 +192,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
                                                    public boolean canClose(String inputString) {
                                                      return true;
                                                    }
-                                                 });
+                                                 }, null, DartBundle.message("connect.to.running.app.comment"));
 
       if (debugUrl == null) {
         // Cancel button pressed


### PR DESCRIPTION
@devoncarew @alexander-doroshko 

The label above the input field doesn't wrap (or take HTML), but we are able to add a "comment" which shows up as the light gray text above OK & Cancel:

![Screenshot from 2020-02-13 13-27-28](https://user-images.githubusercontent.com/1533520/74480156-44228d80-4e65-11ea-82a1-ed289acb8768.png)
