### PR TITLE
remove debug claim from cfml plugin description

### DIFF
--- a/CFML/resources/META-INF/plugin.xml
+++ b/CFML/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
     <![CDATA[
     Adds support for ColdFusion Markup Language (CFML).
     <ul><li>Provides coding assistance, navigation and search for CFML files</li>
-    <li>Helps to deploy applications to the ColdFusion server with a dedicated run/debug configuration</li></ul>
+    <li>Helps to deploy applications to the ColdFusion server with a dedicated run configuration</li></ul>
 
 Requires the <a href="http://www.adobe.com/products/coldfusion-family.html">ColdFusion server</a> and configured path mapping between local folders with your application and corresponding directories on the server.
 To configure path mappings, open the <b>Settings / Preferences</b> dialog and select <b>Languages & Frameworks | ColdFusion</b>.


### PR DESCRIPTION
The CFML plugin doesn't provide debugging support but the documentation claims it does. Remove the claim to prevent confusion.