### PR TITLE
Dart: View record fields in the debugger

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/frame/DartVmServiceValue.java
@@ -474,11 +474,29 @@ public class DartVmServiceValue extends XNamedValue {
     }
 
     final XValueChildrenList childrenList = new XValueChildrenList(fields.size());
-    for (BoundField field : fields) {
-      final InstanceRef value = field.getValue();
-      if (value != null) {
-        childrenList
-          .add(new DartVmServiceValue(myDebugProcess, myIsolateId, field.getDecl().getName(), value, null, field.getDecl(), false));
+    if (getInstanceRef().getKind() == InstanceKind.Record) {
+      for (BoundField field : fields) {
+        assert field != null;
+        Object name = field.getName();
+        InstanceRef value = field.getValue();
+        if (name != null && value != null) {
+          final String n;
+          if (name instanceof String) {
+            n = (String)name;
+          } else {
+            n = "$" + (int)name;
+          }
+          childrenList.add(new DartVmServiceValue(myDebugProcess, myIsolateId, n, value, null, null, false));
+        }
+      }
+    }
+    else {
+      for (BoundField field : fields) {
+        final InstanceRef value = field.getValue();
+        if (value != null) {
+          childrenList
+            .add(new DartVmServiceValue(myDebugProcess, myIsolateId, field.getDecl().getName(), value, null, field.getDecl(), false));
+        }
       }
     }
     node.addChildren(childrenList, true);


### PR DESCRIPTION
This depends on #886.

Debugging some Dart code from the records spec:
<img width="1394" alt="Screenshot 2023-03-09 at 1 38 33 PM" src="https://user-images.githubusercontent.com/8518285/224166675-b12a8674-3d8b-41c2-a86a-b7acba2e0862.png">

I see the indexes have been fixed to start at one rather than zero, which is good.

@alexander-doroshko 

Fixes https://github.com/flutter/flutter-intellij/issues/6652