### PR TITLE
Add basic editions support to intellij protobuf plugin.

### DIFF
--- a/protobuf/protoeditor-core/resources/include/google/protobuf/descriptor.proto
+++ b/protobuf/protoeditor-core/resources/include/google/protobuf/descriptor.proto
@@ -41,7 +41,7 @@ syntax = "proto2";
 
 package google.protobuf;
 
-option go_package = "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor";
+option go_package = "google.golang.org/protobuf/types/descriptorpb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DescriptorProtos";
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -56,6 +56,38 @@ option optimize_for = SPEED;
 // files it parses.
 message FileDescriptorSet {
   repeated FileDescriptorProto file = 1;
+}
+
+// The full set of known editions.
+enum Edition {
+  // A placeholder for an unknown edition value.
+  EDITION_UNKNOWN = 0;
+
+  // Legacy syntax "editions".  These pre-date editions, but behave much like
+  // distinct editions.  These can't be used to specify the edition of proto
+  // files, but feature definitions must supply proto2/proto3 defaults for
+  // backwards compatibility.
+  EDITION_PROTO2 = 998;
+  EDITION_PROTO3 = 999;
+
+  // Editions that have been released.  The specific values are arbitrary and
+  // should not be depended on, but they will always be time-ordered for easy
+  // comparison.
+  EDITION_2023 = 1000;
+  EDITION_2024 = 1001;
+
+  // Placeholder editions for testing feature resolution.  These should not be
+  // used or relyed on outside of tests.
+  EDITION_1_TEST_ONLY = 1;
+  EDITION_2_TEST_ONLY = 2;
+  EDITION_99997_TEST_ONLY = 99997;
+  EDITION_99998_TEST_ONLY = 99998;
+  EDITION_99999_TEST_ONLY = 99999;
+
+  // Placeholder for specifying unbounded edition support.  This should only
+  // ever be used by plugins that can expect to never require any changes to
+  // support a new edition.
+  EDITION_MAX = 0x7FFFFFFF;
 }
 
 // Describes a complete .proto file.
@@ -86,8 +118,13 @@ message FileDescriptorProto {
   optional SourceCodeInfo source_code_info = 9;
 
   // The syntax of the proto file.
-  // The supported values are "proto2" and "proto3".
+  // The supported values are "proto2", "proto3", and "editions".
+  //
+  // If `edition` is present, this value must be "editions".
   optional string syntax = 12;
+
+  // The edition of the proto file.
+  optional Edition edition = 14;
 }
 
 // Describes a message type.
@@ -129,6 +166,52 @@ message ExtensionRangeOptions {
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
+  message Declaration {
+    // The extension number declared within the extension range.
+    optional int32 number = 1;
+
+    // The fully-qualified name of the extension field. There must be a leading
+    // dot in front of the full name.
+    optional string full_name = 2;
+
+    // The fully-qualified type name of the extension field. Unlike
+    // Metadata.type, Declaration.type must have a leading dot for messages
+    // and enums.
+    optional string type = 3;
+
+    // If true, indicates that the number is reserved in the extension range,
+    // and any extension field with the number will fail to compile. Set this
+    // when a declared extension field is deleted.
+    optional bool reserved = 5;
+
+    // If true, indicates that the extension must be defined as repeated.
+    // Otherwise the extension must be defined as optional.
+    optional bool repeated = 6;
+
+    reserved 4;  // removed is_repeated
+  }
+
+  // For external users: DO NOT USE. We are in the process of open sourcing
+  // extension declaration and executing internal cleanups before it can be
+  // used externally.
+  repeated Declaration declaration = 2 [retention = RETENTION_SOURCE];
+
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 50;
+
+  // The verification state of the extension range.
+  enum VerificationState {
+    // All the extensions of the range must be declared.
+    DECLARATION = 0;
+    UNVERIFIED = 1;
+  }
+
+  // The verification state of the range.
+  // TODO: flip the default to DECLARATION once all empty ranges
+  // are marked as UNVERIFIED.
+  optional VerificationState verification = 3
+      [default = UNVERIFIED, retention = RETENTION_SOURCE];
+
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
 }
