### PR TITLE
IDEA-137625 Add support for language injection in Cucumber plugin

### DIFF
--- a/cucumber/src/META-INF/plugin.xml
+++ b/cucumber/src/META-INF/plugin.xml
@@ -9,6 +9,8 @@
   ]]>
   </description>
   <depends>com.intellij.modules.xml</depends>
+  <depends>com.intellij.modules.json</depends>
+  <depends>org.jetbrains.plugins.yaml</depends>
   <vendor>JetBrains</vendor>
 
   <extensions defaultExtensionNs="com.intellij">
@@ -92,6 +94,7 @@
       <className>org.jetbrains.plugins.cucumber.intentions.ScenarioToOutlineIntention</className>
       <category>Cucumber</category>
     </intentionAction>
+    <multiHostInjector implementation="org.jetbrains.plugins.cucumber.injector.LanguageInjector"/>
   </extensions>
 
   <extensionPoints>

--- a/cucumber/src/org/jetbrains/plugins/cucumber/injector/InjectedLanguage.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/injector/InjectedLanguage.java
@@ -1,0 +1,102 @@
+package org.jetbrains.plugins.cucumber.injector;
+
+import com.intellij.json.JsonLanguage;
+import com.intellij.lang.Language;
+import com.intellij.lang.xml.XMLLanguage;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.YAMLLanguage;
+
+import java.util.Arrays;
+
+public enum InjectedLanguage {
+    JSON {
+        @Override
+        Language getLanguage() {
+            return JsonLanguage.INSTANCE;
+        }
+    },
+    XML {
+        @Override
+        Language getLanguage() {
+            return XMLLanguage.INSTANCE;
+        }
+
+        /**
+         * Override of the default behaviour for XML. The PSI for XML follows the structure below:
+         *
+         * - host.getFirstChild() => The opening docstring separator
+         * - host.getFirstChild().getNextSibling() => The first PSI element of the XML structure
+         * - host.getFirstChild().getNextSibling().getNextSibling() => The next PSI element of the XML structure
+         * - ...
+         * - host.getLastChild() => The closing docstring separator
+         * @param host the element where the language will be injected into
+         * @return the computed text range
+         */
+        @Override
+        TextRange getRangeInsideHost(@NotNull final PsiLanguageInjectionHost host) {
+            final int startOfXml = host.getFirstChild().getNextSibling().getTextRange().getEndOffset();
+            final PsiElement beforeClosingDocString = host.getLastChild().getPrevSibling();
+            final int endOfXml = beforeClosingDocString.getTextRange().getEndOffset();
+            final int trailingSpacesLength = endOfXml <= startOfXml ? 0 :
+                    InjectedLanguage.trailingSpacesLength(beforeClosingDocString.getText());
+            final int startOffset = startOfXml - host.getTextRange().getStartOffset();
+            final int length = endOfXml - startOfXml - trailingSpacesLength;
+
+            return TextRange.from(startOffset, length);
+        }
+    },
+    YAML {
+        @Override
+        Language getLanguage() {
+            return YAMLLanguage.INSTANCE;
+        }
+    };
+
+    abstract Language getLanguage();
+
+    /**
+     * Compute the text range inside the element into which the language will be injected. By default it is assumed
+     * that the PSI structure for docstrings is:
+     *
+     * - host.getFirstChild() => The opening docstring separator
+     * - host.getFirstChild().getNextSibling() => The text within the docstring
+     * - host.getLastChild() => The closing docstring separator
+     *
+     * This method will compute the range spanning from the first character after the language type string and any
+     * subsequent whitespace to the last character of the docstring text excluding any trailing whitespace.
+     *
+     * @param host the element where the language will be injected into
+     * @return the computed text range
+     */
+    TextRange getRangeInsideHost(@NotNull final PsiLanguageInjectionHost host) {
+        final PsiElement docStringSep = host.getFirstChild();
+        final PsiElement docStringText = docStringSep.getNextSibling();
+        final String afterLangType = StringUtils.substringAfter(docStringText.getText(), name().toLowerCase());
+        final int leadingSpacesLength = leadingSpacesLength(afterLangType);
+        final int langTypeAndSpacesLength = name().length() + leadingSpacesLength;
+        final int startOffset = docStringSep.getTextLength() + langTypeAndSpacesLength;
+        final int trailingSpacesLength = startOffset + docStringSep.getTextLength() >= host.getTextLength() ? 0 :
+                trailingSpacesLength(docStringText.getText());
+        // Skip the docstring separators, the content type string and any leading/trailing whitespace
+        final int length = host.getTextLength() - startOffset - trailingSpacesLength - docStringSep.getTextLength();
+
+        return TextRange.from(startOffset, length);
+    }
+
+    static InjectedLanguage getInjectedLanguage(final String text) {
+        return Arrays.stream(InjectedLanguage.values()).
+                filter(value -> StringUtils.startsWithIgnoreCase(text, value.name())).findFirst().orElse(null);
+    }
+
+    private static int leadingSpacesLength(final String text) {
+        return StringUtils.length(text) - StringUtils.length(StringUtils.stripStart(text, null));
+    }
+
+    private static int trailingSpacesLength(final String text) {
+        return StringUtils.length(text) - StringUtils.length(StringUtils.stripEnd(text, null));
+    }
+}

