### PR TITLE
Fix for PbCommentTest.

### DIFF
--- a/protobuf/protoeditor-core/test/com/intellij/protobuf/ide/editing/PbCommenterTest.java
+++ b/protobuf/protoeditor-core/test/com/intellij/protobuf/ide/editing/PbCommenterTest.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.impl.source.PostprocessReformattingAspect;
 import com.intellij.testFramework.EditorTestUtil;
 import com.intellij.testFramework.EditorTestUtil.CaretAndSelectionState;
 import com.intellij.testFramework.EditorTestUtil.CaretInfo;
@@ -74,6 +75,7 @@ public class PbCommenterTest extends PbCodeInsightFixtureTestCase {
 
   private void performTypingAction(Editor editor, char typedChar) {
     EditorTestUtil.performTypingAction(editor, typedChar);
+    PostprocessReformattingAspect.getInstance(getProject()).doPostponedFormatting();
     PsiDocumentManager.getInstance(getProject()).commitAllDocuments();
   }
 }


### PR DESCRIPTION
The old method to do this stopped working in 2020.2, updated to the method used elsewhere in the platform.

This fixes a google-internal test that broke in with 2020.2.