### PR TITLE
Fix contract in AngularJS plugin.

### DIFF
--- a/AngularJS/src/org/angular2/entities/ivy/Angular2IvySymbolDef.kt
+++ b/AngularJS/src/org/angular2/entities/ivy/Angular2IvySymbolDef.kt
@@ -281,7 +281,7 @@ abstract class Angular2IvySymbolDef private constructor(private val myFieldOrStu
                                                              itemMapper: (T) -> R?,
                                                              nullIfNotFound: Boolean): List<R>? {
     contract {
-      returnsNotNull() implies (!nullIfNotFound)
+      returns(null) implies (nullIfNotFound)
     }
     val declaration = getDefFieldArgument(index)
                       ?: return if (nullIfNotFound) null else emptyList()


### PR DESCRIPTION
The contract for `processTupleArgument` is meant to say that the function will not return a non-null value if `nullIfNotFound = false`. However, the old contract said the opposite: that if the function returned a non-null value, then `nullIfNotFound = false`, which is not true (if the value is found, `nullIfNotFound` plays no role).

At the moment, the compiler cannot use either contract meaningfully so the difference is immaterial.  If https://youtrack.jetbrains.com/issue/KT-63378/Support-or-prohibit-contracts-that-use-Boolean-parameters-on-the-right-of-an-implies is resolved and support for this is added, the new contract will allow the call-sites that pass `nullIfNotFound = false` to perform a smart cast to `List<R>` instead of having to use `!!`.