### PR TITLE
Document the reason of failure of DartServerEditingTest

### DIFF
--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerEditingTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerEditingTest.java
@@ -14,6 +14,7 @@ public class DartServerEditingTest extends CodeInsightFixtureTestCase {
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
   }
 
+  // fails because of https://github.com/dart-lang/sdk/issues/31456
   public void testInsertImportsOnPaste() {
     myFixture.configureByText("foo.dart", "import 'dart:math';\n" +
                                           "main() {\n" +


### PR DESCRIPTION
Currently, `DartServerEditingTest.testInsertImportsOnPaste()` fails because the feature is disabled in Dart SDK.

This PR document the reason, I hope it is fixed soon.