### PR TITLE
Remove use of Guava types from PbFile and related APIs.

### DIFF
--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbFile.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbFile.java
@@ -15,14 +15,14 @@
  */
 package com.intellij.protobuf.lang.psi;
 
-import com.google.common.collect.ImmutableMultimap;
 import com.intellij.psi.impl.PsiFileEx;
 import com.intellij.psi.impl.source.PsiFileWithStubSupport;
 import com.intellij.psi.util.QualifiedName;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 /** A protobuf file. */
 public interface PbFile
@@ -67,7 +67,7 @@ public interface PbFile
    * @return A map containing the package's children.
    */
   @NotNull
-  ImmutableMultimap<String, PbSymbol> getPackageSymbolMap(QualifiedName packageName);
+  Map<String, Collection<PbSymbol>> getPackageSymbolMap(QualifiedName packageName);
 
   /**
    * Returns a map of all fully-qualified symbols defined in this file.
@@ -78,7 +78,7 @@ public interface PbFile
    * for "com", "com.foo", "com.foo.bar", and "com.foo.bar.MyMessage".
    */
   @NotNull
-  ImmutableMultimap<QualifiedName, PbSymbol> getLocalQualifiedSymbolMap();
+  Map<QualifiedName, Collection<PbSymbol>> getLocalQualifiedSymbolMap();
 
   /**
    * Returns a map of all fully-qualified symbols exported when this file is imported.
@@ -93,7 +93,7 @@ public interface PbFile
    * @see #getLocalQualifiedSymbolMap()
    */
   @NotNull
-  ImmutableMultimap<QualifiedName, PbSymbol> getExportedQualifiedSymbolMap();
+  Map<QualifiedName, Collection<PbSymbol>> getExportedQualifiedSymbolMap();
 
   /**
    * Returns a map of all fully-qualified symbols defined in this and imported files.
@@ -108,7 +108,7 @@ public interface PbFile
    * @see #getLocalQualifiedSymbolMap()
    */
   @NotNull
-  ImmutableMultimap<QualifiedName, PbSymbol> getFullQualifiedSymbolMap();
+  Map<QualifiedName, Collection<PbSymbol>> getFullQualifiedSymbolMap();
 
   /**
    * Returns the {@link PbSymbolOwner} that owns the elements defined in this file. This is either

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbSymbolOwner.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbSymbolOwner.java
@@ -17,6 +17,7 @@ package com.intellij.protobuf.lang.psi;
 
 import com.google.common.collect.Multimap;
 import com.intellij.psi.util.QualifiedName;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,11 +44,11 @@ public interface PbSymbolOwner extends PbElement {
    * #getChildScope()}.
    */
   @NotNull
-  Multimap<String, PbSymbol> getSymbolMap();
+  Map<String, Collection<PbSymbol>> getSymbolMap();
 
   @NotNull
   default Collection<PbSymbol> getSymbols() {
-    return getSymbolMap().values();
+    return getSymbolMap().values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
   }
 
   @NotNull

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbPackageNameMixin.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbPackageNameMixin.java
@@ -28,6 +28,8 @@ import com.intellij.protobuf.lang.psi.PbSymbol;
 import com.intellij.protobuf.lang.psi.PbSymbolOwner;
 import com.intellij.protobuf.lang.psi.ProtoTokenTypes;
 import com.intellij.protobuf.lang.psi.util.PbPsiImplUtil;
+import java.util.Collection;
+import java.util.Map;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -96,7 +98,7 @@ abstract class PbPackageNameMixin extends PbElementBase implements PbPackageName
 
   @NotNull
   @Override
