### PR TITLE
Parse web format of files with 'packages/' 

### DIFF
--- a/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/DartConsoleFilterTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/ide/runner/DartConsoleFilterTest.java
@@ -85,6 +85,8 @@ public class DartConsoleFilterTest extends TestCase {
                    "foo.dart/bar.dart_baz.dart.more.dart", -1, -1);
     doPositiveTest("file:foo.dart/bar.dart_baz.dart.more.dart,evenmore.dart", Type.FILE, "file:foo.dart/bar.dart_baz.dart.more.dart",
                    "foo.dart/bar.dart_baz.dart.more.dart", -1, -1);
+    doPositiveTest("packages/hello_flutter_external/main.dart 63:7  <fn>", Type.PACKAGE, "packages/hello_flutter_external/main.dart",
+                   "hello_flutter_external/main.dart", 62, 6);
   }
 
   public void testRelativePathsConsoleFilter() {


### PR DESCRIPTION
This addresses https://github.com/flutter/flutter-intellij/issues/6131. The flutter issue occurs because the stdout for flutter web differs from other platforms. We investigated whether we should change the stdout to be more consistent but decided it made more sense to parse the file names differently (see https://github.com/dart-lang/sdk/issues/49147).

CC @jwren