### PR TITLE
Update OSMORC plugin to bnd 5.0.0

### DIFF
--- a/osmorc/osmorc-jps-plugin/intellij.osgi.jps.iml
+++ b/osmorc/osmorc-jps-plugin/intellij.osgi.jps.iml
@@ -14,40 +14,40 @@
     <orderEntry type="module" module-name="intellij.maven.jps" />
     <orderEntry type="module-library" exported="">
       <library name="bndlib" type="repository">
-        <properties maven-id="biz.aQute.bnd:biz.aQute.bndlib:4.2.0">
+        <properties maven-id="biz.aQute.bnd:biz.aQute.bndlib:5.0.0">
           <exclude>
             <dependency maven-id="org.slf4j:slf4j-api" />
           </exclude>
         </properties>
         <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.bndlib/5.0.0/biz.aQute.bndlib-5.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.bndlib/4.2.0/biz.aQute.bndlib-4.2.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.bndlib/5.0.0/biz.aQute.bndlib-5.0.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" exported="">
       <library name="bndlib-repository" type="repository">
-        <properties maven-id="biz.aQute.bnd:biz.aQute.repository:4.2.0">
+        <properties maven-id="biz.aQute.bnd:biz.aQute.repository:5.0.0">
           <exclude>
             <dependency maven-id="biz.aQute.bnd:biz.aQute.bndlib" />
             <dependency maven-id="org.slf4j:slf4j-api" />
           </exclude>
         </properties>
         <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.repository/4.2.0/biz.aQute.repository-4.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.repository/5.0.0/biz.aQute.repository-5.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.repository/4.2.0/biz.aQute.repository-4.2.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.repository/5.0.0/biz.aQute.repository-5.0.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" exported="">
       <library name="bndlib-resolve" type="repository">
-        <properties maven-id="biz.aQute.bnd:biz.aQute.resolve:4.2.0">
+        <properties maven-id="biz.aQute.bnd:biz.aQute.resolve:5.0.0">
           <exclude>
             <dependency maven-id="biz.aQute.bnd:biz.aQute.bndlib" />
             <dependency maven-id="biz.aQute.bnd:biz.aQute.repository" />
@@ -55,11 +55,11 @@
           </exclude>
         </properties>
         <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.resolve/4.2.0/biz.aQute.resolve-4.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.resolve/5.0.0/biz.aQute.resolve-5.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.resolve/4.2.0/biz.aQute.resolve-4.2.0-sources.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/biz/aQute/bnd/biz.aQute.resolve/5.0.0/biz.aQute.resolve-5.0.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>


### PR DESCRIPTION
bnd 5.0 was recently released and some of our customers are asking for the updated OSMORC plugin. This patch is unfortunately not tested because I am not sure how to build and test this repository? Is it possible to streamline these updates? Just create a PR like this? Could we build a snapshot version of the plugin in our build?

There seem to be a number of companies interested in this plugin and it would be nice if we could work together to keep this plugin synchronized with the bnd release cycle.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>