### PR TITLE
Update dartfmt strings to the Dart formatter

### DIFF
--- a/Dart/resources/messages/DartBundle.properties
+++ b/Dart/resources/messages/DartBundle.properties
@@ -273,18 +273,18 @@ dart.sort.members.hint.success=The code has been successfully sorted
 dart.sort.members.files.no.dart.files=No applicable Dart files were found.
 dart.sort.members.files.dialog.question=Run Dart member sorter on {0, choice, 1#the selected file|2#the {0} selected Dart files}?
 
-action.Dart.DartStyle.text=Reformat Code with Dartfmt
-action.Dart.DartStyle.description=Format your Dart code using dartfmt (the Dart Style formatter)
-action.Dart.DartStyle.progress.title=Formatting code with dartfmt...
-dart.style.action.name.ellipsis=Reformat Code with Dartfmt...
+action.Dart.DartStyle.text=Reformat Code with the Dart Formatter
+action.Dart.DartStyle.description=Format your Dart code using the Dart formatter
+action.Dart.DartStyle.progress.title=Formatting code with the Dart formatter...
+dart.style.action.name.ellipsis=Reformat Code with the Dart Formatter...
 dart.style.hint.failed=Failed to reformat code
 dart.style.hint.already.good=Reformat: no formatting changes
 dart.style.hint.success=Reformat: code successfully formatted
 dart.style.files.no.dart.files=No applicable Dart files were found.
-dart.style.files.dialog.question=Run dartfmt on {0, choice, 1#the selected file|2#the {0} selected Dart files}?
+dart.style.files.dialog.question=Run the Dart formatter on {0, choice, 1#the selected file|2#the {0} selected Dart files}?
 organized.directives=Organized directives
 
-code.style.settings.dartfmt.faq=<html>Code is formatted using the <code>dartfmt</code> tool from the Dart SDK. See <a href='https://github.com/dart-lang/dart_style/wiki/FAQ'>FAQ</a>.</html>
+code.style.settings.dartfmt.faq=<html>Code is formatted using the <code>dart format</code> tool included with the Dart SDK. See <a href='https://github.com/dart-lang/dart_style/wiki/FAQ'>FAQ</a>.</html>
 code.style.settings.label.line.length=&Line length:
 
 action.Dart.DartFix.text=Migrate Code to NNBD with Dartfix


### PR DESCRIPTION
Open to suggestions here on the exact changes to the strings, but the name `dartfmt` is going to be less common as it has been replaced with `dart format` in 2.10.4. 

Refer to https://github.com/dart-lang/site-www/issues/3111#issuecomment-810843455 for context