### PR TITLE
remove the (commented out) use of the --file-read-mode cli option

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -1984,7 +1984,6 @@ public final class DartAnalysisServerService implements Disposable {
 
       @NonNls String serverArgsRaw = "";
       serverArgsRaw += " --useAnalysisHighlight2";
-      //serverArgsRaw += " --file-read-mode=normalize-eol-always";
       try {
         serverArgsRaw += " " + Registry.stringValue("dart.server.additional.arguments");
       }


### PR DESCRIPTION
- remove the (commented out) use of the --file-read-mode cli option

This option hadn't been used in ~4 years. Given that, we're planning to remove it from the analysis server.

@alexander-doroshko 