### PR TITLE
Remove unneeded modifiers.

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerErrorCode.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerErrorCode.java
@@ -36,7 +36,7 @@ public enum AnalysisServerErrorCode {
    * 
    * @param message the message template used to create the message to be displayed for the error
    */
-  private AnalysisServerErrorCode(String message) {
+  AnalysisServerErrorCode(String message) {
     this.message = message;
   }
 

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -38,9 +38,9 @@ public interface AnalysisServerListener {
    *
    * @param directories a list of the paths of the files that are being analyzed
    */
-  public void computedAnalyzedFiles(List<String> directories);
+  void computedAnalyzedFiles(List<String> directories);
 
-  public void computedAvailableSuggestions(@NotNull final List<AvailableSuggestionSet> changed,
+  void computedAvailableSuggestions(@NotNull final List<AvailableSuggestionSet> changed,
                                            @NotNull final int[] removed);
 
   /**
@@ -59,15 +59,15 @@ public interface AnalysisServerListener {
    *                          indicated completion
    * @param libraryFile       The library file that contains the file where completion was requested.
    */
-  public void computedCompletion(String completionId,
-                                 int replacementOffset,
-                                 int replacementLength,
-                                 List<CompletionSuggestion> completions,
-                                 List<IncludedSuggestionSet> includedSuggestionSets,
-                                 List<String> includedElementKinds,
-                                 List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
-                                 boolean isLast,
-                                 @Nullable String libraryFile);
+  void computedCompletion(String completionId,
+                          int replacementOffset,
+                          int replacementLength,
+                          List<CompletionSuggestion> completions,
+                          List<IncludedSuggestionSet> includedSuggestionSets,
+                          List<String> includedElementKinds,
+                          List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
+                          boolean isLast,
+                          @Nullable String libraryFile);
 
   /**
    * Reports the errors associated with a given file.
@@ -75,7 +75,7 @@ public interface AnalysisServerListener {
    * @param file   the file containing the errors
    * @param errors the errors contained in the file
    */
-  public void computedErrors(String file, List<AnalysisError> errors);
+  void computedErrors(String file, List<AnalysisError> errors);
 
   /**
    * A new collection of highlight regions has been computed for the given file. Each highlight
@@ -86,7 +86,7 @@ public interface AnalysisServerListener {
    * @param file       the file containing the highlight regions
    * @param highlights the highlight regions contained in the file
    */
-  public void computedHighlights(String file, List<HighlightRegion> highlights);
+  void computedHighlights(String file, List<HighlightRegion> highlights);
 
   /**
    * New collections of implemented classes and class members have been computed for the given file.
@@ -95,8 +95,8 @@ public interface AnalysisServerListener {
    * @param implementedClasses the classes defined in the file that are implemented or extended.
    * @param implementedMembers the member defined in the file that are implemented or overridden.
    */
-  public void computedImplemented(String file, List<ImplementedClass> implementedClasses,
-                                  List<ImplementedMember> implementedMembers);
+  void computedImplemented(String file, List<ImplementedClass> implementedClasses,
+                           List<ImplementedMember> implementedMembers);
 
   /**
    * New launch data has been computed.
@@ -106,7 +106,7 @@ public interface AnalysisServerListener {
    * @param referencedFiles a list of the Dart files that are referenced by the file, or
    *                        {@code null} for non-HTML files
    */
-  public void computedLaunchData(String file, String kind, String[] referencedFiles);
+  void computedLaunchData(String file, String kind, String[] referencedFiles);
 
   /**
    * A new collection of navigation regions has been computed for the given file. Each navigation
@@ -118,7 +118,7 @@ public interface AnalysisServerListener {
    * @param file       the file containing the navigation regions
    * @param highlights the highlight regions associated with the source
    */
-  public void computedNavigation(String file, List<NavigationRegion> targets);
+  void computedNavigation(String file, List<NavigationRegion> targets);
 
   /**
    * A new collection of occurrences that been computed for the given file. Each occurrences object
@@ -127,7 +127,7 @@ public interface AnalysisServerListener {
    * @param file             the file containing the occurrences
    * @param occurrencesArray the array of occurrences in the passed file
    */
-  public void computedOccurrences(String file, List<Occurrences> occurrencesArray);
+  void computedOccurrences(String file, List<Occurrences> occurrencesArray);
 
   /**
    * A new outline has been computed for the given file.
@@ -135,7 +135,7 @@ public interface AnalysisServerListener {
    * @param file    the file with which the outline is associated
    * @param outline the outline associated with the file
    */
-  public void computedOutline(String file, Outline outline);
+  void computedOutline(String file, Outline outline);
 
   /**
    * A new collection of overrides that have been computed for a given file. Each override array
@@ -144,9 +144,9 @@ public interface AnalysisServerListener {
    * @param file      the file with which the outline is associated
    * @param overrides the overrides associated with the file
    */
-  public void computedOverrides(String file, List<OverrideMember> overrides);
+  void computedOverrides(String file, List<OverrideMember> overrides);
 
-  public void computedClosingLabels(String file, List<ClosingLabel> labels);
+  void computedClosingLabels(String file, List<ClosingLabel> labels);
 
   /**
    * A new collection of search results have been computed for the given completion id.
@@ -156,7 +156,7 @@ public interface AnalysisServerListener {
    * @param last     {@code true} if this is the last set of results that will be returned for the
    *                 indicated search
    */
-  public void computedSearchResults(String searchId, List<SearchResult> results, boolean last);
+  void computedSearchResults(String searchId, List<SearchResult> results, boolean last);
 
   /**
    * Reports that any analysis results that were previously associated with the given files should
@@ -170,12 +170,12 @@ public interface AnalysisServerListener {
    * <p>
    * It is not possible to subscribe to or unsubscribe from this notification.
    */
-  public void flushedResults(List<String> files);
+  void flushedResults(List<String> files);
 
   /**
 
    */
-  public void requestError(RequestError requestError);
+  void requestError(RequestError requestError);
 
   /**
    * Reports that the server is running. This notification is issued once after the server has
@@ -183,7 +183,7 @@ public interface AnalysisServerListener {
    *
    * @param version the version of the server that is running
    */
-  public void serverConnected(String version);
+  void serverConnected(String version);
 
   /**
    * An error happened in the {@link AnalysisServer}.
@@ -194,7 +194,7 @@ public interface AnalysisServerListener {
    * @param stackTrace the stack trace associated with the generation of the error, used for
    *                   debugging the server
    */
-  public void serverError(boolean isFatal, String message, String stackTrace);
+  void serverError(boolean isFatal, String message, String stackTrace);
 
   /**
    * Reports that the server version is not compatible with the client version. All the requests
@@ -203,7 +203,7 @@ public interface AnalysisServerListener {
    * @param version is the actual version of the server if not {@code null}, or {@code null} if an
    *                error received as a version.
    */
-  public void serverIncompatibleVersion(String version);
+  void serverIncompatibleVersion(String version);
 
   /**
    * Reports the current status of the server.
@@ -213,7 +213,7 @@ public interface AnalysisServerListener {
    * @param pubStatus      the current pub status of the server, or {@code null} if there is no pub
    *                       status
    */
-  public void serverStatus(AnalysisStatus analysisStatus, PubStatus pubStatus);
+  void serverStatus(AnalysisStatus analysisStatus, PubStatus pubStatus);
 
   /**
    * Reports existing imports in a library.

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerStatusListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerStatusListener.java
@@ -24,6 +24,6 @@ public interface AnalysisServerStatusListener {
    * 
    * @param isAlive {@code true} if server still alive
    */
-  public void isAliveServer(boolean isAlive);
+  void isAliveServer(boolean isAlive);
 
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/BasicConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/BasicConsumer.java
@@ -23,5 +23,5 @@ public interface BasicConsumer extends Consumer {
   /**
    * Response from server was received.
    */
-  public void received();
+  void received();
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/BulkFixesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/BulkFixesConsumer.java
@@ -29,12 +29,12 @@ public interface BulkFixesConsumer extends Consumer {
    *
    * @param edits a list of edits
    */
-  public void computedSearchId(List<SourceFileEdit> edits);
+  void computedSearchId(List<SourceFileEdit> edits);
 
   /**
    * If a search id cannot be passed back, some {@link RequestError} is passed back instead.
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/CreateContextConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/CreateContextConsumer.java
@@ -27,7 +27,7 @@ public interface CreateContextConsumer extends Consumer {
    * 
    * @param contextId the id of the context that was computed
    */
-  public void computedExecutionContext(String contextId);
+  void computedExecutionContext(String contextId);
 
   /**
    * If an execution context cannot be passed back, some {@link RequestError} is passed back
@@ -35,5 +35,5 @@ public interface CreateContextConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindElementReferencesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindElementReferencesConsumer.java
@@ -31,7 +31,7 @@ public interface FindElementReferencesConsumer extends Consumer {
    *          be returned in the search results. If no element was found at the given location, this
    *          field will be absent.
    */
-  public void computedElementReferences(String searchId, Element element);
+  void computedElementReferences(String searchId, Element element);
 
   /**
    * If a search id and element cannot be passed back, some {@link RequestError} is passed back
@@ -39,5 +39,5 @@ public interface FindElementReferencesConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindMemberDeclarationsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindMemberDeclarationsConsumer.java
@@ -27,12 +27,12 @@ public interface FindMemberDeclarationsConsumer extends Consumer {
    * 
    * @param searchId the identifier used to associate results with this search request
    */
-  public void computedSearchId(String searchId);
+  void computedSearchId(String searchId);
 
   /**
    * If a search id cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindMemberReferencesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindMemberReferencesConsumer.java
@@ -27,12 +27,12 @@ public interface FindMemberReferencesConsumer extends Consumer {
    * 
    * @param searchId the identifier used to associate results with this search request
    */
-  public void computedSearchId(String searchId);
+  void computedSearchId(String searchId);
 
   /**
    * If a search id cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindTopLevelDeclarationsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FindTopLevelDeclarationsConsumer.java
@@ -27,12 +27,12 @@ public interface FindTopLevelDeclarationsConsumer extends Consumer {
    * 
    * @param searchId the identifier used to associate results with this search request
    */
-  public void computedSearchId(String searchId);
+  void computedSearchId(String searchId);
 
   /**
    * If a search id cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FormatConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/FormatConsumer.java
@@ -31,12 +31,12 @@ public interface FormatConsumer extends Consumer {
    * @param selectionOffset the offset of the selection after formatting the code
    * @param selectionLength the length of the selection after formatting the code
    */
-  public void computedFormat(List<SourceEdit> edits, int selectionOffset, int selectionLength);
+  void computedFormat(List<SourceEdit> edits, int selectionOffset, int selectionLength);
 
   /**
    * If a formatting edits cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetAssistsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetAssistsConsumer.java
@@ -30,12 +30,12 @@ public interface GetAssistsConsumer extends Consumer {
    * 
    * @param sourceChanges an array of computed {@link SourceChange}s
    */
-  public void computedSourceChanges(List<SourceChange> sourceChanges);
+  void computedSourceChanges(List<SourceChange> sourceChanges);
 
   /**
    * If a set of assists cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetAvailableRefactoringsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetAvailableRefactoringsConsumer.java
@@ -31,7 +31,7 @@ public interface GetAvailableRefactoringsConsumer extends Consumer {
    * @param refactoringKinds the kinds of refactorings that are valid for the given selection
    * @see RefactoringKind
    */
-  public void computedRefactoringKinds(List<String> refactoringKinds);
+  void computedRefactoringKinds(List<String> refactoringKinds);
 
   /**
    * If a set of refactoring kinds cannot be passed back, some {@link RequestError} is passed back
@@ -39,5 +39,5 @@ public interface GetAvailableRefactoringsConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetDiagnosticsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetDiagnosticsConsumer.java
@@ -28,12 +28,12 @@ public interface GetDiagnosticsConsumer extends Consumer {
   /**
    * @param contextDataList a list of analysis contexts.
    */
-  public void computedDiagnostics(List<ContextData> contextDataList);
+  void computedDiagnostics(List<ContextData> contextDataList);
 
   /**
    * If a list of analysis contexts cannot be passed back, some {@link RequestError} is passed back instead.
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetElementDeclarationsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetElementDeclarationsConsumer.java
@@ -28,7 +28,7 @@ public interface GetElementDeclarationsConsumer extends Consumer {
    * @param declarations The list of declarations.
    * @param files        The list of the paths of files with declarations.
    */
-  public void computedElementDeclarations(List<ElementDeclaration> declarations, List<String> files);
+  void computedElementDeclarations(List<ElementDeclaration> declarations, List<String> files);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
@@ -36,5 +36,5 @@ public interface GetElementDeclarationsConsumer extends Consumer {
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetErrorsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetErrorsConsumer.java
@@ -29,12 +29,12 @@ public interface GetErrorsConsumer extends Consumer {
    * 
    * @param errors an array of computed {@link AnalysisError}s
    */
-  public void computedErrors(AnalysisError[] errors);
+  void computedErrors(AnalysisError[] errors);
 
   /**
    * If a set of errors cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetFixesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetFixesConsumer.java
@@ -32,12 +32,12 @@ public interface GetFixesConsumer extends Consumer {
    * 
    * @param errorFixesArray a list of computed error fixes
    */
-  public void computedFixes(List<AnalysisErrorFixes> errorFixesArray);
+  void computedFixes(List<AnalysisErrorFixes> errorFixesArray);
 
   /**
    * If a set of fixes cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetHoverConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetHoverConsumer.java
@@ -29,12 +29,12 @@ public interface GetHoverConsumer extends Consumer {
    * 
    * @param hovers an array of computed {@link HoverInformation}s
    */
-  public void computedHovers(HoverInformation[] hovers);
+  void computedHovers(HoverInformation[] hovers);
 
   /**
    * If a result cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetImportedElementsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetImportedElementsConsumer.java
@@ -19,7 +19,7 @@ import org.dartlang.analysis.server.protocol.RequestError;
 import java.util.List;
 
 public interface GetImportedElementsConsumer extends Consumer {
-  public void computedImportedElements(List<ImportedElements> importedElements);
+  void computedImportedElements(List<ImportedElements> importedElements);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetKytheEntriesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetKytheEntriesConsumer.java
@@ -30,7 +30,7 @@ public interface GetKytheEntriesConsumer extends Consumer {
    *                the file. This could be due to a referenced file that does not exist or generated files not being generated or passed
    *                before the call to "getKytheEntries".
    */
-  public void computedKytheEntries(List<KytheEntry> entries, List<String> files);
+  void computedKytheEntries(List<KytheEntry> entries, List<String> files);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
@@ -38,5 +38,5 @@ public interface GetKytheEntriesConsumer extends Consumer {
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetLibraryDependenciesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetLibraryDependenciesConsumer.java
@@ -33,7 +33,7 @@ public interface GetLibraryDependenciesConsumer extends Consumer {
    * @param packageMap a map of context source roots to maps of package names to lists of associated
    *          source directories
    */
-  public void computedDependencies(String[] libraries,
+  void computedDependencies(String[] libraries,
       Map<String, Map<String, List<String>>> packageMap);
 
   /**
@@ -41,5 +41,5 @@ public interface GetLibraryDependenciesConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetNavigationConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetNavigationConsumer.java
@@ -30,12 +30,12 @@ public interface GetNavigationConsumer extends Consumer {
    * 
    * @param regions the navigation regions within the requested region of the file
    */
-  public void computedNavigation(List<NavigationRegion> regions);
+  void computedNavigation(List<NavigationRegion> regions);
 
   /**
    * If a result cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetPostfixCompletionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetPostfixCompletionConsumer.java
@@ -24,7 +24,7 @@ import org.dartlang.analysis.server.protocol.SourceChange;
  */
 public interface GetPostfixCompletionConsumer extends Consumer {
 
-  public void computedSourceChange(SourceChange sourceChange);
+  void computedSourceChange(SourceChange sourceChange);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetReachableSourcesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetReachableSourcesConsumer.java
@@ -33,7 +33,7 @@ public interface GetReachableSourcesConsumer extends Consumer {
    *          a specific URI is reachable from a given file, clients can check for its presence in
    *          the resulting key set.
    */
-  public void computedReachableSources(Map<String, List<String>> sources);
+  void computedReachableSources(Map<String, List<String>> sources);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
@@ -41,5 +41,5 @@ public interface GetReachableSourcesConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetRefactoringConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetRefactoringConsumer.java
@@ -53,7 +53,7 @@ public interface GetRefactoringConsumer extends Consumer {
    *          will be omitted if the change field is omitted or if there are no potential edits for
    *          the refactoring.
    */
-  public void computedRefactorings(List<RefactoringProblem> initialProblems,
+  void computedRefactorings(List<RefactoringProblem> initialProblems,
       List<RefactoringProblem> optionsProblems, List<RefactoringProblem> finalProblems,
       RefactoringFeedback feedback, SourceChange change, List<String> potentialEdits);
 
@@ -62,5 +62,5 @@ public interface GetRefactoringConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetRuntimeCompletionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetRuntimeCompletionConsumer.java
@@ -20,7 +20,7 @@ import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression;
 import java.util.List;
 
 public interface GetRuntimeCompletionConsumer extends Consumer {
-  public void computedResult(List<CompletionSuggestion> suggestions, List<RuntimeCompletionExpression> expressions);
+  void computedResult(List<CompletionSuggestion> suggestions, List<RuntimeCompletionExpression> expressions);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetServerPortConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetServerPortConsumer.java
@@ -16,6 +16,6 @@ package com.google.dart.server;
 import org.dartlang.analysis.server.protocol.RequestError;
 
 public interface GetServerPortConsumer extends Consumer {
-  public void computedServerPort(int port);
-  public void onError(RequestError requestError);
+  void computedServerPort(int port);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSignatureConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSignatureConsumer.java
@@ -32,7 +32,7 @@ public interface GetSignatureConsumer extends Consumer {
    *                       leading asterisks in the case of a block comment, the dartdoc is unprocessed markdown. This data is omitted if there
    *                       is no referenced element, or if the element has no dartdoc.
    */
-  public void computedSignature(String name, List<ParameterInfo> parameterInfos, String dartdoc);
+  void computedSignature(String name, List<ParameterInfo> parameterInfos, String dartdoc);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
@@ -40,5 +40,5 @@ public interface GetSignatureConsumer extends Consumer {
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetStatementCompletionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetStatementCompletionConsumer.java
@@ -24,7 +24,7 @@ import org.dartlang.analysis.server.protocol.SourceChange;
  */
 public interface GetStatementCompletionConsumer extends Consumer {
 
-  public void computedSourceChange(SourceChange sourceChange);
+  void computedSourceChange(SourceChange sourceChange);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSuggestionDetailsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSuggestionDetailsConsumer.java
@@ -17,7 +17,7 @@ import org.dartlang.analysis.server.protocol.RequestError;
 import org.dartlang.analysis.server.protocol.SourceChange;
 
 public interface GetSuggestionDetailsConsumer extends Consumer {
-  public void computedDetails(String completion, SourceChange change);
+  void computedDetails(String completion, SourceChange change);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSuggestionsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetSuggestionsConsumer.java
@@ -27,12 +27,12 @@ public interface GetSuggestionsConsumer extends Consumer {
    * 
    * @param completionId a completion id {@link String}
    */
-  public void computedCompletionId(String completionId);
+  void computedCompletionId(String completionId);
 
   /**
    * If a completion id cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetTypeHierarchyConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetTypeHierarchyConsumer.java
@@ -35,12 +35,12 @@ public interface GetTypeHierarchyConsumer extends Consumer {
    *          absent if the code at the given file and offset does not represent a type, or if the
    *          file has not been sufficiently analyzed to allow a type hierarchy to be produced.
    */
-  public void computedHierarchy(List<TypeHierarchyItem> hierarchyItems);
+  void computedHierarchy(List<TypeHierarchyItem> hierarchyItems);
 
   /**
    * If hierarchy items cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetVersionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetVersionConsumer.java
@@ -27,7 +27,7 @@ public interface GetVersionConsumer extends Consumer {
    * 
    * @param version the {@link String} version that has been retrieved
    */
-  public void computedVersion(String version);
+  void computedVersion(String version);
 
   /**
    * If a version {@link String} cannot be passed back, some {@link RequestError} is passed back
@@ -35,5 +35,5 @@ public interface GetVersionConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetWidgetDescriptionConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/GetWidgetDescriptionConsumer.java
@@ -30,7 +30,7 @@ public interface GetWidgetDescriptionConsumer extends Consumer {
    *                   because they have type that we don't know how to edit, or for
    *                   compound properties that work as containers for sub-properties.
    */
-  public void computedGetWidgetDescription(List<FlutterWidgetProperty> properties);
+  void computedGetWidgetDescription(List<FlutterWidgetProperty> properties);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
@@ -38,5 +38,5 @@ public interface GetWidgetDescriptionConsumer extends Consumer {
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ImportElementsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ImportElementsConsumer.java
@@ -17,7 +17,7 @@ import org.dartlang.analysis.server.protocol.RequestError;
 import org.dartlang.analysis.server.protocol.SourceFileEdit;
 
 public interface ImportElementsConsumer extends Consumer {
-  public void computedImportedElements(SourceFileEdit edit);
+  void computedImportedElements(SourceFileEdit edit);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/IsEnabledConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/IsEnabledConsumer.java
@@ -16,7 +16,7 @@ package com.google.dart.server;
 import org.dartlang.analysis.server.protocol.RequestError;
 
 public interface IsEnabledConsumer extends Consumer {
-  public void isEnabled(Boolean value);
+  void isEnabled(Boolean value);
 
   default public void onError(RequestError requestError) {
   }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/JsonConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/JsonConsumer.java
@@ -22,5 +22,5 @@ import org.dartlang.analysis.server.protocol.RequestError;
  * @coverage dart.server
  */
 public interface JsonConsumer extends Consumer {
-  public void onResponse(JsonObject resultObject, RequestError requestError);
+  void onResponse(JsonObject resultObject, RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ListPostfixCompletionTemplatesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/ListPostfixCompletionTemplatesConsumer.java
@@ -5,7 +5,7 @@ import org.dartlang.analysis.server.protocol.RequestError;
 
 public interface ListPostfixCompletionTemplatesConsumer extends Consumer {
 
-  public void postfixCompletionTemplates(PostfixTemplateDescriptor[] templates);
+  void postfixCompletionTemplates(PostfixTemplateDescriptor[] templates);
 
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/MapUriConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/MapUriConsumer.java
@@ -30,7 +30,7 @@ public interface MapUriConsumer extends Consumer {
    * @param uri the URI to which the file path was mapped. This field is omitted if the file field
    *          was not given in the request
    */
-  public void computedFileOrUri(String file, String uri);
+  void computedFileOrUri(String file, String uri);
 
   /**
    * If a file or uri was not mapped and cannot be passed back, some {@link RequestError} is passed
@@ -38,5 +38,5 @@ public interface MapUriConsumer extends Consumer {
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/OrganizeDirectivesConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/OrganizeDirectivesConsumer.java
@@ -28,12 +28,12 @@ public interface OrganizeDirectivesConsumer extends Consumer {
    * 
    * @param edit the computed {@link SourceFileEdit}
    */
-  public void computedEdit(SourceFileEdit edit);
+  void computedEdit(SourceFileEdit edit);
 
   /**
    * If organize changes cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SearchResultsConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SearchResultsConsumer.java
@@ -28,5 +28,5 @@ public interface SearchResultsConsumer extends Consumer {
    * @param searchResults an array of {@link SearchResult}s computed so far
    * @param isLastResult is {@code true} if this is the last set of results
    */
-  public void computed(SearchResult[] searchResults, boolean isLastResult);
+  void computed(SearchResult[] searchResults, boolean isLastResult);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SetWidgetPropertyValueConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SetWidgetPropertyValueConsumer.java
@@ -25,7 +25,7 @@ public interface SetWidgetPropertyValueConsumer extends Consumer {
   /**
    * @param change The change that should be applied.
    */
-  public void computedSetWidgetPropertyValue(SourceChange change);
+  void computedSetWidgetPropertyValue(SourceChange change);
 
   /**
    * If a transitive closure cannot be passed back, some {@link RequestError} is passed back
@@ -33,5 +33,5 @@ public interface SetWidgetPropertyValueConsumer extends Consumer {
    *
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SortMembersConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/SortMembersConsumer.java
@@ -28,12 +28,12 @@ public interface SortMembersConsumer extends Consumer {
    * 
    * @param edit the computed {@link SourceFileEdit}
    */
-  public void computedEdit(SourceFileEdit edit);
+  void computedEdit(SourceFileEdit edit);
 
   /**
    * If sort changes cannot be passed back, some {@link RequestError} is passed back instead.
    * 
    * @param requestError the reason why a result was not passed back
    */
-  public void onError(RequestError requestError);
+  void onError(RequestError requestError);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/UpdateContentConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/UpdateContentConsumer.java
@@ -23,5 +23,5 @@ public interface UpdateContentConsumer extends Consumer {
   /**
    * A response to the request was received.
    */
-  public void onResponse();
+  void onResponse();
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/utilities/instrumentation/InstrumentationBuilder.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/utilities/instrumentation/InstrumentationBuilder.java
@@ -32,7 +32,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder data(String name, boolean value);
+  InstrumentationBuilder data(String name, boolean value);
 
   /**
    * Append the given data to the data being collected by this builder. The information is declared
@@ -43,7 +43,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder data(String name, long value);
+  InstrumentationBuilder data(String name, long value);
 
   /**
    * Append the given data to the data being collected by this builder. The information is declared
@@ -54,7 +54,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder data(String name, String value);
+  InstrumentationBuilder data(String name, String value);
 
   /**
    * Append the given data to the data being collected by this builder. The information is declared
@@ -65,7 +65,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder data(String name, String[] value);
+  InstrumentationBuilder data(String name, String[] value);
 
   /**
    * Answer the {@link InstrumentationLevel} of this {@code InstrumentationBuilder}.
@@ -73,14 +73,14 @@ public interface InstrumentationBuilder {
    * @return one of {@link InstrumentationLevel#EVERYTHING}, {@link InstrumentationLevel#METRICS},
    *         {@link InstrumentationLevel#OFF}
    */
-  public InstrumentationLevel getInstrumentationLevel();
+  InstrumentationLevel getInstrumentationLevel();
 
   /**
    * Log the data that has been collected. The instrumentation builder should not be used after this
    * method is invoked. The behavior of any method defined on this interface that is used after this
    * method is invoked is undefined.
    */
-  public void log();
+  void log();
 
   /**
    * Log the data that has been collected. The instrumentation builder should not be used after this
@@ -89,7 +89,7 @@ public interface InstrumentationBuilder {
    * 
    * @param minTimeToLog if the total elapsed time is less than this, do not record
    */
-  public void log(int minTimeToLog);
+  void log(int minTimeToLog);
 
   /**
    * Append the given metric to the data being collected by this builder. The information is
@@ -100,7 +100,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder metric(String name, boolean value);
+  InstrumentationBuilder metric(String name, boolean value);
 
   /**
    * Append the given metric to the data being collected by this builder. The information is
@@ -111,7 +111,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder metric(String name, long value);
+  InstrumentationBuilder metric(String name, long value);
 
   /**
    * Append the given metric to the data being collected by this builder. The information is
@@ -122,7 +122,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder metric(String name, String value);
+  InstrumentationBuilder metric(String name, String value);
 
   /**
    * Append the given metric to the data being collected by this builder. The information is
@@ -133,7 +133,7 @@ public interface InstrumentationBuilder {
    * @param value the value of the data to be collected
    * @return this builder
    */
-  public InstrumentationBuilder metric(String name, String[] value);
+  InstrumentationBuilder metric(String name, String[] value);
 
   /**
    * Append the given exception to the information being collected by this builder. The exception's
@@ -144,5 +144,5 @@ public interface InstrumentationBuilder {
    * 
    * @param exception the exception (may be {@code null})
    */
-  public InstrumentationBuilder record(Throwable exception);
+  InstrumentationBuilder record(Throwable exception);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/utilities/instrumentation/InstrumentationLogger.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/utilities/instrumentation/InstrumentationLogger.java
@@ -29,5 +29,5 @@ public interface InstrumentationLogger {
    * @param name the name used to uniquely identify the operation
    * @return the builder that was created
    */
-  public InstrumentationBuilder createBuilder(String name);
+  InstrumentationBuilder createBuilder(String name);
 }


### PR DESCRIPTION
This PR removes redundant `public` modifier from interface methods, as suggested by [JLS](https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.4)

> It is permitted, but discouraged as a matter of style, to redundantly specify the public and/or abstract modifier for a method declared in an interface.

Also, it removes redundant `private` modifier for Enumeration constructor.

This code seems to be copied from a frozen repository, but it doesn't mean we shouldn't go forward, I think.