### PR TITLE
[protobuf] Fix bug when annotating missing colon after non-message field name

### DIFF
--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/PbTextAnnotator.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/PbTextAnnotator.java
@@ -203,7 +203,7 @@ public class PbTextAnnotator implements Annotator {
       // The grammar permits value list fields without a colon since it does not have the field type
       // context.
       if (!(name.getDeclaredNamedType() instanceof PbMessageType)) {
-        PsiElement next = name.getNextSibling();
+        PsiElement next = PsiTreeUtil.skipWhitespacesAndCommentsForward(name);
         if (next == null || !":".equals(next.getText())) {
           TextRange range = TextRange.from(name.getTextOffset() + name.getTextLength(), 1);
           holder.newAnnotation(HighlightSeverity.ERROR, PbLangBundle.message("expected.colon.after.non.message.field"))

--- a/protobuf/protoeditor-core/testData/lang/annotation/TextValueErrors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/TextValueErrors.proto.testdata
@@ -244,8 +244,10 @@ option (opt) = {
 
   // Colons are required for non-message repeated fields
   string: ["foo", "bar"]
+  string /*skipped comment and whitespace*/ : ["foo", "bar"]
   string<error descr="Expected ':' after non-message field name"> </error> ["foo", "bar"]
   enum: [FOO, BAR]
+  enum /*skipped comment and whitespace*/ : [FOO, BAR]
   enum<error descr="Expected ':' after non-message field name"> </error> [FOO, BAR]
 
   // Not required for message repeated fields


### PR DESCRIPTION
When annotating text format options, skip whitespace and comments when checking that a colon (`:`) follows a non-message field name.

Reported in the old repository at https://github.com/jvolkman/intellij-protobuf-editor/issues/70
