### PR TITLE
New extension in the Dart plugin: completionTimerExtension

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
 
   <extensionPoints>
     <extensionPoint name="completionExtension" interface="com.jetbrains.lang.dart.ide.completion.DartCompletionExtension" dynamic="true"/>
+    <extensionPoint name="completionTimerExtension" interface="com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension" dynamic="true"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -52,6 +52,7 @@ import com.jetbrains.lang.dart.assists.DartQuickAssistIntentionListener;
 import com.jetbrains.lang.dart.fixes.DartQuickFix;
 import com.jetbrains.lang.dart.fixes.DartQuickFixListener;
 import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
+import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
 import com.jetbrains.lang.dart.ide.template.postfix.DartPostfixTemplateProvider;
 import com.jetbrains.lang.dart.sdk.DartSdk;
@@ -471,6 +472,10 @@ public final class DartAnalysisServerService implements Disposable {
           }
           for (final IncludedSuggestionSet includedSet : completionInfo.myIncludedSuggestionSets) {
             libraryRefConsumer.consumeLibraryRef(includedSet, includedKinds, includedRelevanceTags, completionInfo.myLibraryFilePathSD);
+          }
+
+          for (DartCompletionTimerExtension extension : DartCompletionTimerExtension.getExtensions()) {
+            extension.dartCompletionEnd();
           }
           return;
         }

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartCompletionTimerExtension.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartCompletionTimerExtension.java
@@ -1,0 +1,27 @@
+package com.jetbrains.lang.dart.ide.completion;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * This extension allows downstream plugins to measure the end-to-end completion time, calling one method just before the Dart Analysis
+ * Server is called, and a second just before the UI is displayed to the user.
+ * <p/>
+ * For the DAS completion timing only, a RequestListener and ResponseListener can be attached to the analysis server already.
+ */
+public abstract class DartCompletionTimerExtension {
+
+  private static final ExtensionPointName<DartCompletionTimerExtension> EP_NAME =
+    ExtensionPointName.create("Dart.completionTimerExtension");
+
+  @NotNull
+  public static List<DartCompletionTimerExtension> getExtensions() {
+    return EP_NAME.getExtensionList();
+  }
+
+  public abstract void dartCompletionStart();
+
+  public abstract void dartCompletionEnd();
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/completion/DartServerCompletionContributor.java
@@ -112,6 +112,11 @@ public class DartServerCompletionContributor extends CompletionContributor {
                das.updateFilesContent();
 
                final int offset = InjectedLanguageManager.getInstance(project).injectedToHost(originalFile, parameters.getOffset());
+
+               for (DartCompletionTimerExtension extension : DartCompletionTimerExtension.getExtensions()) {
+                 extension.dartCompletionStart();
+               }
+
                final String completionId = das.completion_getSuggestions(file, offset);
                if (completionId == null) return;
 


### PR DESCRIPTION
This change allows downstream plugins to record the end-to-end time for Dart code completions to be displayed to end users.