### PR TITLE
Dart: allow quick fixes with multiple edits. and support .arb translation files.

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/Dart/src/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -892,6 +892,7 @@ public final class DartAnalysisServerService implements Disposable {
     return fileName.endsWith(".dart") ||
            fileName.endsWith(".htm") ||
            fileName.endsWith(".html") ||
+           fileName.endsWith(".arb") ||
            fileName.equals(".analysis_options") ||
            fileName.equals("analysis_options.yaml") ||
            fileName.equals("pubspec.yaml") ||

--- a/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFix.java
+++ b/Dart/src/com/jetbrains/lang/dart/fixes/DartQuickFix.java
@@ -144,14 +144,17 @@ public final class DartQuickFix implements IntentionAction, Comparable<Intention
 
   public static boolean isAvailable(@NotNull Project project, @NotNull SourceChange sourceChange) {
     final List<SourceFileEdit> fileEdits = sourceChange.getEdits();
-    if (fileEdits.size() != 1) return false;
+    if (fileEdits.size() < 1) {
+      return false;
+    }
 
-    final SourceFileEdit fileEdit = fileEdits.get(0);
-    final VirtualFile virtualFile = AssistUtils.findVirtualFile(fileEdit);
-    final ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
+    for (SourceFileEdit fileEdit : fileEdits) {
+      final VirtualFile virtualFile = AssistUtils.findVirtualFile(fileEdit);
+      final ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
 
-    if (fileEdit.getFileStamp() != -1) {
-      if (virtualFile == null || !fileIndex.isInContent(virtualFile)) return false;
+      if (fileEdit.getFileStamp() != -1) {
+        if (virtualFile == null || !fileIndex.isInContent(virtualFile)) return false;
+      }
     }
 
     return true;


### PR DESCRIPTION
When a analysis warning is produced with multiple fixes they were correctly displayed in the "Dart Analysis" tool window. But in the quick fix drop down only fixsets with a single fix were displayed.
This changes this behavior to allow multiple fixes. And it seems to work for me.

In addition i've added `.arb` files to the list of analysis files.