### PR TITLE
IDEA-138550 Add basic support for bnd-maven-plugin

### DIFF
--- a/osmorc/osmorc-jps-plugin/src/messages/OsgiJpsBundle.properties
+++ b/osmorc/osmorc-jps-plugin/src/messages/OsgiJpsBundle.properties
@@ -5,6 +5,7 @@ session.bundle.path.empty=Bundle path is empty - please check OSGi facet setting
 session.cannot.delete.bundle=Cannot delete bundle file ''{0}''
 session.cannot.create.output=Cannot create a directory for bundles ''{0}''
 session.running.bnd=Running Bnd to build the bundle
+session.pom.missing=Cannot find Maven pom.xml
 session.bnd.missing=Bnd file ''{0}'' is missing - please check OSGi facet settings
 session.bundlor.running=Running Bundlor to calculate the manifest
 session.bundlor.missing=Bundlor file ''{0}'' is missing - please check OSGi facet settings

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsgiBuildSession.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsgiBuildSession.java
@@ -158,6 +158,46 @@ public class OsgiBuildSession implements Reporter {
       }
       mySourceToReport = null;
     }
+    else if (myExtension.isUseBndMavenPlugin()) {
+      File bndFile = myExtension.getBundleDescriptorFile();
+      File base = null;
+      if (bndFile != null && bndFile.isFile()) {
+        // explicitly specified bndfile that exists
+        mySourceToReport = bndFile.getAbsolutePath();
+      }
+      else if (StringUtil.isNotEmpty(myExtension.getBndFileLocation())) {
+        // explicitly specified bndfile that does not exist - fail to report a build error
+        throw new OsgiBuildException(message("session.bnd.missing", myExtension.getBndFileLocation()));
+      }
+      else {
+        // no bndfile specified, try to fallback to the default bnd.bnd file next to the pom.xml
+        File mavenProjectPath = OsgiBuildUtil.getMavenProjectPath(myContext, myModule);
+        if (mavenProjectPath != null) {
+          bndFile = new File(mavenProjectPath.getParentFile(), "bnd.bnd");
+          if (bndFile.isFile()) {
+            mySourceToReport = bndFile.getAbsolutePath();
+          }
+          else{
+            bndFile = null;
+            // default not found, use the pom.xml location as the base and error source
+            mySourceToReport = mavenProjectPath.getAbsolutePath();
+            base = mavenProjectPath.getParentFile();
+          }
+        }
+      }
+
+      Properties mavenProperties = OsgiBuildUtil.getMavenProjectProperties(myContext, myModule);
+      try {
+        myBndWrapper.build(bndFile, myExtension.getAdditionalProperties(), mavenProperties,
+                           myClasses, mySources, base, myModuleOutputDir, myOutputJarFile);
+      }
+      catch (Exception e) {
+        throw new OsgiBuildException(message("session.unknown.error"), e, null);
+      }
+      finally {
+        mySourceToReport = null;
+      }
+    }
     else if (myExtension.isUseBundlorFile()) {
       String bundlorPath = myExtension.getBundlorFileLocation();
       File bundlorFile = OsgiBuildUtil.findFileInModuleContentRoots(myModule, bundlorPath);

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsgiBuildSession.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsgiBuildSession.java
@@ -172,17 +172,19 @@ public class OsgiBuildSession implements Reporter {
       else {
         // no bndfile specified, try to fallback to the default bnd.bnd file next to the pom.xml
         File mavenProjectPath = OsgiBuildUtil.getMavenProjectPath(myContext, myModule);
-        if (mavenProjectPath != null) {
-          bndFile = new File(mavenProjectPath.getParentFile(), "bnd.bnd");
-          if (bndFile.isFile()) {
-            mySourceToReport = bndFile.getAbsolutePath();
-          }
-          else{
-            bndFile = null;
-            // default not found, use the pom.xml location as the base and error source
-            mySourceToReport = mavenProjectPath.getAbsolutePath();
-            base = mavenProjectPath.getParentFile();
-          }
+        if (mavenProjectPath == null) {
+          throw new OsgiBuildException(message("session.pom.missing"));
+        }
+
+        bndFile = new File(mavenProjectPath.getParentFile(), "bnd.bnd");
+        if (bndFile.isFile()) {
+          mySourceToReport = bndFile.getAbsolutePath();
+        }
+        else{
+          bndFile = null;
+          // default not found, use the pom.xml location as the base and error source
+          mySourceToReport = mavenProjectPath.getAbsolutePath();
+          base = mavenProjectPath.getParentFile();
         }
       }
 

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsmorcBuildTarget.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/OsmorcBuildTarget.java
@@ -80,6 +80,14 @@ public class OsmorcBuildTarget extends ModuleBasedTarget<BuildRootDescriptor> {
       if (file != null) {
         rootDescriptors.add(new BuildRootDescriptorImpl(this, file, true));
       }
+      else if (extension.isUseBndMavenPlugin()) {
+        // fallback to watching the default bnd file
+        File mavenProjectPath = OsgiBuildUtil.findMavenProjectPath(dataPaths, myModule);
+        if (mavenProjectPath != null) {
+          file = new File(mavenProjectPath.getParentFile(), "bnd.bnd");
+          rootDescriptors.add(new BuildRootDescriptorImpl(this, file, true));
+        }
+      }
     }
 
     JpsJavaExtensionService.dependencies(getModule()).recursively().productionOnly().processModules(module -> {

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/ReportingBuilder.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/build/ReportingBuilder.java
@@ -25,6 +25,7 @@
 package org.jetbrains.osgi.jps.build;
 
 import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Processor;
 import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +40,7 @@ public class ReportingBuilder extends Builder {
     myReporter = reporter;
   }
 
-  public ReportingBuilder(@NotNull Reporter reporter, @NotNull Builder parent) {
+  public ReportingBuilder(@NotNull Reporter reporter, @NotNull Processor parent) {
     super(parent);
     myReporter = reporter;
     use(parent);

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/JpsOsmorcModuleExtension.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/JpsOsmorcModuleExtension.java
@@ -39,6 +39,8 @@ public interface JpsOsmorcModuleExtension extends JpsElement {
 
   boolean isUseBndFile();
 
+  boolean isUseBndMavenPlugin();
+
   boolean isUseBundlorFile();
 
   boolean isManifestManuallyEdited();

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/ManifestGenerationMode.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/ManifestGenerationMode.java
@@ -29,6 +29,10 @@ public enum ManifestGenerationMode {
    */
   Bnd,
   /**
+   * Bnd will generate it using a bnd file, configured from bnd-maven-plugin.
+   */
+  BndMavenPlugin,
+  /**
    * Bundlor will generate it, using a bundlor file.
    */
   Bundlor

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/JpsOsmorcModuleExtensionImpl.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/model/impl/JpsOsmorcModuleExtensionImpl.java
@@ -45,6 +45,13 @@ public class JpsOsmorcModuleExtensionImpl extends JpsElementBase<JpsOsmorcModule
       if (myProperties.myManifestGenerationMode == ManifestGenerationMode.Bnd) {
         return OsgiBuildUtil.findFileInModuleContentRoots(getModule(), getBndFileLocation());
       }
+      else if (myProperties.myManifestGenerationMode == ManifestGenerationMode.BndMavenPlugin) {
+        if (StringUtil.isNotEmpty(getBndFileLocation())) {
+          return OsgiBuildUtil.findFileInModuleContentRoots(getModule(), getBndFileLocation());
+        }
+
+        return null;
+      }
       else if (myProperties.myManifestGenerationMode == ManifestGenerationMode.Bundlor) {
         return OsgiBuildUtil.findFileInModuleContentRoots(getModule(), getBundlorFileLocation());
       }
@@ -114,6 +121,11 @@ public class JpsOsmorcModuleExtensionImpl extends JpsElementBase<JpsOsmorcModule
   @Override
   public boolean isUseBndFile() {
     return myProperties.myManifestGenerationMode == ManifestGenerationMode.Bnd;
+  }
+
+  @Override
+  public boolean isUseBndMavenPlugin() {
+    return myProperties.myManifestGenerationMode == ManifestGenerationMode.BndMavenPlugin;
   }
 
   @Override

--- a/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/util/OsgiBuildUtil.java
+++ b/osmorc/osmorc-jps-plugin/src/org/jetbrains/osgi/jps/util/OsgiBuildUtil.java
@@ -59,6 +59,11 @@ public final class OsgiBuildUtil {
 
   private static File findMavenProjectPath(CompileContext context, JpsModule module) {
     BuildDataPaths dataPaths = context.getProjectDescriptor().dataManager.getDataPaths();
+    return findMavenProjectPath(dataPaths, module);
+  }
+
+  @Nullable
+  public static File findMavenProjectPath(BuildDataPaths dataPaths, JpsModule module) {
     MavenProjectConfiguration projectConfig = JpsMavenExtensionService.getInstance().getMavenProjectConfiguration(dataPaths);
     if (projectConfig != null) {
       MavenModuleResourceConfiguration moduleConfig = projectConfig.moduleConfigurations.get(module.getName());

--- a/osmorc/resources/META-INF/osgi-maven-support.xml
+++ b/osmorc/resources/META-INF/osgi-maven-support.xml
@@ -26,6 +26,7 @@
 
   <extensions defaultExtensionNs="org.jetbrains.idea.maven">
     <importer implementation="org.osmorc.maven.facet.OsmorcFacetImporter"/>
+    <importer implementation="org.osmorc.maven.facet.OsmorcBndFacetImporter"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/osmorc/resources/messages/OsmorcBundle.properties
+++ b/osmorc/resources/messages/OsmorcBundle.properties
@@ -153,6 +153,7 @@ bundle.selector.group.modules=Modules
 bundle.selector.group.framework=Framework bundles
 bundle.selector.group.libraries=Project libraries
 
+maven.import.error=Error processing bnd-maven-plugin configuration in ''{0}'': {1}
 maven.import.embed.error=Error when processing Embed-Dependency directive in ''{0}'': {1}
 
 facet.type.name=OSGi
@@ -181,6 +182,7 @@ facet.form.general.custom=Custom
 facet.form.general.custom.path=Manifest file location
 facet.form.general.custom.comment=(relative to module root)
 facet.form.general.bnd=Use Bnd and ignore facet configuration
+facet.form.general.bndmavenplugin=Use configuration from bnd-maven-plugin
 facet.form.general.bnd.path=Bnd file location
 facet.form.general.bundlor=Use Bundlor and ignore facet configuration
 facet.form.general.bundlor.path=Bundlor file location

--- a/osmorc/src/org/osmorc/facet/OsmorcFacetConfiguration.java
+++ b/osmorc/src/org/osmorc/facet/OsmorcFacetConfiguration.java
@@ -26,6 +26,7 @@ package org.osmorc.facet;
 
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
+import com.intellij.compiler.server.BuildManager;
 import com.intellij.facet.FacetConfiguration;
 import com.intellij.facet.ui.FacetEditorContext;
 import com.intellij.facet.ui.FacetEditorTab;
@@ -300,6 +301,10 @@ public final class OsmorcFacetConfiguration implements FacetConfiguration, Modif
 
   public boolean isUseBndFile() {
     return getManifestGenerationMode() == ManifestGenerationMode.Bnd;
+  }
+
+  public boolean isUseBndMavenPlugin() {
+    return getManifestGenerationMode() == ManifestGenerationMode.BndMavenPlugin;
   }
 
   /**

--- a/osmorc/src/org/osmorc/facet/ui/OsmorcFacetGeneralEditorTab.form
+++ b/osmorc/src/org/osmorc/facet/ui/OsmorcFacetGeneralEditorTab.form
@@ -124,7 +124,7 @@
               <text resource-bundle="messages/OsmorcBundle" key="facet.form.general.bnd"/>
             </properties>
           </component>
-          <grid id="c756d" binding="myBndPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="c756d" binding="myBndPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="3" use-parent-layout="true"/>
@@ -147,6 +147,14 @@
                 </constraints>
                 <properties>
                   <text resource-bundle="messages/OsmorcBundle" key="facet.form.general.bnd.path"/>
+                </properties>
+              </component>
+              <component id="ade9b" class="javax.swing.JCheckBox" binding="myUseBndMavenPluginCheckBox">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="messages/OsmorcBundle" key="facet.form.general.bndmavenplugin"/>
                 </properties>
               </component>
             </children>

--- a/osmorc/src/org/osmorc/facet/ui/OsmorcFacetJAREditorTab.java
+++ b/osmorc/src/org/osmorc/facet/ui/OsmorcFacetJAREditorTab.java
@@ -256,8 +256,9 @@ public class OsmorcFacetJAREditorTab extends FacetEditorTab {
     myJarOutputPathChooser.setEnabled(myPlaceInThisPathRadioButton.isSelected());
 
     Boolean bnd = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.BND_CREATION_KEY);
+    Boolean bndMavenPlugin = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.BND_MAVEN_PLUGIN_CREATION_KEY);
     Boolean bundlor = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.BUNDLOR_CREATION_KEY);
-    boolean useExternalTool = Boolean.TRUE.equals(bnd) || Boolean.TRUE.equals(bundlor);
+    boolean useExternalTool = Boolean.TRUE.equals(bnd) || Boolean.TRUE.equals(bndMavenPlugin) || Boolean.TRUE.equals(bundlor);
     myAdditionalJARContentsTable.setEnabled(!useExternalTool);
     myAdditionalJarContentsPanel.setEnabled(!useExternalTool);
     myIgnoreFilePatternTextField.setEnabled(!useExternalTool);

--- a/osmorc/src/org/osmorc/facet/ui/OsmorcFacetManifestGenerationEditorTab.java
+++ b/osmorc/src/org/osmorc/facet/ui/OsmorcFacetManifestGenerationEditorTab.java
@@ -78,8 +78,9 @@ public class OsmorcFacetManifestGenerationEditorTab extends FacetEditorTab {
   private void updateGui() {
     boolean isManuallyEdited = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.MANUAL_MANIFEST_EDITING_KEY) == Boolean.TRUE;
     boolean isBnd = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.BND_CREATION_KEY) == Boolean.TRUE;
+    boolean isBndMavenPlugin = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.BND_MAVEN_PLUGIN_CREATION_KEY) == Boolean.TRUE;
     boolean isBundlor = myEditorContext.getUserData(OsmorcFacetGeneralEditorTab.BUNDLOR_CREATION_KEY) == Boolean.TRUE;
-    boolean isUiEnabled = !(isManuallyEdited || isBnd || isBundlor);
+    boolean isUiEnabled = !(isManuallyEdited || isBnd || isBndMavenPlugin || isBundlor);
 
     myBundleSymbolicName.setEnabled(isUiEnabled);
     myBundleActivator.setEnabled(isUiEnabled);

--- a/osmorc/src/org/osmorc/maven/facet/OsmorcBndFacetImporter.java
+++ b/osmorc/src/org/osmorc/maven/facet/OsmorcBndFacetImporter.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2007-2009, Osmorc Development Team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright notice, this list
+ *       of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this
+ *       list of conditions and the following disclaimer in the documentation and/or other
+ *       materials provided with the distribution.
+ *     * Neither the name of 'Osmorc Development Team' nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without specific
+ *       prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.osmorc.maven.facet;
+
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.version.MavenVersion;
+import aQute.lib.utf8properties.UTF8Properties;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jdom.Element;
+import org.jetbrains.idea.maven.importing.FacetImporter;
+import org.jetbrains.idea.maven.importing.MavenRootModelAdapter;
+import org.jetbrains.idea.maven.model.MavenId;
+import org.jetbrains.idea.maven.model.MavenPlugin;
+import org.jetbrains.idea.maven.project.*;
+import org.jetbrains.osgi.jps.model.ManifestGenerationMode;
+import org.jetbrains.osgi.jps.model.OutputPathType;
+import org.osmorc.facet.OsmorcFacet;
+import org.osmorc.facet.OsmorcFacetConfiguration;
+import org.osmorc.facet.OsmorcFacetType;
+import org.osmorc.i18n.OsmorcBundle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Reads Maven project data and imports OSGi settings from bnd-maven-plugin as an Osmorc facet.
+ * <p>
+ * The generated manifest will only be similar to the Maven plugin, not the same. The Maven
+ * model available here does not export everything required and the two-phase execution
+ * (parsing in the facet, Bnd-execution in the JPS build) is not the same as the
+ * everything-at-once in an actual Maven build.
+ */
+public class OsmorcBndFacetImporter extends FacetImporter<OsmorcFacet, OsmorcFacetConfiguration, OsmorcFacetType> {
+  private static final Logger LOG = Logger.getInstance(OsmorcBndFacetImporter.class);
+  private static final String BND_PLUGIN_GOAL = "bnd-process";
+
+  public OsmorcBndFacetImporter() {
+    super("biz.aQute.bnd", "bnd-maven-plugin", OsmorcFacetType.getInstance());
+  }
+
+  @Override
+  public boolean isApplicable(MavenProject mavenProject) {
+    return super.isApplicable(mavenProject) && !"bundle".equals(mavenProject.getPackaging());
+  }
+
+  @Override
+  public void getSupportedDependencyTypes(Collection<String> result, SupportedRequestType type) {
+    result.add("bundle");
+  }
+
+  @Override
+  protected void setupFacet(OsmorcFacet osmorcFacet, MavenProject mavenProjectModel) { }
+
+  @Override
+  protected void reimportFacet(IdeModifiableModelsProvider modelsProvider, Module module,
+                               MavenRootModelAdapter mavenRootModelAdapter, OsmorcFacet osmorcFacet,
+                               MavenProjectsTree mavenProjectsTree, MavenProject mavenProject,
+                               MavenProjectChanges changes, Map<MavenProject, String> mavenProjectStringMap,
+                               List<MavenProjectsProcessorTask> mavenProjectsProcessorPostConfigurationTasks) {
+    OsmorcFacetConfiguration conf = osmorcFacet.getConfiguration();
+    if (conf.isDoNotSynchronizeWithMaven()) {
+      return;
+    }
+
+    MavenPlugin plugin = mavenProject.findPlugin(myPluginGroupID, myPluginArtifactID);
+    if (plugin == null) {
+      return;
+    }
+
+    conf.setManifestGenerationMode(ManifestGenerationMode.BndMavenPlugin);
+    Map<String, String> props = new LinkedHashMap<>();  // to preserve the order of elements
+
+    // load properties from Maven plugin configuration
+    try {
+      String bndFile = loadProjectProperties(props, mavenProject);
+      conf.setBndFileLocation(bndFile);
+    }
+    catch (Exception e) {
+      String message = OsmorcBundle.message("maven.import.error", mavenProject.getPath(), e.getMessage());
+      OsmorcBundle.bnd("", message, NotificationType.ERROR).notify(module.getProject());
+    }
+
+    // add defaults derived from Maven properties
+    // developers and license are not available from the model map
+    MavenId mavenId = mavenProject.getMavenId();
+    Map<String, String> modelMap = mavenProject.getModelMap();
+    props.putIfAbsent(Constants.BUNDLE_SYMBOLICNAME, mavenId.getArtifactId());
+    addProperty(props, Constants.BUNDLE_NAME, mavenProject.getName());
+    props.computeIfAbsent(Constants.BUNDLE_VERSION, k -> new MavenVersion(mavenId.getVersion()).getOSGiVersion().toString());
+    addProperty(props, Constants.BUNDLE_DESCRIPTION, modelMap.get("description"));
+    addProperty(props, Constants.BUNDLE_VENDOR, modelMap.get("organization.name"));
+    addProperty(props, Constants.BUNDLE_SCM, modelMap.get("scm"));
+    addProperty(props, Constants.BUNDLE_DOCURL, modelMap.get("url"));
+
+    // add settings for reproducible build if Maven is configured for it
+    String outputTimestamp = mavenProject.getProperties().getProperty("project.build.outputTimestamp");
+    if (StringUtil.isNotEmpty(outputTimestamp)) {
+      props.putIfAbsent(Constants.NOEXTRAHEADERS, "true");
+      props.putIfAbsent(Constants.SNAPSHOT, "SNAPSHOT");
+    }
+
+    // Fix for IDEA-63242 - don't merge it with the existing settings, overwrite them
+    conf.importAdditionalProperties(props, true);
+
+    // Fix for IDEA-66235 - inherit jar filename from maven
+    String jarFileName = mavenProject.getFinalName() + ".jar";
+
+    // Fix for IDEA-67088, preserve existing output path settings on reimport.
+    switch (conf.getOutputPathType()) {
+      case OsgiOutputPath:
+        conf.setJarFileLocation(jarFileName, OutputPathType.OsgiOutputPath);
+        break;
+      case SpecificOutputPath:
+        String path = new File(conf.getJarFilePath(), jarFileName).getPath();
+        conf.setJarFileLocation(path, OutputPathType.SpecificOutputPath);
+        break;
+      default:
+        conf.setJarFileLocation(jarFileName, OutputPathType.CompilerOutputPath);
+    }
+  }
+
+  private static void addProperty(Map<String, String> headers, String headerName, String value) {
+    if (!StringUtil.isEmpty(value)) {
+      headers.putIfAbsent(headerName, value);
+    }
+  }
+
+  private String loadProjectProperties(Map<String, String> props, MavenProject mavenProject) throws IOException {
+    VirtualFile pomVirtualFile = mavenProject.getFile();
+
+    // get bnd-maven-plugin configuration from <plugin>/<execution> or fallback to <plugin>
+    Element configuration = getGoalConfig(mavenProject, BND_PLUGIN_GOAL);
+    if (configuration == null || configuration.getContent().isEmpty()) {
+      configuration = getConfig(mavenProject);
+    }
+
+    if (configuration != null) {
+      // configuration in <bnd> element
+      Element bndElement = configuration.getChild("bnd");
+      if (bndElement != null) {
+        LOG.debug("Using headers from bnd-element in " + mavenProject.getPath());
+        File pomFile = new File(pomVirtualFile.getPath());
+        UTF8Properties properties = new UTF8Properties();
+        properties.load(bndElement.getValue(), pomFile, null);
+        for (Map.Entry<?, ?> e : properties.replaceHere(pomFile.getParentFile()).entrySet()) {
+          props.put(e.getKey().toString(), e.getValue().toString());
+        }
+      }
+
+      // <bndfile> element
+      Element bndfileElement = configuration.getChild("bndfile");
+      if (bndfileElement != null) {
+        String bndFile = bndfileElement.getValue();
+        LOG.debug("Using bnd file from bndfile-element: " + bndFile);
+        return bndFile;
+      }
+    }
+
+    // no bnd file found, use properties from <bnd> element or defaults only
+    return null;
+  }
+}


### PR DESCRIPTION
This PR adds a new FacetImporter to detect the bnd-maven-plugin to add and configure the OSGI facet.

The generated manifest and jar will only be similar to the Maven plugin, not the same. The Maven model available during the import is not the same as the native Maven model, and the two-phase execution (parsing in the facet, Bnd-execution in the JPS build) is not the same as the everything-at-once in an actual Maven build. It is however sufficient for basic support and to enable all the existing code assistance.

Detection of the plugin is shown as a new UI option:
![image](https://user-images.githubusercontent.com/949783/103416637-d91a9c00-4b87-11eb-863c-17d7b209541c.png)

The embedded bndtools are updated to v5.2.0.