@@ -152,9 +235,10 @@ message FieldDescriptorProto {
     TYPE_BOOL = 8;
     TYPE_STRING = 9;
     // Tag-delimited aggregate.
-    // Group type is deprecated and not supported in proto3. However, Proto3
-    // implementations should still be able to parse the group wire format and
-    // treat group fields as unknown fields.
+    // Group type is deprecated and not supported after google.protobuf.
+    // However, Proto3 implementations should still be able to parse the group
+    // wire format and treat group fields as unknown fields.  In Editions, the
+    // group wire format can be enabled via the `message_encoding` feature.
     TYPE_GROUP = 10;
     TYPE_MESSAGE = 11;  // Length-delimited aggregate.
 
@@ -171,8 +255,11 @@ message FieldDescriptorProto {
   enum Label {
     // 0 is reserved for errors
     LABEL_OPTIONAL = 1;
-    LABEL_REQUIRED = 2;
     LABEL_REPEATED = 3;
+    // The required label is only allowed in google.protobuf.  In proto3 and
+    // Editions it's explicitly prohibited.  In Editions, the `field_presence`
+    // feature can be used to get this behavior.
+    LABEL_REQUIRED = 2;
   }
 
   optional string name = 1;
@@ -198,7 +285,6 @@ message FieldDescriptorProto {
   // For booleans, "true" or "false".
   // For strings, contains the default text contents (not escaped in any way).
   // For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  // TODO(kenton):  Base-64 encode?
   optional string default_value = 7;
 
   // If set, gives the index of a oneof in the containing type's oneof_decl
@@ -212,6 +298,29 @@ message FieldDescriptorProto {
   optional string json_name = 10;
 
   optional FieldOptions options = 8;
+
+  // If true, this is a proto3 "optional". When a proto3 field is optional, it
+  // tracks presence regardless of field type.
+  //
+  // When proto3_optional is true, this field must belong to a oneof to signal
+  // to old proto3 clients that presence is tracked for this field. This oneof
+  // is known as a "synthetic" oneof, and this field must be its sole member
+  // (each proto3 optional field gets its own synthetic oneof). Synthetic oneofs
+  // exist in the descriptor only, and do not generate any API. Synthetic oneofs
+  // must be ordered after all "real" oneofs.
+  //
+  // For message fields, proto3_optional doesn't create any semantic change,
+  // since non-repeated message fields always track presence. However it still
+  // indicates the semantic detail of whether the user wrote "optional" or not.
+  // This can be useful for round-tripping the .proto file. For consistency we
+  // give message fields a synthetic oneof also, even though it is not required
+  // to track presence. This is especially important because the parser can't
+  // tell if a field is a message or an enum, so it must always create a
+  // synthetic oneof.
+  //
+  // Proto2 optional fields do not set this flag, because they already indicate
+  // optional with `LABEL_OPTIONAL`.
+  optional bool proto3_optional = 17;
 }
 
 // Describes a oneof.
@@ -282,7 +391,6 @@ message MethodDescriptorProto {
   optional bool server_streaming = 6 [default = false];
 }
 
-
 // ===================================================================
 // Options
 
@@ -316,40 +424,41 @@ message MethodDescriptorProto {
 //   to automatically assign option numbers.
 
 message FileOptions {
-
   // Sets the Java package where classes generated from this .proto will be
   // placed.  By default, the proto package is used, but this is often
   // inappropriate because proto packages do not normally start with backwards
   // domain names.
   optional string java_package = 1;
 
-
-  // If set, all the classes from the .proto file are wrapped in a single
-  // outer class with the given name.  This applies to both Proto1
-  // (equivalent to the old "--one_java_file" option) and Proto2 (where
-  // a .proto always translates to a single class, but you may want to
-  // explicitly choose the class name).
+  // Controls the name of the wrapper Java class generated for the .proto file.
+  // That class will always contain the .proto file's getDescriptor() method as
+  // well as any top-level extensions defined in the .proto file.
+  // If java_multiple_files is disabled, then all the other classes from the
+  // .proto file will be nested inside the single wrapper outer class.
   optional string java_outer_classname = 8;
 
-  // If set true, then the Java code generator will generate a separate .java
+  // If enabled, then the Java code generator will generate a separate .java
   // file for each top-level message, enum, and service defined in the .proto
-  // file.  Thus, these types will *not* be nested inside the outer class
-  // named by java_outer_classname.  However, the outer class will still be
+  // file.  Thus, these types will *not* be nested inside the wrapper class
+  // named by java_outer_classname.  However, the wrapper class will still be
   // generated to contain the file's getDescriptor() method as well as any
   // top-level extensions defined in the file.
   optional bool java_multiple_files = 10 [default = false];
 
   // This option does nothing.
-  optional bool java_generate_equals_and_hash = 20 [deprecated=true];
+  optional bool java_generate_equals_and_hash = 20 [deprecated = true];
 
-  // If set true, then the Java2 code generator will generate code that
-  // throws an exception whenever an attempt is made to assign a non-UTF-8
-  // byte sequence to a string field.
-  // Message reflection will do the same.
-  // However, an extension field still accepts non-UTF-8 byte sequences.
-  // This option has no effect on when used with the lite runtime.
+  // A proto2 file can set this to true to opt in to UTF-8 checking for Java,
+  // which will throw an exception if invalid UTF-8 is parsed from the wire or
+  // assigned to a string field.
+  //
+  // TODO: clarify exactly what kinds of field types this option
+  // applies to, and update these docs accordingly.
+  //
+  // Proto3 files already perform these checks. Setting the option explicitly to
+  // false has no effect: it cannot be used to opt proto3 files out of UTF-8
+  // checks.
   optional bool java_string_check_utf8 = 27 [default = false];
-
 
   // Generated classes can be optimized for speed or code size.
   enum OptimizeMode {
@@ -367,9 +476,6 @@ message FileOptions {
   //   - Otherwise, the basename of the .proto file, without extension.
   optional string go_package = 11;
 
-
-
-
   // Should generic services be generated in each language?  "Generic" services
   // are not specific to any particular RPC system.  They are generated by the
   // main code generators in each language (without additional plugins).
@@ -383,7 +489,7 @@ message FileOptions {
   optional bool cc_generic_services = 16 [default = false];
   optional bool java_generic_services = 17 [default = false];
   optional bool py_generic_services = 18 [default = false];
-  optional bool php_generic_services = 42 [default = false];
+  reserved 42;  // removed php_generic_services
 
   // Is this file deprecated?
   // Depending on the target platform, this can emit Deprecated annotations
@@ -393,8 +499,7 @@ message FileOptions {
 
   // Enables the use of arenas for the proto messages in this file. This applies
   // only to generated classes for C++.
-  optional bool cc_enable_arenas = 31 [default = false];
-
+  optional bool cc_enable_arenas = 31 [default = true];
 
   // Sets the objective c class prefix which is prepended to all objective c
   // generated classes from this .proto. There is no default.
@@ -428,6 +533,8 @@ message FileOptions {
   // determining the ruby package.
   optional string ruby_package = 45;
 
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 50;
 
   // The parser stores options it doesn't recognize here.
   // See the documentation for the "Options" section above.
@@ -472,6 +579,8 @@ message MessageOptions {
   // this is a formalization for deprecating messages.
   optional bool deprecated = 3 [default = false];
 
+  reserved 4, 5, 6;
+
   // Whether the message is an automatically generated map entry type for the
   // maps field.
   //
@@ -498,6 +607,20 @@ message MessageOptions {
   reserved 8;  // javalite_serializable
   reserved 9;  // javanano_as_lite
 
+  // Enable the legacy handling of JSON field name conflicts.  This lowercases
+  // and strips underscored from the fields before comparison in proto3 only.
+  // The new behavior takes `json_name` into account and applies to proto2 as
+  // well.
+  //
+  // This should only be used as a temporary measure against broken builds due
+  // to the change in behavior for JSON field name conflicts.
+  //
+  // TODO This is legacy behavior we plan to remove once downstream
+  // teams have had time to migrate.
+  optional bool deprecated_legacy_json_field_conflicts = 11 [deprecated = true];
+
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 12;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -509,13 +632,21 @@ message MessageOptions {
 message FieldOptions {
   // The ctype option instructs the C++ code generator to use a different
   // representation of the field than it normally would.  See the specific
-  // options below.  This option is not yet implemented in the open source
-  // release -- sorry, we'll try to include it in a future version!
+  // options below.  This option is only implemented to support use of
+  // [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of
+  // type "bytes" in the open source release -- sorry, we'll try to include
+  // other types in a future version!
   optional CType ctype = 1 [default = STRING];
   enum CType {
     // Default mode.
     STRING = 0;
 
+    // The option [ctype=CORD] may be applied to a non-repeated field of type
+    // "bytes". It indicates that in C++, the data should be stored in a Cord
+    // instead of a string.  For very large strings, this may reduce memory
+    // fragmentation. It may also allow better performance when parsing from a
+    // Cord, or when parsing with aliasing enabled, as the parsed Cord may then
+    // alias the original buffer.
     CORD = 1;
 
     STRING_PIECE = 2;
@@ -524,7 +655,9 @@ message FieldOptions {
   // a more efficient representation on the wire. Rather than repeatedly
   // writing the tag and type for each element, the entire array is encoded as
   // a single length-delimited blob. In proto3, only explicit setting it to
-  // false will avoid using packed encoding.
+  // false will avoid using packed encoding.  This option is prohibited in
+  // Editions, but the `repeated_field_encoding` feature can be used to control
+  // the behavior.
   optional bool packed = 2;
 
   // The jstype option determines the JavaScript type used for values of the
@@ -567,18 +700,17 @@ message FieldOptions {
   // call from multiple threads concurrently, while non-const methods continue
   // to require exclusive access.
   //
-  //
-  // Note that implementations may choose not to check required fields within
-  // a lazy sub-message.  That is, calling IsInitialized() on the outer message
-  // may return true even if the inner message has missing required fields.
-  // This is necessary because otherwise the inner message would have to be
-  // parsed in order to perform the check, defeating the purpose of lazy
-  // parsing.  An implementation which chooses not to check required fields
-  // must be consistent about it.  That is, for any particular sub-message, the
-  // implementation must either *always* check its required fields, or *never*
-  // check its required fields, regardless of whether or not the message has
-  // been parsed.
+  // Note that lazy message fields are still eagerly verified to check
+  // ill-formed wireformat or missing required fields. Calling IsInitialized()
+  // on the outer message would fail if the inner message has missing required
+  // fields. Failed verification would result in parsing failure (except when
+  // uninitialized messages are acceptable).
   optional bool lazy = 5 [default = false];
+
+  // unverified_lazy does no correctness checks on the byte stream. This should
+  // only be used where lazy with verification is prohibitive for performance
+  // reasons.
+  optional bool unverified_lazy = 15 [default = false];
 
   // Is this field deprecated?
   // Depending on the target platform, this can emit Deprecated annotations
@@ -589,6 +721,48 @@ message FieldOptions {
   // For Google-internal migration only. Do not use.
   optional bool weak = 10 [default = false];
 
+  // Indicate that the field value should not be printed out when using debug
+  // formats, e.g. when the field contains sensitive credentials.
+  optional bool debug_redact = 16 [default = false];
+
+  // If set to RETENTION_SOURCE, the option will be omitted from the binary.
+  // Note: as of January 2023, support for this is in progress and does not yet
+  // have an effect (b/264593489).
+  enum OptionRetention {
+    RETENTION_UNKNOWN = 0;
+    RETENTION_RUNTIME = 1;
+    RETENTION_SOURCE = 2;
+  }
+
+  optional OptionRetention retention = 17;
+
+  // This indicates the types of entities that the field may apply to when used
+  // as an option. If it is unset, then the field may be freely used as an
+  // option on any kind of entity. Note: as of January 2023, support for this is
+  // in progress and does not yet have an effect (b/264593489).
+  enum OptionTargetType {
+    TARGET_TYPE_UNKNOWN = 0;
+    TARGET_TYPE_FILE = 1;
+    TARGET_TYPE_EXTENSION_RANGE = 2;
+    TARGET_TYPE_MESSAGE = 3;
+    TARGET_TYPE_FIELD = 4;
+    TARGET_TYPE_ONEOF = 5;
+    TARGET_TYPE_ENUM = 6;
+    TARGET_TYPE_ENUM_ENTRY = 7;
+    TARGET_TYPE_SERVICE = 8;
+    TARGET_TYPE_METHOD = 9;
+  }
+
+  repeated OptionTargetType targets = 19;
+
+  message EditionDefault {
+    optional Edition edition = 3;
+    optional string value = 2;  // Textproto value.
+  }
+  repeated EditionDefault edition_defaults = 20;
+
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 21;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -596,10 +770,14 @@ message FieldOptions {
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
 
-  reserved 4;  // removed jtype
+  reserved 4;   // removed jtype
+  reserved 18;  // reserve target, target_obsolete_do_not_use
 }
 
 message OneofOptions {
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 1;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -608,7 +786,6 @@ message OneofOptions {
 }
 
 message EnumOptions {
-
   // Set this option to true to allow mapping different tag names to the same
   // value.
   optional bool allow_alias = 2;
@@ -620,6 +797,17 @@ message EnumOptions {
   optional bool deprecated = 3 [default = false];
 
   reserved 5;  // javanano_as_lite
+
+  // Enable the legacy handling of JSON field name conflicts.  This lowercases
+  // and strips underscored from the fields before comparison in proto3 only.
+  // The new behavior takes `json_name` into account and applies to proto2 as
+  // well.
+  // TODO Remove this legacy behavior once downstream teams have
+  // had time to migrate.
+  optional bool deprecated_legacy_json_field_conflicts = 6 [deprecated = true];
+
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 7;
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -635,6 +823,14 @@ message EnumValueOptions {
   // this is a formalization for deprecating enum values.
   optional bool deprecated = 1 [default = false];
 
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 2;
+
+  // Indicate that fields annotated with this enum value should not be printed
+  // out when using debug formats, e.g. when the field contains sensitive
+  // credentials.
+  optional bool debug_redact = 3 [default = false];
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -643,6 +839,8 @@ message EnumValueOptions {
 }
 
 message ServiceOptions {
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 34;
 
   // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
   //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -663,7 +861,6 @@ message ServiceOptions {
 }
 
 message MethodOptions {
-
   // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
   //   framework.  We apologize for hoarding these numbers to ourselves, but
   //   we were already using them long before we decided to release Protocol
@@ -686,13 +883,15 @@ message MethodOptions {
   optional IdempotencyLevel idempotency_level = 34
       [default = IDEMPOTENCY_UNKNOWN];
 
+  // Any features defined in the specific edition.
+  optional FeatureSet features = 35;
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
 }
-
 
 // A message representing a option the parser does not recognize. This only
 // appears in options protos created by the compiler::Parser class.
@@ -704,8 +903,8 @@ message UninterpretedOption {
   // The name of the uninterpreted option.  Each string represents a segment in
   // a dot-separated name.  is_extension is true iff a segment represents an
   // extension (denoted with parentheses in options specs in .proto files).
-  // E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-  // "foo.(bar.baz).qux".
+  // E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+  // "foo.(bar.baz).moo".
   message NamePart {
     required string name_part = 1;
     required bool is_extension = 2;
@@ -720,6 +919,132 @@ message UninterpretedOption {
   optional double double_value = 6;
   optional bytes string_value = 7;
   optional string aggregate_value = 8;
+}
+
+// ===================================================================
+// Features
+
+// TODO Enums in C++ gencode (and potentially other languages) are
+// not well scoped.  This means that each of the feature enums below can clash
+// with each other.  The short names we've chosen maximize call-site
+// readability, but leave us very open to this scenario.  A future feature will
+// be designed and implemented to handle this, hopefully before we ever hit a
+// conflict here.
+message FeatureSet {
+  enum FieldPresence {
+    FIELD_PRESENCE_UNKNOWN = 0;
+    EXPLICIT = 1;
+    IMPLICIT = 2;
+    LEGACY_REQUIRED = 3;
+  }
+  optional FieldPresence field_presence = 1 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    edition_defaults = { edition: EDITION_PROTO2, value: "EXPLICIT" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "IMPLICIT" },
+    edition_defaults = { edition: EDITION_2023, value: "EXPLICIT" }
+  ];
+
+  enum EnumType {
+    ENUM_TYPE_UNKNOWN = 0;
+    OPEN = 1;
+    CLOSED = 2;
+  }
+  optional EnumType enum_type = 2 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE,
+    edition_defaults = { edition: EDITION_PROTO2, value: "CLOSED" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "OPEN" }
+  ];
+
+  enum RepeatedFieldEncoding {
+    REPEATED_FIELD_ENCODING_UNKNOWN = 0;
+    PACKED = 1;
+    EXPANDED = 2;
+  }
+  optional RepeatedFieldEncoding repeated_field_encoding = 3 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    edition_defaults = { edition: EDITION_PROTO2, value: "EXPANDED" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "PACKED" }
+  ];
+
+  enum Utf8Validation {
+    UTF8_VALIDATION_UNKNOWN = 0;
+    VERIFY = 2;
+    NONE = 3;
+  }
+  optional Utf8Validation utf8_validation = 4 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    edition_defaults = { edition: EDITION_PROTO2, value: "NONE" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "VERIFY" }
+  ];
+
+  enum MessageEncoding {
+    MESSAGE_ENCODING_UNKNOWN = 0;
+    LENGTH_PREFIXED = 1;
+    DELIMITED = 2;
+  }
+  optional MessageEncoding message_encoding = 5 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_FIELD,
+    targets = TARGET_TYPE_FILE,
+    edition_defaults = { edition: EDITION_PROTO2, value: "LENGTH_PREFIXED" }
+  ];
+
+  enum JsonFormat {
+    JSON_FORMAT_UNKNOWN = 0;
+    ALLOW = 1;
+    LEGACY_BEST_EFFORT = 2;
+  }
+  optional JsonFormat json_format = 6 [
+    retention = RETENTION_RUNTIME,
+    targets = TARGET_TYPE_MESSAGE,
+    targets = TARGET_TYPE_ENUM,
+    targets = TARGET_TYPE_FILE,
+    edition_defaults = { edition: EDITION_PROTO2, value: "LEGACY_BEST_EFFORT" },
+    edition_defaults = { edition: EDITION_PROTO3, value: "ALLOW" }
+  ];
+
+  reserved 999;
+
+  extensions 1000;  // for Protobuf C++
+  extensions 1001;  // for Protobuf Java
+  extensions 1002;  // for Protobuf Go
+
+  extensions 9990;  // for deprecated Java Proto1
+
+  extensions 9995 to 9999;  // For internal testing
+  extensions 10000;         // for https://github.com/bufbuild/protobuf-es
+}
+
+// A compiled specification for the defaults of a set of features.  These
+// messages are generated from FeatureSet extensions and can be used to seed
+// feature resolution. The resolution with this object becomes a simple search
+// for the closest matching edition, followed by proto merges.
+message FeatureSetDefaults {
+  // A map from every known edition with a unique set of defaults to its
+  // defaults. Not all editions may be contained here.  For a given edition,
+  // the defaults at the closest matching edition ordered at or before it should
+  // be used.  This field must be in strict ascending order by edition.
+  message FeatureSetEditionDefault {
+    optional Edition edition = 3;
+    optional FeatureSet features = 2;
+  }
+  repeated FeatureSetEditionDefault defaults = 1;
+
+  // The minimum supported edition (inclusive) when this was constructed.
+  // Editions before this will not have defaults.
+  optional Edition minimum_edition = 4;
+
+  // The maximum known edition (inclusive) when this was constructed. Editions
+  // after this will not have reliable defaults.
+  optional Edition maximum_edition = 5;
 }
 
 // ===================================================================
@@ -777,8 +1102,8 @@ message SourceCodeInfo {
     // location.
     //
     // Each element is a field number or an index.  They form a path from
-    // the root FileDescriptorProto to the place where the definition.  For
-    // example, this path:
+    // the root FileDescriptorProto to the place where the definition appears.
+    // For example, this path:
     //   [ 4, 3, 2, 7, 1 ]
     // refers to:
     //   file.message_type(3)  // 4, 3
@@ -832,13 +1157,13 @@ message SourceCodeInfo {
     //   // Comment attached to baz.
     //   // Another line attached to baz.
     //
-    //   // Comment attached to qux.
+    //   // Comment attached to moo.
     //   //
-    //   // Another line attached to qux.
-    //   optional double qux = 4;
+    //   // Another line attached to moo.
+    //   optional double moo = 4;
     //
     //   // Detached comment for corge. This is not leading or trailing comments
-    //   // to qux or corge because there are blank lines separating it from
+    //   // to moo or corge because there are blank lines separating it from
     //   // both.
     //
     //   // Detached comment for corge paragraph 2.
@@ -878,8 +1203,20 @@ message GeneratedCodeInfo {
     optional int32 begin = 3;
 
     // Identifies the ending offset in bytes in the generated code that
-    // relates to the identified offset. The end offset should be one past
+    // relates to the identified object. The end offset should be one past
     // the last relevant byte (so the length of the text = end - begin).
     optional int32 end = 4;
+
+    // Represents the identified object's effect on the element in the original
+    // .proto file.
+    enum Semantic {
+      // There is no effect or the effect is indescribable.
+      NONE = 0;
+      // The element is set or otherwise mutated.
+      SET = 1;
+      // An alias to the element is returned.
+      ALIAS = 2;
+    }
+    optional Semantic semantic = 5;
   }
 }

--- a/protobuf/protoeditor-core/resources/messages/ProtobufLangBundle.properties
+++ b/protobuf/protoeditor-core/resources/messages/ProtobufLangBundle.properties
@@ -79,6 +79,17 @@ proto3.enums=Only proto3 enums can be used in proto3 messages
 proto3.first.enum.value.zero=First enum value must be 0 in proto3
 proto3.field.name.uniqueness=proto3 field names must be unique after being converted to lowercase with underscores removed
 
+# Editions annotations
+editions.unsupported=Edition ''{0}'' is not yet supported
+editions.field.label.optional=The optional label is not allowed since edition 2023
+editions.field.label.required=The required label is not allowed since edition 2023
+editions.group.invalid=Group syntax is not allowed since edition 2023
+editions.features.invalid=Features are not allowed before edition 2023
+editions.field.reserved.string=String literal reserved fields are not allowed since edition 2023
+editions.field.reserved.identifier=Identifier reserved fields are not allowed before edition 2023
+editions.enum.value.reserved.string=String literal reserved enum values are not allowed since edition 2023
+editions.enum.value.reserved.identifier=Identifier reserved enum values are not allowed before edition 2023
+
 # Field problems
 field.number.must.be.positive=Field numbers must be positive integers
 field.number.in.proto.reserved.range=Field numbers {0} through {1} are reserved for the protobuf implementation

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/bnf/proto.bnf
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/bnf/proto.bnf
@@ -274,7 +274,8 @@ private meta BlockEntry ::= !'}' <<p>> { pin = 1 }
 /*
  * Syntax statement.
  */
-SyntaxStatement ::= syntax '=' StringValue ';'
+SyntaxType ::= syntax | edition
+SyntaxStatement ::= SyntaxType '=' StringValue ';'
 {
   pin = 1
   implements = [
@@ -282,6 +283,9 @@ SyntaxStatement ::= syntax '=' StringValue ';'
     'com.intellij.protobuf.lang.psi.PbStatement'
   ]
   mixin = 'com.intellij.protobuf.lang.psi.impl.PbSyntaxStatementMixin'
+  methods = [
+    syntaxType = 'SyntaxType'
+  ]
 }
 
 /*
@@ -580,7 +584,8 @@ ReservedRange ::= IntegerValue (to (IntegerValue | max))?
 private ReservedRangeRecovery ::= !(IntegerValue | ',') MessageRecovery
 
 // These rules start with lookahead predicates (&...) for disambiguation.
-private ReservedNames ::= &StringValue <<CommaSeparatedList ';' StringValue>>
+private ReservedName ::= StringValue | IdentifierValue
+private ReservedNames ::= &ReservedName <<CommaSeparatedList ';' ReservedName>>
 private ReservedNumbers ::= &IntegerValue <<CommaSeparatedList ';' ReservedRange>>
 
 /*
@@ -653,7 +658,8 @@ EnumReservedRange ::= IntegerValue (to (IntegerValue | max))?
 private EnumReservedRangeRecovery ::= !(IntegerValue | ',') EnumRecovery
 
 // These rules start with lookahead predicates (&...) for disambiguation.
-private EnumReservedNames ::= &StringValue <<CommaSeparatedList ';' StringValue>>
+private EnumReservedName ::= StringValue | IdentifierValue
+private EnumReservedNames ::= &EnumReservedName <<CommaSeparatedList ';' EnumReservedName>>
 private EnumReservedNumbers ::= &IntegerValue <<CommaSeparatedList ';' EnumReservedRange>>
 
 /*

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/ide/highlighter/PbSyntaxHighlighter.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/ide/highlighter/PbSyntaxHighlighter.java
@@ -100,6 +100,7 @@ public class PbSyntaxHighlighter extends SyntaxHighlighterBase {
         KEYWORD,
         ProtoTokenTypes.BUILT_IN_TYPE,
         ProtoTokenTypes.DEFAULT,
+        ProtoTokenTypes.EDITION,
         ProtoTokenTypes.ENUM,
         ProtoTokenTypes.EXTEND,
         ProtoTokenTypes.EXTENSIONS,

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/jflex/proto.flex
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/jflex/proto.flex
@@ -133,6 +133,7 @@ String = {SingleQuotedString} | {DoubleQuotedString}
 
   "default"                 { return keyword(ProtoTokenTypes.DEFAULT); }
   "enum"                    { return keyword(ProtoTokenTypes.ENUM); }
+  "edition"                 { return keyword(ProtoTokenTypes.EDITION); }
   "extend"                  { return keyword(ProtoTokenTypes.EXTEND); }
   "extensions"              { return keyword(ProtoTokenTypes.EXTENSIONS); }
   "group"                   { return keyword(ProtoTokenTypes.GROUP); }

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/EditionsAnnotator.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/EditionsAnnotator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.protobuf.lang.annotation;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.protobuf.lang.PbLangBundle;
+import com.intellij.protobuf.lang.psi.*;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+/** Annotations specific to editions >= 2023. */
+public class EditionsAnnotator implements Annotator {
+  @Override
+  public void annotate(@NotNull PsiElement element, @NotNull final AnnotationHolder holder) {
+    // Only operate on editions files.
+    if (!(element instanceof PbElement)
+        || ((PbElement) element).getPbFile().getSyntaxLevel() != SyntaxLevel.EDITIONS) {
+      return;
+    }
+
+    element.accept(
+        new PbVisitor() {
+          @Override
+          public void visitSyntaxStatement(@NotNull PbSyntaxStatement syntax) {
+            annotateEdition(syntax, holder);
+          }
+
+          @Override
+          public void visitField(@NotNull PbField field) {
+            annotateField(field, holder);
+          }
+
+          @Override
+          public void visitGroupDefinition(@NotNull PbGroupDefinition group) {
+            annotateGroupDefinition(group, holder);
+          }
+        });
+  }
+
+  /*
+   * Check the edition specification.
+   */
+  private static void annotateEdition(PbSyntaxStatement syntax, AnnotationHolder holder) {
+    if (syntax.getEdition() == null || !syntax.getEdition().equals("2023")) {
+      holder
+          .newAnnotation(
+              HighlightSeverity.ERROR,
+              PbLangBundle.message("editions.unsupported", syntax.getEdition()))
+          .range(syntax)
+          .create();
+    }
+  }
+
+  /*
+   * In editions, only repeated or null labels are allowed.
+   */
+  private static void annotateField(PbField field, AnnotationHolder holder) {
+    if (field instanceof PbMapField) {
+      return;
+    }
+    PbFieldLabel label = field.getDeclaredLabel();
+    if (label != null && !label.getText().equals("repeated")) {
+      holder
+          .newAnnotation(
+              HighlightSeverity.ERROR,
+              PbLangBundle.message("editions.field.label." + label.getText()))
+          .range(label)
+          .create();
+    }
+  }
+
+  /*
+   * Group syntax is not allowed
+   */
+  private static void annotateGroupDefinition(PbGroupDefinition group, AnnotationHolder holder) {
+    holder
+        .newAnnotation(HighlightSeverity.ERROR, PbLangBundle.message("editions.group.invalid"))
+        .range(group)
+        .create();
+  }
+}

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/EnumTracker.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/EnumTracker.java
@@ -125,8 +125,25 @@ final class EnumTracker {
         for (PbEnumReservedRange reservedRange : reservedStatement.getEnumReservedRangeList()) {
           visitReservedRange(reservedStatement, reservedRange);
         }
+        for (PbIdentifierValue reservedName : reservedStatement.getIdentifierValueList()) {
+          if (enumDefinition.getPbFile().getSyntaxLevel() == SyntaxLevel.EDITIONS) {
+            visitReservedName(reservedStatement, reservedName);
+          } else {
+            queueError(
+                reservedStatement,
+                reservedName,
+                PbLangBundle.message("editions.enum.value.reserved.identifier"));
+          }
+        }
         for (PbStringValue reservedName : reservedStatement.getStringValueList()) {
-          visitReservedName(reservedStatement, reservedName);
+          if (enumDefinition.getPbFile().getSyntaxLevel() != SyntaxLevel.EDITIONS) {
+            visitReservedName(reservedStatement, reservedName);
+          } else {
+            queueError(
+                reservedStatement,
+                reservedName,
+                PbLangBundle.message("editions.enum.value.reserved.string"));
+          }
         }
       }
     }
@@ -211,7 +228,7 @@ final class EnumTracker {
     }
 
     private void visitReservedName(
-        PbEnumReservedStatement reservedStatement, PbStringValue reservedName) {
+        PbEnumReservedStatement reservedStatement, ProtoLiteral reservedName) {
       String name = reservedName.getAsString();
       if (!reservedNames.add(name)) {
         queueError(

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/PbAnnotator.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/PbAnnotator.java
@@ -468,6 +468,7 @@ public class PbAnnotator implements Annotator {
     annotateRepeatedMessageFieldInitialization(name, holder);
     annotateOptionOccurrences(name, holder);
     annotateSpecialOption(name, holder);
+    annotateFeatureOptions(name, holder);
   }
 
   private static void annotateExtensionName(
@@ -541,6 +542,21 @@ public class PbAnnotator implements Annotator {
       // field cannot be a qualifier.
       holder.newAnnotation(HighlightSeverity.ERROR, PbLangBundle.message("repeated.message.aggregate.value", field.getName()))
           .range(getOptionNameAnnotationElement(name))
+          .create();
+    }
+  }
+
+  private static void annotateFeatureOptions(PbOptionName name, AnnotationHolder holder) {
+    PsiElement qualifier = name.getSymbol();
+    if (qualifier != null
+        && qualifier.getText().equals("features")
+        && name.getPbFile().getSyntaxLevel() != SyntaxLevel.EDITIONS) {
+      // Features are not "special" options, but they are banned outside of editions files.
+      holder
+          .newAnnotation(
+              HighlightSeverity.ERROR,
+              PbLangBundle.message("editions.features.invalid", name.getText()))
+          .range(qualifier)
           .create();
     }
   }

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/completion/PbCompletionContributor.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/completion/PbCompletionContributor.java
@@ -170,6 +170,12 @@ public class PbCompletionContributor extends CompletionContributor {
         .collect(Collectors.toList());
     }
 
+    private static List<LookupElement> createEditionsFieldLabels() {
+      return Stream.of("repeated")
+        .map(PbCompletionContributor::lookupElementWithSpace)
+        .collect(Collectors.toList());
+    }
+
     private static LookupElement createGroupKeyWord() { return lookupElementWithSpace("group"); }
 
     @Override
@@ -194,6 +200,7 @@ public class PbCompletionContributor extends CompletionContributor {
         result.addAllElements(switch (syntaxLevel) {
           case PROTO2 -> createProto2FieldLabels();
           case PROTO3 -> createProto3FieldLabels();
+          case EDITIONS -> createEditionsFieldLabels();
         });
       } else {
         // In proto2, we can have a "group" right after the field label.

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbMessageType.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbMessageType.java
@@ -47,9 +47,17 @@ public interface PbMessageType extends PbNamedTypeElement, PbSymbolOwner {
       return false;
     }
     for (PbReservedStatement reservedStatement : body.getReservedStatementList()) {
-      for (PbStringValue reservedName : reservedStatement.getStringValueList()) {
-        if (fieldName.equals(reservedName.getAsString())) {
-          return true;
+      if (getPbFile().getSyntaxLevel() == SyntaxLevel.EDITIONS) {
+        for (PbIdentifierValue reservedName : reservedStatement.getIdentifierValueList()) {
+          if (fieldName.equals(reservedName.getAsString())) {
+            return true;
+          }
+        }
+      } else {
+        for (PbStringValue reservedName : reservedStatement.getStringValueList()) {
+          if (fieldName.equals(reservedName.getAsString())) {
+            return true;
+          }
         }
       }
     }

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbSyntaxStatementBase.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbSyntaxStatementBase.java
@@ -21,4 +21,7 @@ interface PbSyntaxStatementBase extends PbElement {
 
   @Nullable
   SyntaxLevel getSyntaxLevel();
+
+  @Nullable
+  String getEdition();
 }

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/ProtoTokenTypes.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/ProtoTokenTypes.java
@@ -70,6 +70,7 @@ public final class ProtoTokenTypes {
 
   // Keywords found in .proto files.
   public static final IElementType DEFAULT = put("default", new ProtoKeywordTokenType("default"));
+  public static final IElementType EDITION = put("edition", new ProtoKeywordTokenType("edition"));
   public static final IElementType ENUM = put("enum", new ProtoKeywordTokenType("enum"));
   public static final IElementType EXTEND = put("extend", new ProtoKeywordTokenType("extend"));
   public static final IElementType EXTENSIONS =

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/SyntaxLevel.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/SyntaxLevel.java
@@ -20,7 +20,8 @@ import org.jetbrains.annotations.Nullable;
 /** An enum defining possible syntax levels. */
 public enum SyntaxLevel {
   PROTO2("proto2"),
-  PROTO3("proto3");
+  PROTO3("proto3"),
+  EDITIONS("editions");
 
   @Nullable
   public static SyntaxLevel forString(String level) {

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbSyntaxStatementMixin.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbSyntaxStatementMixin.java
@@ -32,9 +32,21 @@ abstract class PbSyntaxStatementMixin extends PbStatementBase implements PbSynta
   @Nullable
   @Override
   public SyntaxLevel getSyntaxLevel() {
+    if (getSyntaxType().getText().equals("edition")) {
+      return SyntaxLevel.EDITIONS;
+    }
     PbStringValue syntaxString = getStringValue();
     if (syntaxString != null) {
       return SyntaxLevel.forString(syntaxString.getAsString());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getEdition() {
+    if (getSyntaxLevel() == SyntaxLevel.EDITIONS) {
+      return getStringValue().getAsString();
     }
     return null;
   }

--- a/protobuf/protoeditor-core/test/com/intellij/protobuf/lang/annotation/PbAnnotatorErrorTest.java
+++ b/protobuf/protoeditor-core/test/com/intellij/protobuf/lang/annotation/PbAnnotatorErrorTest.java
@@ -103,6 +103,14 @@ public class PbAnnotatorErrorTest extends PbCodeInsightFixtureTestCase {
     doTest("lang/annotation/Proto3Errors.proto.testdata");
   }
 
+  public void testProtoEditionUnsupportedErrorAnnotations() {
+    doTest("lang/annotation/EditionUnsupportedErrors.proto.testdata");
+  }
+
+  public void testProtoEdition2023ErrorAnnotations() {
+    doTest("lang/annotation/Edition2023Errors.proto.testdata");
+  }
+
   public void testFieldErrorAnnotations() {
     doTest("lang/annotation/FieldErrors.proto.testdata");
   }

--- a/protobuf/protoeditor-core/test/com/intellij/protobuf/lang/parser/PbParserTest.java
+++ b/protobuf/protoeditor-core/test/com/intellij/protobuf/lang/parser/PbParserTest.java
@@ -82,4 +82,8 @@ public class PbParserTest extends ParsingTestCase {
   public void testEnumReservedRange() {
     doTest(true);
   }
+
+  public void testEnumReservedRangeEditions() {
+    doTest(true);
+  }
 }

--- a/protobuf/protoeditor-core/testData/lang/annotation/Edition2023Errors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/Edition2023Errors.proto.testdata
@@ -1,0 +1,58 @@
+edition = "2023";
+
+message RegularMessage {
+  int32 a = 1;
+  repeated string b = 2;
+  int32 required_field = 3 [features.field_presence = LEGACY_REQUIRED];
+
+  message SubMessage {
+    int32 a = 1;
+  }
+  SubMessage message_field = 4 [features.message_encoding = DELIMITED];
+
+  oneof oneof_field {
+    float oneof1 = 5;
+    int32 oneof2 = 6;
+    string oneof3 = 7;
+  }
+
+  map<int32, int64> map_field = 8;
+
+  extensions 100 to 200;
+}
+
+extend RegularMessage {
+  int32 regular_extension = 100;
+}
+
+enum RegularEnum {
+  option features.enum_type = CLOSED;
+  REGULAR_ENUM_UNKNOWN = 0;
+  REGULAR_ENUM_1 = 1;
+}
+
+message BannedMessage {
+  <error descr="The optional label is not allowed since edition 2023">optional</error> string optional_field = 2;
+  <error descr="The required label is not allowed since edition 2023">required</error> string required_field = 3;
+  <error descr="Group syntax is not allowed since edition 2023">group group_field = 4 {}</error>
+
+  reserved <error descr="String literal reserved fields are not allowed since edition 2023">"a"</error>,
+    <error descr="String literal reserved fields are not allowed since edition 2023">"b"</error>,
+    c;
+
+  reserved <error descr="Field name 'c' is reserved multiple times">c</error>;
+}
+
+extend RegularMessage {
+  <error descr="The optional label is not allowed since edition 2023">optional</error> int32 optional_ext = 150;
+  <error descr="The required label is not allowed since edition 2023">required</error> float required_ext = 151;
+  <error descr="Group syntax is not allowed since edition 2023">group group_ext = 152 {}</error>
+}
+
+
+enum BannedEnum {
+  BANNED_SYNTAX_UNKNOWN = 0;
+  reserved <error descr="String literal reserved enum values are not allowed since edition 2023">"VALUEA"</error>,
+    <error descr="String literal reserved enum values are not allowed since edition 2023">"VALUEB"</error>,
+    VALUEC;
+}

--- a/protobuf/protoeditor-core/testData/lang/annotation/EditionUnsupportedErrors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/EditionUnsupportedErrors.proto.testdata
@@ -1,0 +1,1 @@
+<error descr="Edition 'unknown' is not yet supported">edition = "unknown";</error>

--- a/protobuf/protoeditor-core/testData/lang/annotation/EnumErrors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/EnumErrors.proto.testdata
@@ -74,6 +74,10 @@ enum ReservedNameTwice {
   REQUIRED2 = 1000;  // A value is required.
 }
 
+enum ReservedIdentifier {
+  reserved <error descr="Identifier reserved enum values are not allowed before edition 2023">FOO</error>;
+}
+
 enum ValueUsesReservedName {
   BAR = 1;
   <error descr="Enum value name 'FOO_RESERVED' is reserved">FOO_RESERVED</error> = 2;

--- a/protobuf/protoeditor-core/testData/lang/annotation/FieldErrors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/FieldErrors.proto.testdata
@@ -149,6 +149,10 @@ message ReservedNameTwice {
   reserved <error descr="Field name 'foo' is reserved multiple times">"foo"</error>;
 }
 
+message ReservedIdentifier {
+  reserved <error descr="Identifier reserved fields are not allowed before edition 2023">a</error>;
+}
+
 message UsesReservedName {
   optional int32 bar = 1;
   optional int32 <error descr="Field name 'foo' is reserved">foo</error> = 2;

--- a/protobuf/protoeditor-core/testData/lang/annotation/Proto2Errors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/Proto2Errors.proto.testdata
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 package foo.bar;
 
+option <error descr="Features are not allowed before edition 2023">features</error>.enum_type = OPEN;
+
 message Test {
   optional string labeled_field = 1;
   optional group LabeledGroup = 2 {}

--- a/protobuf/protoeditor-core/testData/lang/annotation/Proto3Errors.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/annotation/Proto3Errors.proto.testdata
@@ -6,6 +6,8 @@ import <error descr="Weak imports are not supported in proto3">weak</error> "lan
 import "lang/annotation/proto2enum.proto";
 import "google/protobuf/descriptor.proto";
 
+option <error descr="Features are not allowed before edition 2023">features</error>.enum_type = CLOSED;
+
 message MessageSetTest {
   option <error descr="MessageSet is not supported in proto3">message_set_wire_format</error> = true;
 }

--- a/protobuf/protoeditor-core/testData/lang/parser/EnumReservedRangeEditions.proto.testdata
+++ b/protobuf/protoeditor-core/testData/lang/parser/EnumReservedRangeEditions.proto.testdata
@@ -1,0 +1,10 @@
+edition = "2023;
+
+enum TestEnumReservedRange {
+  FOO = 0;
+  reserved 2, 15, 9 to 11, 3, 20 to max;
+  reserved -10 to 5;
+  reserved -100;
+  reserved foo;
+  reserved bar, baz;
+}

--- a/protobuf/resources/META-INF/plugin.xml
+++ b/protobuf/resources/META-INF/plugin.xml
@@ -84,6 +84,7 @@
     <annotator language="protobuf" implementationClass="com.intellij.protobuf.lang.annotation.PbAnnotator"/>
     <annotator language="protobuf" implementationClass="com.intellij.protobuf.lang.annotation.Proto2Annotator"/>
     <annotator language="protobuf" implementationClass="com.intellij.protobuf.lang.annotation.Proto3Annotator"/>
+    <annotator language="protobuf" implementationClass="com.intellij.protobuf.lang.annotation.EditionsAnnotator"/>
     <annotator language="protobuf" implementationClass="com.intellij.protobuf.lang.annotation.PbTextAnnotator"/>
 
     <!-- Structure view -->


### PR DESCRIPTION
This updates the protobuf grammar to include the following changes in edition 2023:
- Addition of `edition` keyword
- Reserved fields and enum values are now specified as identifiers instead of string literals

This also adds some basic validation checks:
- Enforce that only supported editions are allowed
- Enforce reserved fields and enum values obey the file's syntax
- Prohibit the removed `optional`, `required`, and `group` keywords
- Prohibit the `features` option from being used outside editions

As an immediate follow up we will audit all the gencode -> proto utilities exposed by the plugin and at least add some editions tests.

Future changes could actually handle feature cascading and provide some of the additional checks that protoc will apply during builds.  For example, every feature specifies the type of descriptors it's allowed to be specified on, and certain combinations of features are prohibited.