### PR TITLE
Dart plugin: implement and use the `completion_getSuggestionDetails2` protocol

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -100,6 +100,7 @@ public final class DartAnalysisServerService implements Disposable {
   private static final long STATEMENT_COMPLETION_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(100);
   private static final long GET_SUGGESTIONS_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
   private static final long GET_SUGGESTION_DETAILS_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(100);
+  private static final long GET_SUGGESTION_DETAILS2_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(100);
   private static final long FIND_ELEMENT_REFERENCES_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
   private static final long GET_TYPE_HIERARCHY_TIMEOUT = TimeUnit.SECONDS.toMillis(10);
   private static final long EXECUTION_CREATE_CONTEXT_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
@@ -1443,6 +1444,43 @@ public final class DartAnalysisServerService implements Disposable {
     }
     return resultRef.get();
   }
+
+
+  @Nullable
+  public Pair<String, SourceChange> completion_getSuggestionDetails2(@NotNull VirtualFile file,
+                                                                     int _offset,
+                                                                     String completion,
+                                                                     String libraryUri) {
+    final AnalysisServer server = myServer;
+    if (server == null) {
+      return null;
+    }
+
+    final String filePath = FileUtil.toSystemDependentName(file.getPath());
+    final Ref<Pair<String, SourceChange>> resultRef = new Ref<>();
+    final CountDownLatch latch = new CountDownLatch(1);
+    final int offset = getOriginalOffset(file, _offset);
+    server.completion_getSuggestionDetails2(filePath, offset, completion, libraryUri, new GetSuggestionDetailsConsumer2() {
+      @Override
+      public void computedDetails(String completion, SourceChange change) {
+        resultRef.set(new Pair<>(completion, change));
+        latch.countDown();
+      }
+
+      @Override
+      public void onError(RequestError requestError) {
+        latch.countDown();
+      }
+    });
+
+    awaitForLatchCheckingCanceled(server, latch, GET_SUGGESTION_DETAILS2_TIMEOUT);
+
+    if (latch.getCount() > 0) {
+      logTookTooLongMessage("completion_getSuggestionDetails2", GET_SUGGESTION_DETAILS2_TIMEOUT, filePath);
+    }
+    return resultRef.get();
+  }
+
 
   @Nullable
   public String completion_getSuggestions(@NotNull final VirtualFile file, final int _offset) {

--- a/Dart/testData/analysisServer/completion/IncompleteTernary.after.dart
+++ b/Dart/testData/analysisServer/completion/IncompleteTernary.after.dart
@@ -1,7 +1,7 @@
 void main() {
-  new A(x: true ? true<caret>);
+  new A(x: 1 != 2 ? true<caret>);
 }
 
 class A {
-  A({int x});
+  A({bool? x});
 }

--- a/Dart/testData/analysisServer/completion/IncompleteTernary.dart
+++ b/Dart/testData/analysisServer/completion/IncompleteTernary.dart
@@ -1,7 +1,7 @@
 void main() {
-  new A(x: true ? tru<caret>);
+  new A(x: 1 != 2 ? tru<caret>);
 }
 
 class A {
-  A({int x});
+  A({bool? x});
 }

--- a/Dart/testData/analysisServer/completion/NotYetImportedClass.after.dart
+++ b/Dart/testData/analysisServer/completion/NotYetImportedClass.after.dart
@@ -1,5 +1,3 @@
-import 'dart:async' as prefix0;
+import 'dart:async';
 
-class A extends prefix0.SynchronousStreamController<caret>
-
-SynchronousStreamController(){} // it's here to test that 'dart.async' will be imported with prefix
+class A extends SynchronousStreamController<caret>

--- a/Dart/testData/analysisServer/completion/NotYetImportedClass.dart
+++ b/Dart/testData/analysisServer/completion/NotYetImportedClass.dart
@@ -1,3 +1,1 @@
 class A extends SynchronousStreamControl<caret>
-
-SynchronousStreamController(){} // it's here to test that 'dart.async' will be imported with prefix

--- a/Dart/testData/analysisServer/completion/WithImportPrefix.after.dart
+++ b/Dart/testData/analysisServer/completion/WithImportPrefix.after.dart
@@ -1,5 +1,5 @@
 import "dart:io" as io;
 
 main() {
-  io.FileSystemEntityType<caret>
+  io.ConnectionTask<caret>
 }

--- a/Dart/testData/analysisServer/completion/WithImportPrefix.dart
+++ b/Dart/testData/analysisServer/completion/WithImportPrefix.dart
@@ -1,5 +1,5 @@
 import "dart:io" as io;
 
 main() {
-  FileSystemEntityT<caret>
+  ConnectionTas<caret>
 }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartServerCompletionTest.java
@@ -111,9 +111,11 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
     doTest();
   }
 
