### PR TITLE
WEB-41595 call hierarchy: jump to caller position

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallChild.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallChild.java
@@ -1,0 +1,22 @@
+// Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.ide.hierarchy.call;
+
+import com.intellij.psi.PsiElement;
+
+public class DartCallChild {
+  private PsiElement element;
+  private PsiElement reference;
+
+  public DartCallChild(PsiElement element, PsiElement reference) {
+    this.element = element;
+    this.reference = reference;
+  }
+
+  public PsiElement getElement() {
+    return element;
+  }
+
+  public PsiElement getReference() {
+    return reference;
+  }
+}

--- a/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyNodeDescriptor.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyNodeDescriptor.java
@@ -1,24 +1,43 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.lang.dart.ide.hierarchy.call;
 
+import com.intellij.codeInsight.highlighting.HighlightManager;
+import com.intellij.ide.IdeBundle;
 import com.intellij.ide.hierarchy.HierarchyNodeDescriptor;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.colors.EditorColors;
+import com.intellij.openapi.editor.markup.RangeHighlighter;
 import com.intellij.openapi.roots.ui.util.CompositeAppearance;
 import com.intellij.openapi.util.Comparing;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.pom.Navigatable;
 import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiEditorUtil;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartComponentType;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartMethodDeclaration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class DartCallHierarchyNodeDescriptor extends HierarchyNodeDescriptor {
+import java.util.ArrayList;
+import java.util.List;
+
+public class DartCallHierarchyNodeDescriptor extends HierarchyNodeDescriptor implements Navigatable {
+
+  private final List<PsiReference> myReferences = new ArrayList<>();
 
   public DartCallHierarchyNodeDescriptor(final NodeDescriptor parentDescriptor, @NotNull final PsiElement element, final boolean isBase) {
     super(element.getProject(), parentDescriptor, element, isBase);
+  }
+
+  public void addReference(PsiReference reference) {
+    myReferences.add(reference);
   }
 
   @Override
@@ -47,11 +66,77 @@ public class DartCallHierarchyNodeDescriptor extends HierarchyNodeDescriptor {
       if (file != null) {
         myHighlightedText.getEnding().addText(" (" + file.getName() + ")", HierarchyNodeDescriptor.getPackageNameAttributes());
       }
+      var myUsageCount = myReferences.size();
+      if (myUsageCount > 1) {
+        myHighlightedText.getEnding().addText(IdeBundle.message("node.call.hierarchy.N.usages", myUsageCount), HierarchyNodeDescriptor.getUsageCountPrefixAttributes());
+      }
+
     }
     myName = myHighlightedText.getText();
     if (!Comparing.equal(myHighlightedText, oldText)) {
       changes = true;
     }
     return changes;
+  }
+
+  private @Nullable Navigatable getNavigatable() {
+    if (!myReferences.isEmpty()) {
+      final var reference = myReferences.get(0);
+      if (reference instanceof Navigatable) {
+        return (Navigatable)reference;
+      }
+    }
+    final var ret = getPsiElement();
+    if (ret instanceof Navigatable) {
+      return (Navigatable)ret;
+    }
+    return null;
+  }
+
+  @Override
+  public void navigate(boolean requestFocus) {
+    final var nav = getNavigatable();
+    if (nav == null) {
+      return;
+    }
+    nav.navigate(requestFocus);
+
+    if (!(nav instanceof PsiElement)) {
+      return;
+    }
+
+    Editor editor = PsiEditorUtil.findEditor((PsiElement) nav);
+
+    if (editor != null) {
+      HighlightManager highlightManager = HighlightManager.getInstance(myProject);
+      List<RangeHighlighter> highlighters = new ArrayList<>();
+      for (PsiReference psiReference : myReferences) {
+        PsiElement eachElement = psiReference.getElement();
+        PsiElement eachMethodCall = eachElement.getParent();
+        if (eachMethodCall != null) {
+          TextRange textRange = eachMethodCall.getTextRange();
+          highlightManager.addRangeHighlight(editor, textRange.getStartOffset(), textRange.getEndOffset(),
+                                             EditorColors.SEARCH_RESULT_ATTRIBUTES, false, highlighters);
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean canNavigate() {
+    final var nav = getNavigatable();
+    if (nav != null) {
+      return nav.canNavigate();
+    }
+    return false;
+  }
+
+  @Override
+  public boolean canNavigateToSource() {
+    final var nav = getNavigatable();
+    if (nav != null) {
+      return nav.canNavigateToSource();
+    }
+    return false;
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCalleeTreeStructure.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCalleeTreeStructure.java
@@ -25,7 +25,7 @@ public class DartCalleeTreeStructure extends DartCallHierarchyTreeStructure {
     super(project, element, currentScopeType);
   }
 
-  private static void getCallees(@NotNull PsiElement element, @NotNull List<PsiElement> results) {
+  private static void getCallees(@NotNull PsiElement element, @NotNull List<DartCallChild> results) {
     DartComponentName name = (DartComponentName)element;
     DartComponent decl = (DartComponent)name.getParent();
     PsiFile file = decl.getContainingFile();
@@ -39,7 +39,7 @@ public class DartCalleeTreeStructure extends DartCallHierarchyTreeStructure {
 
   private static void resolveReferences(@NotNull DartComponent component,
                                         @NotNull List<DartNavigationRegion> regions,
-                                        @NotNull List<PsiElement> results) {
+                                        @NotNull List<DartCallChild> results) {
     component.acceptChildren(new DartRecursiveVisitor() {
       @Override
       public void visitReferenceExpression(@NotNull DartReferenceExpression reference) {
@@ -49,7 +49,7 @@ public class DartCalleeTreeStructure extends DartCallHierarchyTreeStructure {
           if (isExecutable(target)) {
             PsiElement element = getDeclaration(target, reference);
             if (element != null) {
-              results.add(element);
+              results.add(new DartCallChild(element, reference));
             }
           }
         }
@@ -86,8 +86,8 @@ public class DartCalleeTreeStructure extends DartCallHierarchyTreeStructure {
 
   @NotNull
   @Override
-  protected List<PsiElement> getChildren(@NotNull PsiElement element) {
-    final List<PsiElement> list = new ArrayList<>();
+  protected List<DartCallChild> getChildren(@NotNull PsiElement element) {
+    final List<DartCallChild> list = new ArrayList<>();
     getCallees(element, list);
     return list;
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallerTreeStructure.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallerTreeStructure.java
@@ -18,7 +18,7 @@ public class DartCallerTreeStructure extends DartCallHierarchyTreeStructure {
     super(project, element, currentScopeType);
   }
 
-  private static void getCallers(@NotNull PsiElement element, @NotNull List<PsiElement> results, @NotNull GlobalSearchScope scope) {
+  private static void getCallers(@NotNull PsiElement element, @NotNull List<DartCallChild> results, @NotNull GlobalSearchScope scope) {
     FindUsagesHandler finder = createFindUsageHandler(element);
     final CommonProcessors.CollectProcessor<UsageInfo> processor = new CommonProcessors.CollectProcessor<>();
     FindUsagesOptions options = new FindUsagesOptions(scope);
@@ -33,8 +33,8 @@ public class DartCallerTreeStructure extends DartCallHierarchyTreeStructure {
 
   @NotNull
   @Override
-  protected List<PsiElement> getChildren(@NotNull PsiElement element) {
-    final List<PsiElement> list = new ArrayList<>();
+  protected List<DartCallChild> getChildren(@NotNull PsiElement element) {
+    final List<DartCallChild> list = new ArrayList<>();
     getCallers(element, list, getScope());
     return list;
   }

--- a/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
+++ b/Dart/testSrc/com/jetbrains/dart/analysisServer/DartCallHierarchyTest.java
@@ -12,6 +12,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.indexing.FindSymbolParameters;
 import com.jetbrains.lang.dart.ide.DartClassContributor;
 import com.jetbrains.lang.dart.ide.DartSymbolContributor;
+import com.jetbrains.lang.dart.ide.hierarchy.call.DartCallChild;
 import com.jetbrains.lang.dart.ide.hierarchy.call.DartCallHierarchyTreeStructure;
 import com.jetbrains.lang.dart.ide.hierarchy.call.DartCalleeTreeStructure;
 import com.jetbrains.lang.dart.ide.hierarchy.call.DartCallerTreeStructure;
@@ -103,10 +104,10 @@ public class DartCallHierarchyTest extends DartHierarchyTestBase {
                 if (parent != null) {
                   type = parent.getNode().getElementType();
                   if (type == CALL_EXPRESSION) {
-                    List<PsiElement> results = new ArrayList<>();
+                    List<DartCallChild> results = new ArrayList<>();
                     DartCallHierarchyTreeStructure.collectDeclarations(reference.resolve(), results);
                     if (!results.isEmpty()) {
-                      result[0] = results.get(0);
+                      result[0] = results.get(0).getElement();
                       throw new ExitVisitor();
                     }
                   }


### PR DESCRIPTION
When showing caller hierarchy, jump to the actual location of the invocation, not to the enclosed function.

If there are multiple invocations inside a function all locations will be highlighted, similar to how the java plugin works.

<img width="631" alt="Screen Shot 2022-06-24 at 00 08 00" src="https://user-images.githubusercontent.com/313066/175423714-448b672e-54cd-454a-8db1-dfd8fd709005.png">


For some reason I have a few test failures.. but when reverting to the original master, I have the same failures.. so I don't think my changes caused them. Can someone reproduce this? thanks.


https://youtrack.jetbrains.com/issue/WEB-41595/Dart-plugin-Call-hierarchy-should-navigate-to-call-side-not-surrounding-function
