### PR TITLE
Copy/paste error of Logger class

### DIFF
--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbOptionNameMixin.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbOptionNameMixin.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 
 abstract class PbOptionNameMixin extends PbElementBase implements PbOptionName {
 
-  private static final Logger logger = Logger.getInstance(PbOptionNameReference.class);
+  private static final Logger logger = Logger.getInstance(PbOptionNameMixin.class);
 
   PbOptionNameMixin(ASTNode node) {
     super(node);


### PR DESCRIPTION
This fixes the class used by Logger to be the correct one.