--- a/cucumber/src/org/jetbrains/plugins/cucumber/injector/LanguageInjector.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/injector/LanguageInjector.java
@@ -1,0 +1,46 @@
+package org.jetbrains.plugins.cucumber.injector;
+
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.cucumber.psi.GherkinPystring;
+
+import java.util.Collections;
+import java.util.List;
+
+public class LanguageInjector implements MultiHostInjector {
+    @NotNull
+    @Override
+    public List<? extends Class<? extends PsiElement>> elementsToInjectIn() {
+        return Collections.singletonList(GherkinPystring.class);
+    }
+
+    @Override
+    public void getLanguagesToInject(@NotNull final MultiHostRegistrar registrar, @NotNull final PsiElement context) {
+        if (!(context instanceof GherkinPystring)) {
+            return;
+        }
+
+        final PsiLanguageInjectionHost host = (PsiLanguageInjectionHost) context;
+        final InjectedLanguage language = getLanguageFromHost(host);
+
+        if (language != null) {
+            final TextRange range = language.getRangeInsideHost(host);
+
+            if (!range.isEmpty()) {
+                registrar.startInjecting(language.getLanguage());
+                registrar.addPlace(null, null, host, range);
+                registrar.doneInjecting();
+            }
+        }
+    }
+
+    private static InjectedLanguage getLanguageFromHost(@NotNull final PsiLanguageInjectionHost host) {
+        final String text = host.getFirstChild().getNextSibling().getText();
+
+        return InjectedLanguage.getInjectedLanguage(text);
+    }
+}

--- a/cucumber/src/org/jetbrains/plugins/cucumber/psi/impl/GherkinPystringImpl.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/psi/impl/GherkinPystringImpl.java
@@ -1,11 +1,14 @@
 package org.jetbrains.plugins.cucumber.psi.impl;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.LiteralTextEscaper;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.cucumber.psi.GherkinElementVisitor;
 import org.jetbrains.plugins.cucumber.psi.GherkinPystring;
 
-public class GherkinPystringImpl extends GherkinPsiElementBase implements GherkinPystring {
+public class GherkinPystringImpl extends GherkinPsiElementBase implements GherkinPystring, PsiLanguageInjectionHost {
   public GherkinPystringImpl(@NotNull final ASTNode node) {
     super(node);
   }
@@ -18,5 +21,26 @@ public class GherkinPystringImpl extends GherkinPsiElementBase implements Gherki
   @Override
   public String toString() {
     return "GherkinPystring";
+  }
+
+  @Override
+  public boolean isValidHost() {
+    return true;
+  }
+
+  @Override
+  public PsiLanguageInjectionHost updateText(@NotNull final String text) {
+    final String docStringSep = getFirstChild().getText();
+    final int startOffset = text.startsWith(docStringSep) ? docStringSep.length() : 0;
+    final int endOffset = text.endsWith(docStringSep) ? docStringSep.length() : 0;
+    ((LeafPsiElement) getFirstChild().getNextSibling()).
+            replaceWithText(text.substring(startOffset, text.length() - endOffset));
+    getFirstChild().getNextSibling().getNextSibling().replace(getLastChild());
+    return this;
+  }
+
+  @Override
+  public @NotNull LiteralTextEscaper<? extends PsiLanguageInjectionHost> createLiteralTextEscaper() {
+    return LiteralTextEscaper.createSimple(this);
   }
 }


### PR DESCRIPTION
Adds supports for injecting XML/JSON/YAML in Gherkin docstrings. See https://youtrack.jetbrains.com/issue/IDEA-137625 for details of the feature request