### PR TITLE
IDEA-306713: Upgrade dependencies for Error Prone plugin

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
   <artifact version="2.15.0" name="error-prone">
-    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.15.0/error_prone_core-2.15.0-with-dependencies.jar"/>
+    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.16/error_prone_core-2.16-with-dependencies.jar"/>
     <item url="https://repo1.maven.org/maven2/com/google/code/findbugs/jFormatString/3.0.0/jFormatString-3.0.0.jar"/>
-    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-shaded/3.15.0/dataflow-shaded-3.15.0.jar"/>
+    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-shaded/3.24.0/dataflow-shaded-3.24.0.jar"/>
     <item url="https://repo1.maven.org/maven2/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
Upgrade to Error Prone 2.16, and fix Checker Framework Dataflow
dependency to use the correct artifact and version.

[IDEA-306713](https://youtrack.jetbrains.com/issue/IDEA-306713)