### PR TITLE
feat: update Prisma LSP to 5.9.1

### DIFF
--- a/prisma/language-server/package-lock.json
+++ b/prisma/language-server/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "prisma-language-server",
       "dependencies": {
-        "@prisma/language-server": "^5.5.0",
-        "@prisma/prisma-schema-wasm": "^5.6.0-1.de2449110135e91857b477c346b7f74d52d61613"
+        "@prisma/language-server": "^5.9.1",
+        "@prisma/prisma-schema-wasm": "^5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^11.0.0",
@@ -443,12 +443,12 @@
       }
     },
     "node_modules/@prisma/language-server": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-5.5.0.tgz",
-      "integrity": "sha512-xcC9s7xXBmbrYa+YnJWb4qCsXxjXNeTG0rOEIL7ZKOX8u4VMllZbLJy2k8AXK1UW294hSSZ1RI7KQYyTk66Iaw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-5.9.1.tgz",
+      "integrity": "sha512-T6wq87g0l5jTSMTLKHkJG0tJ7Cv7nY9bX97QunaSKLQ6/2HefSYI+7w713/RDtGft1BADookWt4uLtjVGPV7YQ==",
       "dependencies": {
-        "@prisma/prisma-schema-wasm": "5.5.0-19.475c616176945d72f4330c92801f0c5e6398dc0f",
-        "@types/js-levenshtein": "1.1.2",
+        "@prisma/prisma-schema-wasm": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
+        "@types/js-levenshtein": "1.1.3",
         "js-levenshtein": "1.1.6",
         "klona": "2.0.6",
         "nyc": "15.1.0",
@@ -462,15 +462,10 @@
         "node": ">=14"
       }
     },
-    "node_modules/@prisma/language-server/node_modules/@prisma/prisma-schema-wasm": {
-      "version": "5.5.0-19.475c616176945d72f4330c92801f0c5e6398dc0f",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.5.0-19.475c616176945d72f4330c92801f0c5e6398dc0f.tgz",
-      "integrity": "sha512-EgOH4p5g7XdeKFz9vT/IcnG/B01FpWK+3JVC29OMkfVIoTpeVelM4wsTYaBF+jNFKZwDjU1oTHgiHpiaNSfUng=="
-    },
     "node_modules/@prisma/prisma-schema-wasm": {
-      "version": "5.6.0-1.de2449110135e91857b477c346b7f74d52d61613",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.6.0-1.de2449110135e91857b477c346b7f74d52d61613.tgz",
-      "integrity": "sha512-DJp1ZTK5b0DLEIGJGh6K5DVR+uZNrUaSuMBcAdhJ2BrrJs+N9czfgCyGBCA11KQHtriTJDNzGasll1DgNwcpKQ=="
+      "version": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64.tgz",
+      "integrity": "sha512-IuqMy9uI6bax2TiKPfwEOdAsdG8g0+F+1JD28ugUL4q40Q2iLHBgqUgyavSev1z/TUIA/cYJm3ObEUWz9pNnBQ=="
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
@@ -499,9 +494,9 @@
       "dev": true
     },
     "node_modules/@types/js-levenshtein": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.2.tgz",
-      "integrity": "sha512-/NCbMABw2uacuyE16Iwka1EzREDD50/W2ggRBad0y1WHBvAkvR9OEINxModVY7D428gXBe0igeVX7bUc9GaslQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
+      "integrity": "sha512-jd+Q+sD20Qfu9e2aEXogiO3vpOC1PYJOUdyN9gvs4Qrvkg4wF43L5OhqrPeokdv8TL0/mXoYfpkcoGZMNN2pkQ=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -3592,30 +3587,23 @@
       }
     },
     "@prisma/language-server": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-5.5.0.tgz",
