### PR TITLE
Add generated manifest to auto-wrapped bundles

### DIFF
--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/BndWrapper.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/BndWrapper.java
@@ -163,9 +163,8 @@ public class BndWrapper {
         analyzer.setProperty(Constants.BUNDLE_VERSION, version);
       }
 
-      analyzer.calcManifest();
-
       try (Jar jar = analyzer.getJar()) {
+        jar.setManifest(analyzer.calcManifest());
         jar.write(outputJar);
       }
 


### PR DESCRIPTION
calcManifest used to automatically set its result to the jar, but this
is no longer the case since bndtools/bnd@6b8b5596b41cef2eb51acca386b5631ffded0951

Fixes IDEA-112951