### PR TITLE
add emacs tab support for makefile

### DIFF
--- a/makefile/resources/META-INF/plugin.xml
+++ b/makefile/resources/META-INF/plugin.xml
@@ -51,6 +51,8 @@ Plugin source code was previously located at <a href="https://github.com/kropp/i
     <runConfigurationProducer implementation="com.jetbrains.lang.makefile.MakefileRunConfigurationProducer"/>
     <codeStyleSettingsProvider implementation="com.jetbrains.lang.makefile.MakefileCodeStyleSettingsProvider"/>
     <langCodeStyleSettingsProvider implementation="com.jetbrains.lang.makefile.MakefileLangCodeStyleSettingsProvider"/>
+    <lang.formatter language="Makefile" implementationClass="com.jetbrains.lang.makefile.MakefileFormattingModelBuilder" />
+    <lang.emacs language="Makefile" implementationClass="com.jetbrains.lang.makefile.MakefileEmacsHandler" />
     <lang.elementManipulator implementationClass="com.jetbrains.lang.makefile.psi.MakefilePrerequisiteManipulator"
                              forClass="com.jetbrains.lang.makefile.psi.impl.MakefilePrerequisiteImpl"/>
     <lang.elementManipulator implementationClass="com.jetbrains.lang.makefile.psi.MakefileVariableUsageManipulator"

--- a/makefile/src/com/jetbrains/lang/makefile/MakefileEmacsHandler.kt
+++ b/makefile/src/com/jetbrains/lang/makefile/MakefileEmacsHandler.kt
@@ -1,0 +1,24 @@
+package com.jetbrains.lang.makefile
+
+import com.intellij.codeInsight.editorActions.emacs.EmacsProcessingHandler
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.util.DocumentUtil
+
+class MakefileEmacsHandler : EmacsProcessingHandler {
+    override fun changeIndent(project: Project, editor: Editor, file: PsiFile): EmacsProcessingHandler.Result {
+        val selectionModel = editor.selectionModel
+        if (selectionModel.hasSelection()) {
+            return EmacsProcessingHandler.Result.CONTINUE
+        }
+
+        // make-mode.el just inserts a tab character.
+        // auto indentation is left for a to-do.
+        val caretOffset: Int = editor.caretModel.offset
+        editor.document.insertString(caretOffset, "\t")
+        editor.caretModel.moveToOffset(caretOffset + 1)
+
+        return EmacsProcessingHandler.Result.STOP
+    }
+}

--- a/makefile/src/com/jetbrains/lang/makefile/MakefileFormattingBlock.kt
+++ b/makefile/src/com/jetbrains/lang/makefile/MakefileFormattingBlock.kt
@@ -1,0 +1,41 @@
+package com.jetbrains.lang.makefile
+
+import com.intellij.formatting.*
+import com.intellij.lang.ASTNode
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import com.intellij.psi.formatter.common.AbstractBlock
+import com.intellij.psi.formatter.common.SettingsAwareBlock
+import com.jetbrains.lang.makefile.psi.MakefileTypes
+
+internal class MakefileFormattingBlock(
+        node: ASTNode,
+        private val settings: CodeStyleSettings, protected val spacing: SpacingBuilder,
+        alignment: Alignment? = null, wrap: Wrap? = null
+) : AbstractBlock(node, wrap, alignment), SettingsAwareBlock {
+    override fun getSettings(): CodeStyleSettings = settings
+
+    override fun isLeaf(): Boolean = subBlocks.isEmpty()
+
+    override fun getSpacing(child1: Block?, child2: Block): Spacing? = spacing.getSpacing(this, child1, child2)
+
+    override fun getIndent(): Indent? {
+        return Indent.getNormalIndent();
+    }
+
+    override fun buildChildren(): List<Block> {
+        val newAlignment = Alignment.createAlignment()
+
+        return this.children(node)
+                .filter { it.elementType != MakefileTypes.TAB }
+                .map { MakefileFormattingBlock(it, settings, spacing, newAlignment) }
+                .toList()
+    }
+
+    private fun children(node: ASTNode) = sequence<ASTNode> {
+        var child = node.firstChildNode;
+        while(child != null) {
+            yield(child)
+            child = child.treeNext
+        }
+    }
+}

--- a/makefile/src/com/jetbrains/lang/makefile/MakefileFormattingModelBuilder.kt
+++ b/makefile/src/com/jetbrains/lang/makefile/MakefileFormattingModelBuilder.kt
@@ -1,0 +1,13 @@
+package com.jetbrains.lang.makefile
+
+import com.intellij.formatting.*
+import com.intellij.psi.formatter.DocumentBasedFormattingModel
+
+class MakefileFormattingModelBuilder : FormattingModelBuilder {
+    override fun createModel(formattingContext: FormattingContext): FormattingModel {
+        val settings = formattingContext.codeStyleSettings
+        val block = MakefileFormattingBlock(formattingContext.node, settings, SpacingBuilder(settings, MakefileLanguage))
+
+        return DocumentBasedFormattingModel(block, settings, formattingContext.containingFile)
+    }
+}


### PR DESCRIPTION
Original Emacs also simply inserts a tab character for Makefile.

Related: https://youtrack.jetbrains.com/issue/CPP-24135

(I've closed previous PR by mistake https://github.com/JetBrains/intellij-plugins/pull/800)