### PR TITLE
Dart plugin: work in progress towards updated completion support

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -165,7 +165,6 @@
     <gotoSymbolContributor implementation="com.jetbrains.lang.dart.ide.DartSymbolContributor"/>
 
     <completion.contributor language="Dart" implementationClass="com.jetbrains.lang.dart.ide.completion.DartServerCompletionContributor"/>
-    <completion.contributor language="HTML" implementationClass="com.jetbrains.lang.dart.ide.completion.DartServerCompletionContributor"/>
     <gotoDeclarationHandler implementation="com.jetbrains.lang.dart.ide.completion.DartGotoDeclarationHandler"/>
     <lookup.charFilter implementation="com.jetbrains.lang.dart.ide.completion.DartCharFilter"/>
     <lang.smartEnterProcessor language="Dart"


### PR DESCRIPTION
@alexander-doroshko 

This PR:
1) removes the `HTML` support as the angular plugin has been turned down,
2) introduces the usage of the new completion protocol if the returned DAS server version is `1.33` (currently higher than is committed into the Dart SDK)

Status: the new protocol works, the completions are re-queried only when `isIncomplete` is `true`.  What I can't yet figure out is how implement and decide to re-query for completions if `isIncomplete` is `true`, to give users access to more than just the fixed 100 that I have hard coded.  Any input here would be helpful Alex.

FYI @bwilkerson & @scheglov 
