### PR TITLE
Change in the Dart VM debugger to not log an error if there are no isolates

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -99,10 +99,6 @@ public class VmServiceWrapper implements Disposable {
             getVm(new VmServiceConsumers.VmConsumerWrapper() {
               @Override
               public void received(final VM vm) {
-                if (vm.getIsolates().size() == 0) {
-                  Logging.getLogger().logError("No isolates found after VM start: " + vm.getIsolates().size());
-                }
-
                 for (final IsolateRef isolateRef : vm.getIsolates()) {
                   getIsolate(isolateRef.getId(), new VmServiceConsumers.GetIsolateConsumerWrapper() {
                     @Override


### PR DESCRIPTION
@devoncarew @alexander-doroshko 

This is cleanup as part of the recent DDS change in the Dart VM

Change in the Flutter Plugin - https://github.com/flutter/flutter-intellij/pull/4842

Enabling PR for the Dart VM - https://dart-review.googlesource.com/c/sdk/+/162942

