### PR TITLE
Fix for Dart folding of longer methods and getters implemented with the fat arrow (=>) syntax. 

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/folding/DartFoldingBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/folding/DartFoldingBuilder.java
@@ -297,8 +297,16 @@ public class DartFoldingBuilder extends CustomFoldingBuilder implements DumbAwar
                                        @NotNull final PsiElement dartComponentOrOperatorDeclaration) {
     final DartFunctionBody functionBody = PsiTreeUtil.getChildOfType(dartComponentOrOperatorDeclaration, DartFunctionBody.class);
     final IDartBlock block = functionBody == null ? null : functionBody.getBlock();
+    // Handle bodies defined with {...}
     if (block != null && block.getTextLength() > 2) {
       descriptors.add(new FoldingDescriptor(functionBody, block.getTextRange()));
+    }
+    // Handle bodies defined with the fat arrow: =>
+    // A text length of 5 is used for cases as short at "=> 0;"
+    else if (functionBody != null &&
+             functionBody.getTextLength() > 5 &&
+             functionBody.getFirstChild().getText().equals("=>")) {
+      descriptors.add(new FoldingDescriptor(functionBody, functionBody.getTextRange()));
     }
   }
 

--- a/Dart/testData/folding/CustomRegions.dart
+++ b/Dart/testData/folding/CustomRegions.dart
@@ -10,7 +10,7 @@ class Foo <fold text='{...}' expand='true'>{
   Foo.fromJSON(String jsonString) {}
   //</editor-fold></fold>
 
-  String toString() => "";
+  String toString() <fold text='{...}' expand='true'>=> "";</fold>
 
   <fold text='3' expand='true'>//<editor-fold desc="3">
   main() <fold text='{...}' expand='true'>{

--- a/Dart/testData/folding/FunctionBody.dart
+++ b/Dart/testData/folding/FunctionBody.dart
@@ -13,6 +13,10 @@ get topGetter2 <fold text='{...}' expand='true'>{
 set topSetter(p) <fold text='{...}' expand='true'>{
 }</fold>
 
+get topGetter3 <fold text='{...}' expand='true'>=> true ||
+    false ||
+    true;</fold>
+
 class A <fold text='{...}' expand='true'>{
   A()
   <fold text='{...}' expand='true'>{
@@ -22,6 +26,10 @@ class A <fold text='{...}' expand='true'>{
 
   factory A.factory() <fold text='{...}' expand='true'>{
   }</fold>
+
+  bool returnBool() <fold text='{...}' expand='true'>=> true ||
+    false ||
+    true;</fold>
 }</fold>
 
 abstract class B <fold text='{...}' expand='true'>{


### PR DESCRIPTION
Fixes issue WEB-35980