### PR TITLE
Add 'Generate constructor with named arguments'

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -288,8 +288,11 @@
     <action id="Generate.Constructor.Dart" class="com.jetbrains.lang.dart.ide.generation.DartGenerateConstructorAction">
       <add-to-group anchor="first" group-id="GenerateGroup"/>
     </action>
-    <action id="Generate.Named.Constructor.Dart" class="com.jetbrains.lang.dart.ide.generation.DartGenerateNamedConstructorAction">
+    <action id="Generate.Constructor.WithNamedArguments.Dart" class="com.jetbrains.lang.dart.ide.generation.DartGenerateConstructorWithNamedArgumentsAction">
       <add-to-group anchor="after" relative-to-action="Generate.Constructor.Dart"  group-id="GenerateGroup"/>
+    </action>
+    <action id="Generate.Named.Constructor.Dart" class="com.jetbrains.lang.dart.ide.generation.DartGenerateNamedConstructorAction">
+      <add-to-group anchor="after" relative-to-action="Generate.Constructor.WithNamedArguments.Dart"  group-id="GenerateGroup"/>
     </action>
     <action id="Generate.GetAccessor.Dart" class="com.jetbrains.lang.dart.ide.generation.DartGenerateGetterAction">
       <add-to-group anchor="after" relative-to-action="Generate.Named.Constructor.Dart" group-id="GenerateGroup"/>

--- a/Dart/resources/messages/DartBundle.properties
+++ b/Dart/resources/messages/DartBundle.properties
@@ -214,6 +214,7 @@ html.file.right.in.dart.project.root=The HTML file should be in a subfolder (lik
 
 dart.generate.code=Generate Dart Code
 dart.generate.constructor=Generate Constructor
+dart.generate.constructor.with.named.arguments=Generate Constructor with Named Arguments
 dart.generate.named.constructor=Generate Named Constructor
 dart.generate.toString=Generate toString()
 dart.generate.equalsAndHashcode=Generate ==() and hashCode
@@ -340,6 +341,7 @@ action.Generate.GetSetAccessor.Dart.text=Getter and Setter
 action.Generate.SetAccessor.Dart.text=Setter
 action.Generate.GetAccessor.Dart.text=Getter
 action.Generate.Named.Constructor.Dart.text=Named Constructor
+action.Generate.Constructor.WithNamedArguments.Dart.text=Constructor with Named Arguments
 action.Generate.Constructor.Dart.text=Constructor
 action.Dart.Analyzer.Diagnostics.text=Dart Analyzer Diagnostics
 action.Dart.Analyzer.Diagnostics.description=View Dart analyzer diagnostics

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/CreateConstructorWithNamedArgumentsFix.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/CreateConstructorWithNamedArgumentsFix.java
@@ -1,0 +1,77 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.generation;
+
+import com.intellij.codeInsight.template.Template;
+import com.intellij.codeInsight.template.TemplateManager;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.psi.DartClass;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.Set;
+
+public class CreateConstructorWithNamedArgumentsFix extends BaseCreateMethodsFix<DartComponent> {
+  public CreateConstructorWithNamedArgumentsFix(@NotNull final DartClass dartClass) {
+    super(dartClass);
+  }
+
+  @Override
+  protected void processElements(@NotNull final Project project,
+                                 @NotNull final Editor editor,
+                                 @NotNull final Set<DartComponent> elementsToProcess) {
+    final TemplateManager templateManager = TemplateManager.getInstance(project);
+    anchor = doAddMethodsForOne(editor, templateManager, buildFunctionsText(templateManager, elementsToProcess), anchor);
+  }
+
+  @Override
+  protected @NotNull @NlsContexts.Command String getCommandName() {
+    return DartBundle.message("dart.generate.constructor.with.named.arguments");
+  }
+
+  @Override
+  @NotNull
+  protected String getNothingFoundMessage() {
+    return ""; // can't be called actually because processElements() is overridden
+  }
+
+  protected Template buildFunctionsText(TemplateManager templateManager, Set<DartComponent> elementsToProcess) {
+    final Template template = templateManager.createTemplate(getClass().getName(), DART_TEMPLATE_GROUP);
+    template.setToReformat(true);
+
+    //noinspection ConstantConditions
+    template.addTextSegment(myDartClass.getName());
+    template.addTextSegment("({");
+    for (Iterator<DartComponent> iterator = elementsToProcess.iterator(); iterator.hasNext(); ) {
+      DartComponent component = iterator.next();
+
+      if (component.isFinal() && !isNullable(component)) {
+        template.addTextSegment("required ");
+      }
+
+      template.addTextSegment("this.");
+      //noinspection ConstantConditions
+      template.addTextSegment(component.getName());
+      if (iterator.hasNext()) {
+        template.addTextSegment(",");
+      }
+    }
+    template.addTextSegment(",});");
+    template.addEndVariable();
+    template.addTextSegment(" "); // trailing space is removed when auto-reformatting, but it helps to enter line break if needed
+    return template;
+  }
+
+  private static Boolean isNullable(DartComponent component) {
+    return component.getText().contains("? ");
+  }
+
+  @Override
+  protected Template buildFunctionsText(TemplateManager templateManager, DartComponent e) {
+    // ignore
+    return null;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorWithNamedArgumentsAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorWithNamedArgumentsAction.java
@@ -1,0 +1,13 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.generation;
+
+import org.jetbrains.annotations.NotNull;
+
+public class DartGenerateConstructorWithNamedArgumentsAction extends BaseDartGenerateAction {
+
+  @Override
+  @NotNull
+  protected BaseDartGenerateHandler getGenerateHandler() {
+    return new DartGenerateConstructorWithNamedArgumentsHandler();
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorWithNamedArgumentsHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/generation/DartGenerateConstructorWithNamedArgumentsHandler.java
@@ -1,0 +1,36 @@
+// Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.jetbrains.lang.dart.ide.generation;
+
+import com.intellij.util.containers.ContainerUtil;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.DartComponentType;
+import com.jetbrains.lang.dart.psi.DartClass;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DartGenerateConstructorWithNamedArgumentsHandler extends BaseDartGenerateHandler {
+  @Override
+  @NotNull
+  protected String getTitle() {
+    return DartBundle.message("dart.generate.constructor.with.named.arguments");
+  }
+
+  @Override
+  @NotNull
+  protected BaseCreateMethodsFix createFix(@NotNull final DartClass dartClass) {
+    return new CreateConstructorWithNamedArgumentsFix(dartClass);
+  }
+
+  @Override
+  protected void collectCandidates(@NotNull final DartClass dartClass, @NotNull final List<DartComponent> candidates) {
+    candidates.addAll(ContainerUtil.findAll(computeClassMembersMap(dartClass, false).values(),
+                                            component -> DartComponentType.typeOf(component) == DartComponentType.FIELD));
+  }
+
+  @Override
+  protected boolean doAllowEmptySelection() {
+    return true;
+  }
+}


### PR DESCRIPTION
Added a "Generate" option to generate a constructor with named arguments.

Example:

https://user-images.githubusercontent.com/418977/136557355-6c35322e-c0ae-4456-bd78-ee627bd662e8.mov

Could not find any tests for the actions. If there are any, please point me in the right direction.