### PR TITLE
Use getContainerClass method as a fallback when PsiElement couldn't resolve class context

### DIFF
--- a/protobuf/protoeditor-jvm/src/com/intellij/protobuf/jvm/PbJavaGotoReferenceMatch.java
+++ b/protobuf/protoeditor-jvm/src/com/intellij/protobuf/jvm/PbJavaGotoReferenceMatch.java
@@ -18,6 +18,7 @@ package com.intellij.protobuf.jvm;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMember;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.ObjectUtils;
@@ -59,6 +60,10 @@ public class PbJavaGotoReferenceMatch {
     // This means it won't handle things like Class.nanoRepeatedField.len<caret>gth.
     // Eventually we should handle messageInstance<caret>Variable, etc. as well.
     PsiClass classContext = PsiTreeUtil.getContextOfType(resolved, PsiClass.class, false);
+    if (classContext == null && resolvedReference instanceof PsiMember) {
+      // Synthetic methods don't have context and implement getContainingClass directly.
+      classContext = ((PsiMember) resolvedReference).getContainingClass();
+    }
     if (classContext == null || !isPbGeneratedDefinition(classContext)) {
       return null;
     }


### PR DESCRIPTION
Synthetic methods are represented by PSI elements which don't have parent context and so class can't be obtained from the context. These elements implement PsiMember directly and have getContainerClass method to accessing the linked class.