### PR TITLE
[flex] Fix for ANE extraction on MacOS https://github.com/airsdk/Adob…

### DIFF
--- a/flex/src/com/intellij/lang/javascript/flex/build/FlexCompilationUtils.java
+++ b/flex/src/com/intellij/lang/javascript/flex/build/FlexCompilationUtils.java
@@ -23,7 +23,7 @@ import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ArrayUtilRt;
 import com.intellij.util.containers.ContainerUtil;
-import com.intellij.util.io.ZipUtil;
+import com.intellij.util.io.Decompressor;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -114,7 +114,7 @@ public final class FlexCompilationUtils {
       }
 
       try {
-        ZipUtil.extract(new File(file.getPath()), subDir, null, true);
+        new Decompressor.Zip(new File(file.getPath())).withZipExtensions().overwrite(true).extract(subDir);
       }
       catch (IOException e) {
         Logger.getLogger(FlexCompilationUtils.class.getName()).warning("Failed to unzip " + file.getPath() + " to " + baseDir.getPath());


### PR DESCRIPTION
See discussion https://github.com/airsdk/Adobe-Runtime-Support/discussions/2581

Changes to Apple's Framework validation no longer allow AIR SDK ANE classes expanded by the Flex Plugin for IntelliJ to be considered valid. This is due to the existing code not respecting symlinks within the ANE (zip) file and creating them as standard directories, which is now considered invalid by Apple on later MacOS environments.

The change is straight forward, however I have been unable to get the development environment working following the instructions here https://github.com/JetBrains/intellij-plugins/blob/master/flex/readme.txt using IntelliJ 2023.1.5