### PR TITLE
Use List instead of ImmutableList in the plugin API.

### DIFF
--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/names/NameGeneratorContributor.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/names/NameGeneratorContributor.java
@@ -15,10 +15,10 @@
  */
 package com.intellij.protobuf.lang.names;
 
-import com.google.common.collect.ImmutableList;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.protobuf.lang.psi.PbFile;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
+import java.util.List;
 
 /** Extension point for things that provide names for a protobuf generated class. */
 public interface NameGeneratorContributor {
@@ -41,5 +41,5 @@ public interface NameGeneratorContributor {
    * @return a list of name generators for the provided file
    */
   @RequiresReadLock
-  <T> ImmutableList<T> contributeGenerators(PbFile file, Class<T> generatorClass);
+  <T> List<T> contributeGenerators(PbFile file, Class<T> generatorClass);
 }

--- a/protobuf/protoeditor-jvm/src/com/intellij/protobuf/jvm/names/NameGeneratorSelector.java
+++ b/protobuf/protoeditor-jvm/src/com/intellij/protobuf/jvm/names/NameGeneratorSelector.java
@@ -78,7 +78,8 @@ public final class NameGeneratorSelector {
           "NameSelector using "
           + contributor.getClass().getName()
           + " for protobuf name generators");
-        return contributor.contributeGenerators(file, JavaNameGenerator.class);
+        return ImmutableList.copyOf(
+            contributor.contributeGenerators(file, JavaNameGenerator.class));
       }
     }
     return contributeDefaultGenerators(file);


### PR DESCRIPTION
Interface NameGeneratorSelector can be implemented in other plugins. Since each plugin can bundle their own version of guava, using a guava type in the return value is unsafe and results in LinkageErrors at runtime. Use the java List interface instead which avoid any such issues.