### PR TITLE
WEB-46098 Deno: Support custom DENO_DIR environment variable

### DIFF
--- a/Deno/src/com/intellij/deno/DenoUtil.kt
+++ b/Deno/src/com/intellij/deno/DenoUtil.kt
@@ -37,6 +37,10 @@ object DenoUtil {
   }
 
   private fun getDenoDirPath(): String {
+    val denoDir = System.getenv("DENO_DIR");
+    if (denoDir != null) {
+      return denoDir
+    }
     val userHome = SystemProperties.getUserHome()
     if (SystemInfoRt.isMac) {
       return "$userHome/Library/Caches/deno"


### PR DESCRIPTION
This PR aims to support the `DENO_DIR` environment variable.

Deno itself also checks whether the variable is absolute or not [here](https://github.com/denoland/deno/blob/d619e3c7ac8618c5cd30fcc314db2ef994c604e4/cli/deno_dir.rs#L18-L22). I'm not really sure how the paths are handled inside of IntelliJ so I'll only mention it but this has to be checked.