### PR TITLE
Update various Dart links to their current equivalents

### DIFF
--- a/Dart/README.md
+++ b/Dart/README.md
@@ -1,6 +1,6 @@
 # Dart Plugin for IntelliJ IDEA and other JetBrains IDEs
 
-This plugin provides support for the [Dart programming language](https://www.dartlang.org/).
+This plugin provides support for the [Dart programming language](https://www.dart.dev/).
 
 ## Installing and Getting Started
 

--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
   <name>Dart</name>
   <id>Dart</id>
   <description><![CDATA[
-<p>Support for <a href="https://www.dartlang.org/">Dart</a></p>
+<p>Support for <a href="https://www.dart.dev/">Dart</a></p>
 <p>Features</p>
 <ul>
 <li>Smart coding assistance for Dart that includes code completion, formatting, navigation, intentions, refactorings, and more</li>

--- a/Dart/resources/inspectionDescriptions/DartOutdatedDependencies.html
+++ b/Dart/resources/inspectionDescriptions/DartOutdatedDependencies.html
@@ -1,7 +1,7 @@
 <html>
 <body>
-This inspection checks whether <code><a href="https://www.dartlang.org/tools/pub/cmd/pub-get.html">pub get</a></code>
-or <code><a href="https://www.dartlang.org/tools/pub/cmd/pub-upgrade.html">pub upgrade</a></code> is run after editing
-<code><a href="https://www.dartlang.org/tools/pub/pubspec.html">pubspec.yaml</a></code> file.
+This inspection checks whether <code><a href="https://dart.dev/tools/pub/cmd/pub-get.html">pub get</a></code>
+or <code><a href="https://dart.dev/tools/pub/cmd/pub-upgrade.html">pub upgrade</a></code> is run after editing
+<code><a href="https://dart.dev/tools/pub/pubspec.html">pubspec.yaml</a></code> file.
 </body>
 </html>

--- a/Dart/src/com/jetbrains/lang/dart/DartStartupActivity.java
+++ b/Dart/src/com/jetbrains/lang/dart/DartStartupActivity.java
@@ -78,12 +78,12 @@ public final class DartStartupActivity implements StartupActivity.Background {
       root == null ? null : ProjectRootManager.getInstance(module.getProject()).getFileIndex().getContentRootForFile(root);
     if (contentRoot == null) return;
 
-    // http://pub.dartlang.org/doc/glossary.html#entrypoint-directory
+    // https://dart.dev/tools/pub/glossary#entrypoint-directory
     // Entrypoint directory: A directory inside your package that is allowed to contain Dart entrypoints.
     // Pub has a whitelist of these directories: benchmark, bin, example, test, tool, and web.
     // Any subdirectories of those (except bin) may also contain entrypoints.
     //
-    // the same can be seen in the pub tool source code: [repo root]/sdk/lib/_internal/pub/lib/src/entrypoint.dart
+    // the same can be seen in the pub tool source code: https://github.com/dart-lang/pub/blob/master/lib/src/entrypoint.dart
 
     final DartSdk sdk = DartSdk.getDartSdk(module.getProject());
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class DartDocumentationProvider implements DocumentationProvider {
-  private static final String BASE_DART_DOC_URL = "https://api.dartlang.org/stable/";
+  private static final String BASE_DART_DOC_URL = "https://api.dart.dev/stable/";
 
   @Override
   public String generateDoc(@NotNull final PsiElement element, @Nullable final PsiElement originalElement) {
@@ -116,12 +116,12 @@ public class DartDocumentationProvider implements DocumentationProvider {
 
   @Nullable
   private static String constructDocUrl(@NotNull final DartComponent component) {
-    // class:       https://api.dartlang.org/stable/dart-web_audio/AnalyserNode-class.html
-    // constructor: https://api.dartlang.org/stable/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html
-    //              https://api.dartlang.org/stable/dart-core/List/List.html
-    // method:      https://api.dartlang.org/stable/dart-core/Object/toString.html
-    // property:    https://api.dartlang.org/stable/dart-core/List/length.html
-    // function:    https://api.dartlang.org/stable/dart-math/cos.html
+    // class:       https://api.dart.dev/stable/dart-web_audio/AnalyserNode-class.html
+    // constructor: https://api.dart.dev/stable/dart-core/DateTime/DateTime.fromMicrosecondsSinceEpoch.html
+    //              https://api.dart.dev/stable/dart-core/List/List.html
+    // method:      https://api.dart.dev/stable/dart-core/Object/toString.html
+    // property:    https://api.dart.dev/stable/dart-core/List/length.html
+    // function:    https://api.dart.dev/stable/dart-math/cos.html
 
     final String libRelatedUrlPart = getLibRelatedUrlPart(component);
     final String name = component.getName();

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -174,7 +174,7 @@ public class DartCommandLineRunningState extends CommandLineState {
 
         try {
           if (vmOption.equals("--enable-vm-service") || vmOption.equals("--observe")) {
-            customObservatoryPort = 8181; // default port, see https://www.dartlang.org/tools/dart-vm/
+            customObservatoryPort = 8181; // default port, see https://dart.dev/tools/dart-devtools#3-start-the-target-app
           }
           else if (vmOption.startsWith("--enable-vm-service:")) {
             customObservatoryPort = parseIntBeforeSlash(vmOption.substring("--enable-vm-service:".length()));

--- a/Dart/src/com/jetbrains/lang/dart/sdk/DartSdkUpdateChecker.java
+++ b/Dart/src/com/jetbrains/lang/dart/sdk/DartSdkUpdateChecker.java
@@ -24,8 +24,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class DartSdkUpdateChecker {
-  public static final String SDK_STABLE_DOWNLOAD_URL = "https://www.dartlang.org/redirects/sdk-download-stable";
-  private static final String SDK_DEV_DOWNLOAD_URL = "https://www.dartlang.org/redirects/sdk-download-dev";
+  public static final String SDK_STABLE_DOWNLOAD_URL = "https://www.dart.dev/redirects/sdk-download-stable";
+  private static final String SDK_DEV_DOWNLOAD_URL = "https://www.dart.dev/redirects/sdk-download-dev";
 
   private static final String SDK_STABLE_UPDATE_CHECK_URL =
     "https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION";

--- a/Dart/src/com/jetbrains/lang/dart/util/DartUrlResolver.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartUrlResolver.java
@@ -41,7 +41,7 @@ public abstract class DartUrlResolver {
   public abstract VirtualFile getPubspecYamlFile();
 
   /**
-   * Process 'Path Packages' (https://www.dartlang.org/tools/pub/dependencies.html#path-packages) and this package itself (symlink to local 'lib' folder)
+   * Process 'Path Packages' (https://dart.dev/tools/pub/dependencies#path-packages) and this package itself (symlink to local 'lib' folder)
    */
   public abstract void processLivePackages(final @NotNull PairConsumer<String, VirtualFile> packageNameAndDirConsumer);
 

--- a/Dart/src/com/jetbrains/lang/dart/util/PubspecYamlUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/PubspecYamlUtil.java
@@ -41,7 +41,7 @@ public final class PubspecYamlUtil {
   private static final Key<Pair<Long, Map<String, Object>>> MOD_STAMP_TO_PUBSPEC_NAME = Key.create("MOD_STAMP_TO_PUBSPEC_NAME");
 
   public static boolean isPubspecFile(@NotNull final VirtualFile file) {
-    // https://www.dartlang.org/tools/pub/pubspec
+    // https://dart.dev/tools/pub/pubspec
     return !file.isDirectory() && file.getName().equals(PUBSPEC_YAML);
   }
 
@@ -94,7 +94,7 @@ public final class PubspecYamlUtil {
     processYamlDepsRecursively(project, processedPubspecs, pathPackageNameAndDirConsumer, baseDir, yamlInfo.get(DEPENDENCY_OVERRIDES));
   }
 
-  // Path packages: https://www.dartlang.org/tools/pub/dependencies.html#path-packages
+  // Path packages: https://dart.dev/tools/pub/dependencies#path-packages
   private static void processYamlDepsRecursively(@NotNull final Project project,
                                                  @NotNull final Set<VirtualFile> processedPubspecs,
                                                  @NotNull final PairConsumer<String, VirtualFile> pathPackageNameAndRelPathConsumer,

--- a/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
@@ -67,22 +67,22 @@ public class DartDocumentationProviderTest extends DartCodeInsightFixtureTestCas
   }
 
   public void testDocUrls() {
-    doTestDocUrl("https://api.dartlang.org/stable/dart-core/int-class.html",
+    doTestDocUrl("https://api.dart.dev/stable/dart-core/int-class.html",
                  "core/int.dart",
                  "abstract class int extends num {");
-    doTestDocUrl("https://api.dartlang.org/stable/dart-core/String/String.fromCharCodes.html",
+    doTestDocUrl("https://api.dart.dev/stable/dart-core/String/String.fromCharCodes.html",
                  "core/string.dart",
                  "external factory String.fromCharCodes(Iterable<int> charCodes,");
-    doTestDocUrl("https://api.dartlang.org/stable/dart-core/List/List.html",
+    doTestDocUrl("https://api.dart.dev/stable/dart-core/List/List.html",
                  "core/list.dart",
                  "external factory List([int length]);");
-    doTestDocUrl("https://api.dartlang.org/stable/dart-core/int/int.fromEnvironment.html",
+    doTestDocUrl("https://api.dart.dev/stable/dart-core/int/int.fromEnvironment.html",
                  "core/int.dart",
                  "external const factory int.fromEnvironment(String name, {int defaultValue});");
-    doTestDocUrl("https://api.dartlang.org/stable/dart-math/cos.html",
+    doTestDocUrl("https://api.dart.dev/stable/dart-math/cos.html",
                  "math/math.dart",
                  "external double cos(num radians);");
-    doTestDocUrl("https://api.dartlang.org/stable/dart-core/List/length.html",
+    doTestDocUrl("https://api.dart.dev/stable/dart-core/List/length.html",
                  "core/list.dart",
                  "set length(int newLength);");
   }


### PR DESCRIPTION
Updates some links to their current [`dart.dev`](https://dart.dev) equivalents.