### PR TITLE
Dart: fix parameters in javadoc

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/DebugService.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/DebugService.java
@@ -19,5 +19,5 @@ package com.google.dart.server;
  * @coverage dart.server
  */
 public enum DebugService {
-  LAUNCH_DATA;
+  LAUNCH_DATA
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetAssistsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetAssistsConsumer.java
@@ -28,7 +28,7 @@ public interface GetAssistsConsumer extends Consumer {
   /**
    * A set of {@link SourceChange}s that have been computed.
    * 
-   * @param proposals an array of computed {@link SourceChange}s
+   * @param sourceChanges an array of computed {@link SourceChange}s
    */
   public void computedSourceChanges(List<SourceChange> sourceChanges);
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetServerPortConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetServerPortConsumer.java
@@ -13,10 +13,7 @@
  */
 package com.google.dart.server;
 
-import org.dartlang.analysis.server.protocol.ContextData;
 import org.dartlang.analysis.server.protocol.RequestError;
-
-import java.util.List;
 
 public interface GetServerPortConsumer extends Consumer {
   public void computedServerPort(int port);

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSignatureConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSignatureConsumer.java
@@ -26,11 +26,11 @@ import java.util.List;
  */
 public interface GetSignatureConsumer extends Consumer {
   /**
-   * @param name       The name of the function being invoked at the given offset.
-   * @param parameters A list of information about each of the parameters of the function being invoked.
-   * @param dartdoc    The dartdoc associated with the function being invoked. Other than the removal of the comment delimiters, including
-   *                   leading asterisks in the case of a block comment, the dartdoc is unprocessed markdown. This data is omitted if there
-   *                   is no referenced element, or if the element has no dartdoc.
+   * @param name           The name of the function being invoked at the given offset.
+   * @param parameterInfos A list of information about each of the parameters of the function being invoked.
+   * @param dartdoc        The dartdoc associated with the function being invoked. Other than the removal of the comment delimiters, including
+   *                       leading asterisks in the case of a block comment, the dartdoc is unprocessed markdown. This data is omitted if there
+   *                       is no referenced element, or if the element has no dartdoc.
    */
   public void computedSignature(String name, List<ParameterInfo> parameterInfos, String dartdoc);
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ImportElementsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ImportElementsConsumer.java
@@ -14,10 +14,7 @@
 package com.google.dart.server;
 
 import org.dartlang.analysis.server.protocol.RequestError;
-import org.dartlang.analysis.server.protocol.SourceEdit;
 import org.dartlang.analysis.server.protocol.SourceFileEdit;
-
-import java.util.List;
 
 public interface ImportElementsConsumer extends Consumer {
   public void computedImportedElements(SourceFileEdit edit);

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/NotificationKind.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/NotificationKind.java
@@ -23,5 +23,5 @@ public enum NotificationKind {
   ERRORS,
   HIGHLIGHTS,
   NAVIGATION,
-  OUTLINE;
+  OUTLINE
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SearchResultsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SearchResultsConsumer.java
@@ -25,7 +25,6 @@ public interface SearchResultsConsumer extends Consumer {
   /**
    * {@link SearchResult}s have been computed.
    * 
-   * @param contextId the identifier of the context to search within
    * @param searchResults an array of {@link SearchResult}s computed so far
    * @param isLastResult is {@code true} if this is the last set of results
    */


### PR DESCRIPTION
This change the javadoc of some methods, so a proper documentation is done.

Also, small places of unused import or unneeded semicolons, which are reported as warnings.