-  public Multimap<String, PbSymbol> getSymbolMap() {
+  public Map<String, Collection<PbSymbol>> getSymbolMap() {
     return getPbFile().getPackageSymbolMap(getQualifiedName());
   }
 

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbStubbedSymbolOwnerBase.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbStubbedSymbolOwnerBase.java
@@ -26,6 +26,8 @@ import com.intellij.protobuf.lang.psi.PbSymbol;
 import com.intellij.protobuf.lang.psi.PbSymbolOwner;
 import com.intellij.protobuf.lang.psi.util.PbPsiImplUtil;
 import com.intellij.protobuf.lang.stub.PbNamedElementStub;
+import java.util.Collection;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -48,7 +50,7 @@ abstract class PbStubbedSymbolOwnerBase<T extends PbNamedElementStub<?>>
 
   @NotNull
   @Override
-  public Multimap<String, PbSymbol> getSymbolMap() {
+  public Map<String, Collection<PbSymbol>> getSymbolMap() {
     return PbPsiImplUtil.getCachedSymbolMap(this);
   }
 

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/util/PbPsiImplUtil.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/util/PbPsiImplUtil.java
@@ -25,6 +25,8 @@ import com.intellij.psi.util.CachedValueProvider.Result;
 import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.QualifiedName;
+import java.util.Collection;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -110,13 +112,14 @@ public final class PbPsiImplUtil {
     return TextRange.create(start, end);
   }
 
-  public static ImmutableMultimap<String, PbSymbol> getCachedSymbolMap(PbStatementOwner owner) {
+  public static Map<String, Collection<PbSymbol>> getCachedSymbolMap(PbStatementOwner owner) {
     return CachedValuesManager.getCachedValue(
         owner,
         () ->
             Result.create(
                 computeSymbolMap(owner, PbSymbol.class),
-                PbCompositeModificationTracker.byElement(owner)));
+                PbCompositeModificationTracker.byElement(owner)))
+        .asMap();
   }
 
   public static ImmutableMultimap<String, PbEnumValue> getCachedEnumValueMap(

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/resolve/PbSymbolResolver.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/resolve/PbSymbolResolver.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.protobuf.lang.resolve;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
@@ -30,6 +31,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.compress.utils.Lists;
+import org.assertj.core.util.Sets;
 
 /** Utilities for finding PbSymbol elements using protobuf's scoping and resolution rules. */
 public class PbSymbolResolver {
@@ -42,19 +45,21 @@ public class PbSymbolResolver {
 
   /** Returns a PbSymbolResolver that can resolve symbols in the given file and its imports. */
   public static PbSymbolResolver forFile(PbFile file) {
-    return new PbSymbolResolver(file.getFullQualifiedSymbolMap());
+    return new PbSymbolResolver(
+        Multimaps.newSetMultimap(file.getExportedQualifiedSymbolMap(), Sets::newHashSet));
   }
 
   /** Returns a PbSymbolResolver that can resolve symbols exported by the given file. */
   public static PbSymbolResolver forFileExports(PbFile file) {
-    return new PbSymbolResolver(file.getExportedQualifiedSymbolMap());
+    return new PbSymbolResolver(
+        Multimaps.newSetMultimap(file.getExportedQualifiedSymbolMap(), Sets::newHashSet));
   }
 
   /** Returns a PbSymbolResolver that can resolve symbols exported by the given files. */
   public static PbSymbolResolver forFileExports(List<PbFile> files) {
     ImmutableSetMultimap.Builder<QualifiedName, PbSymbol> builder = ImmutableSetMultimap.builder();
     for (PbFile file : files) {
-      builder.putAll(file.getExportedQualifiedSymbolMap());
+      file.getExportedQualifiedSymbolMap().forEach(builder::putAll);
     }
     return new PbSymbolResolver(builder.build());
   }

--- a/protobuf/protoeditor-jvm/src/com/intellij/protobuf/jvm/names/Proto2DefinitionClassNames.java
+++ b/protobuf/protoeditor-jvm/src/com/intellij/protobuf/jvm/names/Proto2DefinitionClassNames.java
@@ -22,6 +22,7 @@ import com.intellij.protobuf.lang.psi.*;
 import com.intellij.protobuf.lang.psi.util.PbPsiUtil;
 import com.intellij.psi.util.QualifiedName;
 import com.intellij.util.containers.ContainerUtil;
+import java.util.Map;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -80,7 +81,11 @@ public class Proto2DefinitionClassNames {
     // Top level enums and messages (not nested ones).
     // Presence of services depends on the option java_generic_services or plugins.
     // We don't attempt to index services for now.
-    for (PbSymbol symbol : file.getPackageSymbolMap(protoPackage).values()) {
+    for (PbSymbol symbol : file.getPackageSymbolMap(protoPackage)
+        .values()
+        .stream()
+        .flatMap(Collection::stream)
+        .toList()) {
       if (PbPsiUtil.isMessageElement(symbol)) {
         results.addAll(nameGenerator.messageClassNames((PbMessageType) symbol));
       } else if (PbPsiUtil.isEnumElement(symbol)) {
@@ -147,7 +152,7 @@ public class Proto2DefinitionClassNames {
   // See: https://github.com/google/protobuf/blob/3.2.x/src/google/protobuf/compiler/java/java_name_resolver.cc#L131
   // Sadly, this includes nested type names.
   private static boolean fileHasConflictingOuterClassName(PbFile file, String outerClassName) {
-    Multimap<String, PbSymbol> packageSymbolMap =
+    Map<String, Collection<PbSymbol>> packageSymbolMap =
         file.getPackageSymbolMap(file.getPackageQualifiedName());
     if (packageSymbolMap.containsKey(outerClassName)) {
       return true;
@@ -156,6 +161,7 @@ public class Proto2DefinitionClassNames {
         packageSymbolMap
             .values()
             .stream()
+            .flatMap(Collection::stream)
             .filter(PbMessageType.class::isInstance)
             .map(PbMessageType.class::cast)
             .toList();
@@ -169,7 +175,7 @@ public class Proto2DefinitionClassNames {
 
   private static boolean messageHasConflictingOuterClassName(
       PbMessageType message, String outerClassName) {
-    Multimap<String, PbSymbol> symbolMap = message.getSymbolMap();
+    Map<String, Collection<PbSymbol>> symbolMap = message.getSymbolMap();
     Collection<PbSymbol> matches = symbolMap.get(outerClassName);
     if (ContainerUtil.exists(matches, PbNamedTypeElement.class::isInstance)) {
       return true;

--- a/protobuf/protoeditor-python/src/com/intellij/protobuf/python/PbPythonGotoDeclarationHandler.java
+++ b/protobuf/protoeditor-python/src/com/intellij/protobuf/python/PbPythonGotoDeclarationHandler.java
@@ -15,9 +15,10 @@
  */
 package com.intellij.protobuf.python;
 
+import static java.util.stream.Collectors.toList;
+
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.protobuf.lang.psi.PbElement;
@@ -28,13 +29,11 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.QualifiedName;
 import com.jetbrains.python.PythonLanguage;
 import com.jetbrains.python.psi.PyFile;
-import org.jetbrains.annotations.Nullable;
-
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.stream.Collectors.toList;
+import org.jetbrains.annotations.Nullable;
 
 /** Handles goto declaration from python generated code -> .proto files. */
 public final class PbPythonGotoDeclarationHandler implements GotoDeclarationHandler {
@@ -94,7 +93,7 @@ public final class PbPythonGotoDeclarationHandler implements GotoDeclarationHand
       return ImmutableList.of(pbFile);
     }
     QualifiedName qualifiedName = pbFile.getPackageQualifiedName().append(fileLocalSymbol);
-    Multimap<QualifiedName, PbSymbol> fileSymbols = pbFile.getLocalQualifiedSymbolMap();
+    Map<QualifiedName, Collection<PbSymbol>> fileSymbols = pbFile.getLocalQualifiedSymbolMap();
     return ImmutableList.copyOf(fileSymbols.get(qualifiedName));
   }
 
@@ -108,12 +107,15 @@ public final class PbPythonGotoDeclarationHandler implements GotoDeclarationHand
       return ImmutableList.of();
     }
     String desiredSymbol = fileLocalSymbol.replace('.', '_');
-    Multimap<QualifiedName, PbSymbol> fileSymbols = pbFile.getLocalQualifiedSymbolMap();
+    Map<QualifiedName, Collection<PbSymbol>> fileSymbols = pbFile.getLocalQualifiedSymbolMap();
     int numPackageComponents = pbFile.getPackageQualifiedName().getComponentCount();
     List<PbSymbol> matches =
         fileSymbols
-            .entries()
+            .entrySet()
             .stream()
+            .flatMap(e -> e.getValue()
+                .stream()
+                .map(v -> new AbstractMap.SimpleEntry<>(e.getKey(), v)))
             .filter(
                 entry -> {
                   QualifiedName qualifiedName = entry.getKey();


### PR DESCRIPTION
This API can (and is) used from other plugins. Since each plugin can bundle their own version of guava, using a guava type in the return value is unsafe and results in LinkageErrors at runtime.

Switch to Map<X, Collection<Y>> in place of MultiMap<X, Y> and update related code accordingly to avoid such issues.