### PR TITLE
Enable support for fields that end with `$` and `_`

### DIFF
--- a/tapestry/core/src/com/intellij/tapestry/core/model/presentation/TapestryParameter.java
+++ b/tapestry/core/src/com/intellij/tapestry/core/model/presentation/TapestryParameter.java
@@ -46,8 +46,15 @@ public class TapestryParameter implements Comparable {
           name = params.get(PARAMETER_NAME)[0];
         }
       }
+      if (name.startsWith("$") || name.startsWith("_")) {
+          return name.substring(1);
+      }
+       
+      if (name.endsWith("$") || name.endsWith("_")) {
+          return name.substring(0, name.length() - 1);
+      }
 
-      return name.startsWith("$") || name.startsWith("_") ? name.substring(1) : name;
+      return name;
     }
 
   /**

--- a/tapestry/core/src/com/intellij/tapestry/core/util/ClassUtils.java
+++ b/tapestry/core/src/com/intellij/tapestry/core/util/ClassUtils.java
@@ -89,7 +89,9 @@ public final class ClassUtils {
         if (name.startsWith("$") || name.startsWith("_")) {
             return name.substring(1);
         }
-
+        if (name.endsWith("$") || name.endsWith("_")) {
+            return name.substring(0, name.length() - 1);
+        }
         return name;
     }
 }


### PR DESCRIPTION
We are using a field naming methodology were our class fields end in '_'. Currently, the tapestry plugin only supports fields that start with a '$' or '_'. 

Extend the functionality so that components can pick-up fields that end with '_' and not report them as missing.