### PR TITLE
Address a test failure where PbUsageTypeProvider's constructor caused…

### DIFF
--- a/protobuf/protoeditor-core/test/com/intellij/protobuf/lang/findusages/PbFindUsagesProviderTest.java
+++ b/protobuf/protoeditor-core/test/com/intellij/protobuf/lang/findusages/PbFindUsagesProviderTest.java
@@ -19,7 +19,6 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.usageView.UsageInfo;
 import com.intellij.usages.impl.rules.UsageType;
-import com.intellij.usages.impl.rules.UsageTypeProvider;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.protobuf.TestUtils;
 import com.intellij.protobuf.fixtures.PbCodeInsightFixtureTestCase;
@@ -33,8 +32,6 @@ import static com.intellij.protobuf.TestUtils.notNull;
 
 /** Tests for {@link PbFindUsagesProvider}. */
 public class PbFindUsagesProviderTest extends PbCodeInsightFixtureTestCase {
-
-  private static final UsageTypeProvider USAGE_TYPE_PROVIDER = new PbUsageTypeProvider();
 
   @Override
   public void setUp() throws Exception {
@@ -240,8 +237,7 @@ public class PbFindUsagesProviderTest extends PbCodeInsightFixtureTestCase {
   }
 
   private static Collection<String> describeUsages(Collection<UsageInfo> usageInfos) {
-    return usageInfos
-        .stream()
+    return usageInfos.stream()
         .map(
             usageInfo ->
                 notNull(usageInfo.getFile()).getName() + ":" + usageInfo.getNavigationOffset())
@@ -249,11 +245,10 @@ public class PbFindUsagesProviderTest extends PbCodeInsightFixtureTestCase {
   }
 
   private static Collection<String> describeUsageTypeNames(Collection<UsageInfo> usageInfos) {
-    return usageInfos
-        .stream()
+    return usageInfos.stream()
         .map(
             usageInfo -> {
-              UsageType usageType = USAGE_TYPE_PROVIDER.getUsageType(usageInfo.getElement());
+              UsageType usageType = new PbUsageTypeProvider().getUsageType(usageInfo.getElement());
               return usageType != null ? usageType.toString() : UsageType.UNCLASSIFIED.toString();
             })
         .collect(Collectors.toList());


### PR DESCRIPTION
… an NPE when run before project was set up.

This fixes a google-internal test.