### PR TITLE
remove a log warning when we don't understand the uri scheme

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1907,8 +1907,6 @@ public final class DartAnalysisServerService implements Disposable {
 
       @Override
       public void onError(final RequestError error) {
-        LOG.warn(
-          "execution_mapUri(" + _id + ", " + filePath + ", " + _uri + ") returned error " + error.getCode() + ": " + error.getMessage());
         latch.countDown();
       }
     });


### PR DESCRIPTION
When debugging a Flutter web app, we can see the following warning in the log:

```
WARN - yzer.DartAnalysisServerService - execution_mapUri(0, null, org-dartlang-app:/web_entrypoint.dart) returned error INVALID_PARAMETER: Invalid parameter 'uri'. Invalid URI. 
```

This is due to the fact that:
- flutter web uses the special `org-dartlang-app:` uri scheme for the synthetic bootstrap script for flutter web app
- when debugging, we ask the analysis server to map uri to file locations
- the analysis server is not familiar with this uri scheme (and would not be able to locate a corresponding file on disk even if it understood the scheme)

This error isn't actionable by the user, and the fact that we couldn't map from the uri to a file is already indicated by the null result from `execution_mapUri()`.

cc @alexander-doroshko 