### PR TITLE
Update rule localization according to specification

### DIFF
--- a/cucumber/resources/i18n.json
+++ b/cucumber/resources/i18n.json
@@ -2665,7 +2665,7 @@
 		"name": "Russian",
 		"native": "русский",
 		"rule": [
-			"Rule"
+			"Правило"
 		],
 		"scenario": [
 			"Пример",


### PR DESCRIPTION
Rule localization for russian language is wrong. Current value was "Rule", but should be "Правило". Link to spec: https://cucumber.io/docs/gherkin/languages/ 

This mislocalization cause syntax highlight issue: 

![image](https://user-images.githubusercontent.com/5672510/127276273-935c34ad-e76a-473b-87be-a7601468747b.png)

Here is the sample:

```
# language: ru
@framework
Функция: пример

  Правило: некорректная подстветка

  Rule: корректная подстветка, некорректный язык
```