### PR TITLE
[prisma] WEB-60716: Add support for JSON protocol preview feature

### DIFF
--- a/prisma/src/org/intellij/prisma/ide/schema/types/PrismaPreviewFeature.kt
+++ b/prisma/src/org/intellij/prisma/ide/schema/types/PrismaPreviewFeature.kt
@@ -16,7 +16,8 @@ enum class PrismaPreviewFeature {
   ExtendedWhereUnique,
   ClientExtensions,
   MultiSchema,
-  Views;
+  Views,
+  JsonProtocol;
 
   val presentation: String = StringUtil.decapitalize(name)
 }


### PR DESCRIPTION
Adds support for the new JSON protocol preview feature, added in Prisma v4.11.0.

Refs:
https://github.com/prisma/prisma/issues/18095
https://github.com/prisma/prisma/releases/tag/4.11.0

Fixes [WEB-60716](https://youtrack.jetbrains.com/issue/WEB-60716)

