### PR TITLE
Fix WEB-52638, Prettier plugin doesn't take into account prettierrc when detecting if a file can be formatted

### DIFF
--- a/prettierJS/src/javascript/prettier-plugin.ts
+++ b/prettierJS/src/javascript/prettier-plugin.ts
@@ -45,8 +45,8 @@ export class PrettierPlugin implements LanguagePlugin {
 
     private handleReformatCommand(args: FormatArguments): FormatResponse {
         let prettierApi = this.requirePrettierApi(args.prettierPath, args.packageJsonPath);
-
-        let options = {ignorePath: args.ignoreFilePath, withNodeModules: true};
+        let config = prettierApi.resolveConfig.sync(args.path, {useCache: true, editorconfig: true});
+        let options = {ignorePath: args.ignoreFilePath, withNodeModules: true, plugins: config.plugins};
         if (prettierApi.getFileInfo) {
             let fileInfo = prettierApi.getFileInfo.sync(args.path, options)
             if (fileInfo.ignored) {


### PR DESCRIPTION
Addresses https://youtrack.jetbrains.com/issue/WEB-52638.

I'm not sure if the generated files are meant to be included in each commit, so if they are supposed to be committed, someone will need to edit this pull request before merging.