### PR TITLE
Dart Macros lang feature: start to map absolute paths to uri paths, work started on navigation targets

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/resolve/DartResolver.java
+++ b/Dart/src/com/jetbrains/lang/dart/resolve/DartResolver.java
@@ -1,19 +1,23 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.lang.dart.resolve;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiManager;
-import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.*;
+import com.intellij.psi.impl.PsiFileFactoryImpl;
+import com.intellij.psi.impl.source.LightPsiFileImpl;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.ObjectUtils;
 import com.intellij.util.Processor;
 import com.intellij.util.SmartList;
+import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.DartLanguage;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.analyzer.DartServerData;
 import com.jetbrains.lang.dart.analyzer.DartServerData.DartNavigationRegion;
@@ -118,7 +122,7 @@ public class DartResolver implements ResolveCache.AbstractResolver<DartReference
 
   @Nullable
   public static PsiFile findPsiFile(@NotNull Project project, @NotNull String path) {
-    VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(path);
+    VirtualFile virtualFile = DartAnalysisServerService.getInstance(project).getVirtualFileFromURI(path);
     if (virtualFile != null) {
       return PsiManager.getInstance(project).findFile(virtualFile);
     }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListener.java
@@ -222,4 +222,6 @@ public interface AnalysisServerListener {
    * @param existingImports a map from imported library uri onto the names declared by the imported library.
    */
   void computedExistingImports(String file, Map<String, Map<String, Set<String>>> existingImports);
+
+  public void lspTextDocumentContentDidChange(String url);
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/AnalysisServerListenerAdapter.java
@@ -116,4 +116,9 @@ public class AnalysisServerListenerAdapter implements AnalysisServerListener {
   @Override
   public void computedExistingImports(String file, Map<String, Map<String, Set<String>>> existingImports) {
   }
+
+  @Override
+  public void lspTextDocumentContentDidChange(String url) {
+  }
+
 }

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/BroadcastAnalysisServerListener.java
@@ -220,6 +220,13 @@ public class BroadcastAnalysisServerListener implements AnalysisServerListener {
     }
   }
 
+  @Override
+  public void lspTextDocumentContentDidChange(String url) {
+    for (AnalysisServerListener listener : getListeners()) {
+      listener.lspTextDocumentContentDidChange(url);
+    }
+  }
+
   /**
    * Returns an immutable copy of {@link #listeners}.
    */

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -30,6 +30,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import org.dartlang.analysis.server.protocol.*;
 import org.osgi.framework.Version;
 
@@ -85,6 +86,10 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
 
   // Execution domain
   private static final String LAUNCH_DATA_NOTIFICATION_RESULTS = "execution.launchData";
+
+  // LSP
+  public static final String LSP_NOTIFICATION= "lsp.notification";
+
   private final AnalysisServerSocket socket;
   private final Object requestSinkLock = new Object();
   private RequestSink requestSink;
@@ -585,7 +590,7 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     if (requests == null) {
       requests = StringUtilities.EMPTY_LIST;
     }
-    sendRequestToServer(id, RequestUtilities.generateClientCapabilities(id, requests));
+    sendRequestToServer(id, RequestUtilities.generateClientCapabilities(id, requests, DartAnalysisServerService.ENABLE_MACROS));
   }
 
   @Override
@@ -727,6 +732,10 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     }
     else if (event.equals(LAUNCH_DATA_NOTIFICATION_RESULTS)) {
       new NotificationExecutionLaunchDataProcessor(listener).process(response);
+    }
+    else if(event.equals(LSP_NOTIFICATION)) {
+      // lsp.notification
+      new NotificationLspProcessor(listener).process(response);
     }
     // it is a notification, even if we did not handle it
     return true;

--- a/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationLspProcessor.java
+++ b/Dart/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/processor/NotificationLspProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, the Dart project authors.
+ * 
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.dart.server.internal.remote.processor;
+
+import com.google.dart.server.AnalysisServerListener;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Processor for "lsp.notification" notification.
+ * 
+ * @coverage dart.server.remote
+ */
+public class NotificationLspProcessor extends NotificationProcessor {
+
+  public NotificationLspProcessor(AnalysisServerListener listener) {
+    super(listener);
+  }
+
+  @Override
+  public void process(JsonObject response) throws Exception {
+    //  Example:
+    // {"event"::"lsp.notification","params"::
+    //   {"lspNotification"::
+    //     {"jsonrpc"::"2.0","method"::"dart/textDocumentContentDidChange","params"::
+    //       {"uri"::"dart-macro+file::///some/path/lib/test.dart"}}}}
+    JsonObject paramsObject = response.getAsJsonObject("params");
+    if(paramsObject == null) {
+      return;
+    }
+
+    JsonObject lspNotificationObject = paramsObject.getAsJsonObject("lspNotification");
+    if(lspNotificationObject == null) {
+      return;
+    }
+
+    JsonElement methodElement = lspNotificationObject.get("method");
+    if (methodElement != null && methodElement.getAsString().equals("dart/textDocumentContentDidChange")) {
+      JsonObject innerParamsObject = lspNotificationObject.getAsJsonObject("params");
+      if (innerParamsObject != null && innerParamsObject.get("uri").getAsString() != null) {
+        getListener().lspTextDocumentContentDidChange(innerParamsObject.get("uri").getAsString());
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `lsp.notification`, as well as caching of the macro generated, in-memory files, is added as well in this change

@alexander-doroshko 