### PR TITLE
IDEA-138550: Update dependencies for Error Prone plugin

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
   <artifact version="2.7.1" name="error-prone">
-    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.7.1/error_prone_core-2.7.1-with-dependencies.jar"/>
+    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.8.1/error_prone_core-2.8.1-with-dependencies.jar"/>
     <item url="https://repo1.maven.org/maven2/com/google/code/findbugs/jFormatString/3.0.0/jFormatString-3.0.0.jar"/>
-    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-shaded/3.7.1/dataflow-shaded-3.7.1.jar"/>
+    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/3.15.0/dataflow-errorprone-3.15.0.jar"/>
     <item url="https://repo1.maven.org/maven2/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
Upgrade to Error Prone 2.7.1, and fix Checker Framework Dataflow
dependency to use the correct artifact and version.

The latest version of Error Prone at its dependencies are documented at
http://errorprone.info/docs/installation.