-  public void testFunctionAfterShow() {
-    doTest();
-  }
+
+  // Fails due to https://github.com/dart-lang/sdk/issues/47993
+  // public void testFunctionAfterShow() {
+  //  doTest();
+  //}
 
   public void testFunctionAsArgument() {
     doTest();
@@ -123,7 +125,6 @@ public class DartServerCompletionTest extends CodeInsightFixtureTestCase {
     doTest("for");
   }
 
-  // fails because of the fix for https://github.com/dart-lang/sdk/issues/38326
   public void testWithImportPrefix() {
     doTest();
   }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -741,6 +741,9 @@ public class RemoteAnalysisServerImpl implements AnalysisServer {
     else if (consumer instanceof GetSuggestionsConsumer) {
       new CompletionIdProcessor((GetSuggestionsConsumer)consumer).process(resultObject, requestError);
     }
+    else if (consumer instanceof GetSuggestionDetailsConsumer2) {
+      new GetSuggestionDetailsProcessor2((GetSuggestionDetailsConsumer2)consumer).process(resultObject, requestError);
+    }
     else if (consumer instanceof GetSuggestionsConsumer2) {
       new CompletionIdProcessor2((GetSuggestionsConsumer2)consumer).process(resultObject, requestError);
     }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/GetSuggestionDetailsProcessor2.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/GetSuggestionDetailsProcessor2.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2014, the Dart project authors.
- * 
+ *
  * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -13,24 +13,24 @@
  */
 package com.google.dart.server.internal.remote.processor;
 
-import com.google.dart.server.GetSuggestionDetailsConsumer;
-import com.google.dart.server.GetSuggestionsConsumer;
+import com.google.dart.server.GetSuggestionDetailsConsumer2;
+import com.google.dart.server.GetSuggestionsConsumer2;
 import com.google.gson.JsonObject;
 
 import org.dartlang.analysis.server.protocol.RequestError;
 import org.dartlang.analysis.server.protocol.SourceChange;
 
 /**
- * Instances of {@code GetSuggestionDetailsProcessor} translate JSON result objects for a given
- * {@link GetSuggestionDetailsConsumer}.
- * 
+ * Instances of {@code GetSuggestionDetailsProcessor2} translate JSON result objects for a given
+ * {@link GetSuggestionDetailsConsumer2}.
+ *
  * @coverage dart.server.remote
  */
-public class GetSuggestionDetailsProcessor extends ResultProcessor {
+public class GetSuggestionDetailsProcessor2 extends ResultProcessor {
 
-  private final GetSuggestionDetailsConsumer consumer;
+  private final GetSuggestionDetailsConsumer2 consumer;
 
-  public GetSuggestionDetailsProcessor(GetSuggestionDetailsConsumer consumer) {
+  public GetSuggestionDetailsProcessor2(GetSuggestionDetailsConsumer2 consumer) {
     this.consumer = consumer;
   }
 


### PR DESCRIPTION
Dart plugin: implement and use the completion_getSuggestionDetails2 protocol, updates to the Dart completion tests for Dart SDK version `2.15` as well as the latest SDK HEAD version with the new protocol

`testWithImportPrefix` - modified due to change in completion support (or in the inclusion of constants in the `dart:io` package)

`testFunctionAfterShow` - disabled due to https://github.com/dart-lang/sdk/issues/47993

`testNotYetImportedClass` - test updated to match the current functionality of the Dart completion for not yet imported classes

These are failing with the updated DAS API version `1.33`:

`testIncompleteTernary` - test failing with new protocol, even though the DAS is returning correct result and manual testing of this test do work, not sure how to debug further.  Specifically, the lookup panel doesn't exist, and a NPE is being thrown.

`testConstructorParens`, `testDoNotEatAwaitOnTab`, `testNotYetImportedClass` - manual test looks fine to me, but framework is throwing errors with these tests, attempts to add additional pauses, etc, did not work
