### PR TITLE
Update the Dart problem hover tooltips to include the additional context messages

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java
@@ -275,7 +275,7 @@ public final class DartAnnotator implements Annotator {
     final String severity = error.getSeverity();
     final String message = error.getMessage();
     final ProblemHighlightType specialHighlightType = getSpecialHighlightType(error);
-    final String tooltip = DartProblem.generateTooltipText(error.getMessage(), error.getCorrection(), error.getUrl());
+    final String tooltip = DartProblem.generateTooltipText(error.getMessage(), error.getContextMessages(), error.getCorrection(), error.getUrl());
     final HighlightSeverity annotationSeverity;
     TextAttributesKey textAttributesKey;
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -12,8 +12,10 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.PathUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.analyzer.DartServerData;
 import com.jetbrains.lang.dart.util.DartBuildFileUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.dartlang.analysis.server.protocol.AnalysisError;
@@ -167,10 +169,16 @@ public class DartProblem {
   }
 
   public static @NotNull @Nls String generateTooltipText(@NotNull @Nls String message,
+                                                         @NotNull List<DartServerData.DartDiagnosticMessage> contextMessages,
                                                          @Nullable @Nls String correction,
                                                          @Nullable @NonNls String url) {
-
     HtmlBuilder htmlBuilder = new HtmlBuilder().append(message);
+    if (!contextMessages.isEmpty()) {
+      for (DartServerData.DartDiagnosticMessage contextMessage : contextMessages) {
+        htmlBuilder.append(HtmlChunk.br()).append(HtmlChunk.br()).append(contextMessage.getMessage());
+        htmlBuilder.append(HtmlChunk.nbsp()).append("(" + PathUtil.getFileName(contextMessage.getFile()) + ")");
+      }
+    }
     if (StringUtil.isNotEmpty(correction)) {
       htmlBuilder.append(HtmlChunk.br()).append(HtmlChunk.br()).append(correction);
     }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblem.java
@@ -1,8 +1,7 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.lang.dart.ide.errorTreeView;
 
-import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.impl.FileOffsetsManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.NlsSafe;
@@ -186,10 +185,8 @@ public class DartProblem {
 
         VirtualFile vFile = LocalFileSystem.getInstance().findFileByPath(filePath);
         if (vFile != null) {
-          final Document document = FileDocumentManager.getInstance().getDocument(vFile);
-          if (document != null) {
-            // Note, Document.getLineNumber(int) is 0-based, add 1 to match 1-based IntelliJ line numbering:
-            final int line = document.getLineNumber(contextMessage.getOffset()) + 1;
+          int line = FileOffsetsManager.getInstance().getLineNumber(vFile, contextMessage.getOffset());
+          if (line >= 0) {
             htmlBuilder.append(":" + line);
           }
         }

--- a/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsTableModel.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsTableModel.java
@@ -1,7 +1,6 @@
 // Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.lang.dart.ide.errorTreeView;
 
-import com.intellij.analysis.AnalysisBundle;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -12,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.ColumnInfo;
 import com.intellij.util.ui.ListTableModel;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analyzer.DartServerData;
 import org.dartlang.analysis.server.protocol.AnalysisError;
 import org.dartlang.analysis.server.protocol.AnalysisErrorSeverity;
 import org.jetbrains.annotations.Nls;
@@ -37,7 +37,10 @@ class DartProblemsTableModel extends ListTableModel<DartProblem> {
       setText(problem.getErrorMessage().replaceAll("(\n)+", " "));
 
       // Pass null to the url, mouse movement to the hover makes the tooltip go away, see https://youtrack.jetbrains.com/issue/WEB-39449
-      setToolTipText(DartProblem.generateTooltipText(problem.getErrorMessage(), problem.getCorrectionMessage(), null));
+      setToolTipText(DartProblem.generateTooltipText(problem.getErrorMessage(),
+                                                     DartServerData.DartDiagnosticMessage
+                                                       .generateDartDiagnosticMessageList(problem.getDiagnosticMessages()),
+                                                     problem.getCorrectionMessage(), null));
 
       String severity = problem.getSeverity();
       setIcon(AnalysisErrorSeverity.ERROR.equals(severity)


### PR DESCRIPTION
@alexander-doroshko 

See image, but ignore the change showing the text of the URL:

![new_problem_hover](https://user-images.githubusercontent.com/1533520/108268529-80946380-7121-11eb-8313-8df7b87f7687.png)

The new change is that the text "Variable 'i' could be null due to..."

This is an initial cut.  Is it possible with a URL in HTML blocks in IJ to have the location metadata link to a location in source?  You'll see in the PR that we have the offset and full file path for the intervening write.

