### PR TITLE
IDEA-239901 run on module path, similar to running via junit

### DIFF
--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaApplicationConfigurable.form
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaApplicationConfigurable.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jetbrains.plugins.cucumber.java.run.CucumberJavaApplicationConfigurable">
-  <grid id="27dc6" binding="myWholePanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myWholePanel" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="500" height="404"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -41,7 +41,7 @@
       </component>
       <vspacer id="84c61">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="6ccd1" class="com.intellij.execution.ui.CommonJavaParametersPanel" binding="myCommonProgramParameters">
@@ -60,9 +60,20 @@
           <text resource-bundle="messages/ExecutionBundle" key="application.configuration.use.classpath.and.jdk.of.module.label"/>
         </properties>
       </component>
+	  <component id="a287c" class="com.intellij.openapi.ui.LabeledComponent" binding="myUseModulePath">
+		<constraints>
+		  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+		</constraints>
+		<properties>
+		  <componentClass value="javax.swing.JCheckBox"/>
+		  <enabled value="true"/>
+		  <labelLocation value="West"/>
+		  <text value=""/>
+		</properties>
+      </component>
       <component id="cf19a" class="com.intellij.openapi.ui.LabeledComponent" binding="myShortenClasspathModeCombo">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <componentClass value="com.intellij.application.options.ModulesComboBox"/>
@@ -72,7 +83,7 @@
       </component>
       <component id="ca864" class="com.intellij.execution.ui.JrePathEditor" binding="myJrePathEditor">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaApplicationConfigurable.java
+++ b/cucumber-java/src/org/jetbrains/plugins/cucumber/java/run/CucumberJavaApplicationConfigurable.java
@@ -2,6 +2,7 @@
 package org.jetbrains.plugins.cucumber.java.run;
 
 import com.intellij.application.options.ModuleDescriptionsComboBox;
+import com.intellij.execution.ExecutionBundle;
 import com.intellij.execution.configurations.ConfigurationUtil;
 import com.intellij.execution.ui.*;
 import com.intellij.openapi.actionSystem.LangDataKeys;
@@ -16,6 +17,9 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaCodeFragment;
 import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiJavaModule;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiMethodUtil;
 import com.intellij.ui.EditorTextField;
 import com.intellij.ui.EditorTextFieldWithBrowseButton;
@@ -36,6 +40,7 @@ public class CucumberJavaApplicationConfigurable extends SettingsEditor<Cucumber
   private JPanel myWholePanel;
   private LabeledComponent<EditorTextFieldWithBrowseButton> myMainClass;
   private LabeledComponent<ModuleDescriptionsComboBox> myModule;
+  private LabeledComponent<JCheckBox> myUseModulePath;
   private LabeledComponent<RawCommandLineEditor> myGlue;
   private LabeledComponent<TextFieldWithBrowseButton> myFeatureOrFolder;
   private CommonJavaParametersPanel myCommonProgramParameters;
@@ -64,8 +69,13 @@ public class CucumberJavaApplicationConfigurable extends SettingsEditor<Cucumber
 
     myAnchor = UIUtil.mergeComponentsWithAnchor(myMainClass, myGlue, myFeatureOrFolder, myModule, myCommonProgramParameters);
     myJrePathEditor.setAnchor(myModule.getLabel());
+    myUseModulePath.setAnchor(myModule.getLabel());
     myShortenClasspathModeCombo.setAnchor(myModule.getLabel());
     myShortenClasspathModeCombo.setComponent(new ShortenCommandLineModeCombo(myProject, myJrePathEditor, moduleComponent));
+
+    myUseModulePath.getComponent().setText(ExecutionBundle.message("use.module.path.checkbox.label"));
+    myUseModulePath.getComponent().setSelected(true);
+    myUseModulePath.setVisible(FilenameIndex.getFilesByName(project, PsiJavaModule.MODULE_INFO_FILE, GlobalSearchScope.projectScope(myProject)).length > 0);
   }
 
   public void setFeatureOrFolder(String path) {
@@ -110,6 +120,7 @@ public class CucumberJavaApplicationConfigurable extends SettingsEditor<Cucumber
     myFeatureOrFolder.getComponent().setText(configuration.getFilePath());
     myJrePathEditor.setPathOrName(configuration.getAlternativeJrePath(), configuration.isAlternativeJrePathEnabled());
     myShortenClasspathModeCombo.getComponent().setSelectedItem(configuration.getShortenCommandLine());
+    myUseModulePath.getComponent().setSelected(configuration.isUseModulePath());
   }
 
   @Override
@@ -124,6 +135,8 @@ public class CucumberJavaApplicationConfigurable extends SettingsEditor<Cucumber
     configuration.setAlternativeJrePathEnabled(myJrePathEditor.isAlternativeJreSelected());
     configuration.setShortenCommandLine(myShortenClasspathModeCombo.getComponent().getSelectedItem());
     configuration.setModule(myModuleSelector.getModule());
+
+    configuration.setUseModulePath(myUseModulePath.isVisible() && myUseModulePath.getComponent().isSelected());
   }
 
   @NotNull


### PR DESCRIPTION
initial fix for https://youtrack.jetbrains.com/issue/IDEA-239901
* run by default on the module path instead of classpath when module-info.java is present
* add a checkbox in the run configuration to 'use the module path'

Code is copied from JavaTestFrameworkRunnableState


