### PR TITLE
First Dart Macro change

### DIFF
--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/DartLSPTextDocumentContentConsumer.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/DartLSPTextDocumentContentConsumer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server;
+
+import org.dartlang.analysis.server.protocol.RequestError;
+
+public interface DartLSPTextDocumentContentConsumer extends Consumer {
+
+  public void computedDocumentContents(String contents);
+
+  /**
+   * If the file contents can't be sent back, some {@link RequestError} is passed back instead.
+   *
+   * @param requestError the reason why a result was not passed back
+   */
+  public void onError(RequestError requestError);
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -606,6 +606,14 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     stopServer();
   }
 
+  //
+  // LSP over Legacy Dart Analysis Server protocol
+  //
+  public void lspMessage_dart_textDocumentContent(String uri, DartLSPTextDocumentContentConsumer consumer) {
+    String id = generateUniqueId();
+    sendRequestToServer(id, RequestUtilities.generateLSPMessage_dart_textDocumentContent(id, uri), consumer);
+  }
+
   /**
    * Starts the analysis server.
    *
@@ -928,6 +936,12 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     }
     else if (consumer instanceof JsonConsumer) {
       ((JsonConsumer)consumer).onResponse(resultObject, requestError);
+    }
+    //
+    // LSP over Legacy DAS Dart Analysis Server protocol
+    //
+    else if (consumer instanceof DartLSPTextDocumentContentConsumer) {
+      new LSPDartTextDocumentContentProcessor((DartLSPTextDocumentContentConsumer)consumer).process(resultObject, requestError);
     }
 
     synchronized (consumerMapLock) {

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/LSPDartTextDocumentContentProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/LSPDartTextDocumentContentProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.DartLSPTextDocumentContentConsumer;
+import com.google.gson.JsonObject;
+
+import org.dartlang.analysis.server.protocol.RequestError;
+
+/**
+ * Instances of {@code LSPDartTextDocumentContentProcessor} translate JSON result objects for a given
+ * {@link LSPDartTextDocumentContentConsumer}.
+ *
+ * @coverage dart.server.remote
+ */
+public class LSPDartTextDocumentContentProcessor extends ResultProcessor {
+
+  private final DartLSPTextDocumentContentConsumer consumer;
+
+  public LSPDartTextDocumentContentProcessor(DartLSPTextDocumentContentConsumer consumer) {
+    this.consumer = consumer;
+  }
+
+  public void process(JsonObject resultObject, RequestError requestError) {
+    if (resultObject != null) {
+      // Example: {"lspResponse":{"id":"1","jsonrpc":"2.0","result":{"content":"file contents"}}}
+      JsonObject lspResponse = resultObject.getAsJsonObject("lspResponse");
+      JsonObject innerResultObject = lspResponse.getAsJsonObject("result");
+      final String contents = innerResultObject.get("content").getAsString();
+      consumer.computedDocumentContents(contents);
+    }
+    if (requestError != null) {
+      consumer.onError(requestError);
+    }
+  }
+}

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -1199,6 +1199,46 @@ public class RequestUtilities {
     return null;
   }
 
+  //
+  // LSP over Legacy DAS (Dart Analysis Server) protocol below
+  //
+  public static final String LSP_DART_TEXT_DOCUMENT_CONTENT = "dart/textDocumentContent";
+
+  private static final String LSP_HANDLE = "lsp.handle";
+
+  public static final String LSP_JSONRPC = "jsonrpc";
+
+  public static final String LSP_JSONROC_VERSION = "2.0";
+
+  public static final String LSP_MESSAGE = "lspMessage";
+
+  /**
+   * Generate and return a LSP over Legacy DAS request.
+   *
+   * Example:
+   * {"id":"2","method":"lsp.handle","params":
+   *   {"lspMessage":
+   *     {"id":0,"jsonrpc":"2.0","method":"dart/textDocumentContent","params":
+   *       {"position":{"character":7,"line":1},
+   *        "textDocument":{"uri":"some-uri"}}}}}
+   */
+  private static JsonObject generateLSPMessage(String idValue, String lspMethod, JsonObject lspParams) {
+    JsonObject lspMessageParams = new JsonObject();
+    lspMessageParams.addProperty(ID, idValue);
+    lspMessageParams.addProperty(LSP_JSONRPC, LSP_JSONROC_VERSION);
+    lspMessageParams.addProperty(METHOD, lspMethod);
+    lspMessageParams.add(PARAMS, lspParams);
+    JsonObject lspMessage = new JsonObject();
+    lspMessage.add(LSP_MESSAGE, lspMessageParams);
+    return buildJsonObjectRequest(idValue, LSP_HANDLE, lspMessage);
+  }
+
+  public static JsonObject generateLSPMessage_dart_textDocumentContent(String idValue, String uri) {
+    JsonObject lspParams = new JsonObject();
+    lspParams.addProperty("uri", uri);
+    return generateLSPMessage(idValue, LSP_DART_TEXT_DOCUMENT_CONTENT, lspParams);
+  }
+
   private RequestUtilities() {
   }
 }


### PR DESCRIPTION
Addition of the (currently unused) `DartAnalysisServerService.lspMessage_dart_textDocumentContent(..)`, with the associated consumer and processor patterns for communication with the Dart SDK (Dart Analysis Server)

https://github.com/dart-lang/language/issues/1482
https://dart-review.googlesource.com/c/sdk/+/345420
https://dart-review.googlesource.com/c/sdk/+/347023