-      "integrity": "sha512-xcC9s7xXBmbrYa+YnJWb4qCsXxjXNeTG0rOEIL7ZKOX8u4VMllZbLJy2k8AXK1UW294hSSZ1RI7KQYyTk66Iaw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-5.9.1.tgz",
+      "integrity": "sha512-T6wq87g0l5jTSMTLKHkJG0tJ7Cv7nY9bX97QunaSKLQ6/2HefSYI+7w713/RDtGft1BADookWt4uLtjVGPV7YQ==",
       "requires": {
-        "@prisma/prisma-schema-wasm": "5.5.0-19.475c616176945d72f4330c92801f0c5e6398dc0f",
-        "@types/js-levenshtein": "1.1.2",
+        "@prisma/prisma-schema-wasm": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
+        "@types/js-levenshtein": "1.1.3",
         "js-levenshtein": "1.1.6",
         "klona": "2.0.6",
         "nyc": "15.1.0",
         "vscode-languageserver": "8.1.0",
         "vscode-languageserver-textdocument": "1.0.11"
-      },
-      "dependencies": {
-        "@prisma/prisma-schema-wasm": {
-          "version": "5.5.0-19.475c616176945d72f4330c92801f0c5e6398dc0f",
-          "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.5.0-19.475c616176945d72f4330c92801f0c5e6398dc0f.tgz",
-          "integrity": "sha512-EgOH4p5g7XdeKFz9vT/IcnG/B01FpWK+3JVC29OMkfVIoTpeVelM4wsTYaBF+jNFKZwDjU1oTHgiHpiaNSfUng=="
-        }
       }
     },
     "@prisma/prisma-schema-wasm": {
-      "version": "5.6.0-1.de2449110135e91857b477c346b7f74d52d61613",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.6.0-1.de2449110135e91857b477c346b7f74d52d61613.tgz",
-      "integrity": "sha512-DJp1ZTK5b0DLEIGJGh6K5DVR+uZNrUaSuMBcAdhJ2BrrJs+N9czfgCyGBCA11KQHtriTJDNzGasll1DgNwcpKQ=="
+      "version": "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64.tgz",
+      "integrity": "sha512-IuqMy9uI6bax2TiKPfwEOdAsdG8g0+F+1JD28ugUL4q40Q2iLHBgqUgyavSev1z/TUIA/cYJm3ObEUWz9pNnBQ=="
     },
     "@types/eslint": {
       "version": "8.4.6",
@@ -3644,9 +3632,9 @@
       "dev": true
     },
     "@types/js-levenshtein": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.2.tgz",
-      "integrity": "sha512-/NCbMABw2uacuyE16Iwka1EzREDD50/W2ggRBad0y1WHBvAkvR9OEINxModVY7D428gXBe0igeVX7bUc9GaslQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
+      "integrity": "sha512-jd+Q+sD20Qfu9e2aEXogiO3vpOC1PYJOUdyN9gvs4Qrvkg4wF43L5OhqrPeokdv8TL0/mXoYfpkcoGZMNN2pkQ=="
     },
     "@types/json-schema": {
       "version": "7.0.11",

--- a/prisma/language-server/package.json
+++ b/prisma/language-server/package.json
@@ -4,8 +4,8 @@
     "prisma:lsp": "cross-env NODE_ENV=production webpack --config webpack.config.js"
   },
   "dependencies": {
-    "@prisma/language-server": "^5.5.0",
-    "@prisma/prisma-schema-wasm": "^5.6.0-1.de2449110135e91857b477c346b7f74d52d61613"
+    "@prisma/language-server": "^5.9.1",
+    "@prisma/prisma-schema-wasm": "^5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
   },
   "devDependencies": {
     "webpack": "^5.74.0",


### PR DESCRIPTION
Hello from Prisma 👋🏼 

I used the version for `@prisma/prisma-schema-wasm` from https://www.npmjs.com/package/@prisma/language-server?activeTab=code

Because the current version is outdated, see https://github.com/prisma/prisma/discussions/22288#discussioncomment-8384907