### PR TITLE
[error prone] update error prone to 2.23.0 and fix dependencies

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
-  <artifact version="2.18.0" name="error-prone">
-    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.18.0/error_prone_core-2.18.0-with-dependencies.jar"/>
-    <item url="https://repo1.maven.org/maven2/org/checkerframework/dataflow-errorprone/3.27.0/dataflow-errorprone-3.27.0.jar"/>
+  <artifact version="2.23.0" name="error-prone">
+    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.23.0/error_prone_core-2.23.0-with-dependencies.jar"/>
+    <item url="https://repo1.maven.org/maven2/io/github/eisop/checker-qual/3.34.0-eisop1/checker-qual-3.34.0-eisop1.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
One thing to point out, now in Error Prone the `3.34.0-eisop1` is used instead of `3.34.0`, see here:
https://github.com/google/error-prone/blob/v2.23.0/pom.xml#L38C23-L38C36.

This means it is now a slightly different artifact, which is reflected in the changes.