### PR TITLE
[Dart] Add Basic Breadcrumbs Support

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -52,6 +52,7 @@
     <enterHandlerDelegate implementation="com.jetbrains.lang.dart.ide.editor.DartEnterInStringHandler" order="first"/>
     <enterBetweenBracesDelegate language="Dart"  implementationClass="com.intellij.codeInsight.editorActions.enter.EnterBetweenBracesAndBracketsDelegate"/>
     <lang.lineWrapStrategy language="Dart" implementationClass="com.jetbrains.lang.dart.ide.editor.DartLineWrapPositionStrategy"/>
+    <breadcrumbsInfoProvider implementation="com.jetbrains.lang.dart.ide.editor.DartBreadcrumbsInfoProvider"/>
     <stripTrailingSpacesFilterFactory implementation="com.jetbrains.lang.dart.ide.editor.DartStripTrailingSpacesFilterFactory"/>
     <copyPastePostProcessor implementation="com.jetbrains.lang.dart.ide.editor.DartCopyPasteProcessor"/>
     <autoImportOptionsProvider instance="com.jetbrains.lang.dart.ide.editor.DartAutoImportOptionsProvider"/>

--- a/Dart/src/com/jetbrains/lang/dart/ide/editor/DartBreadcrumbsInfoProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/editor/DartBreadcrumbsInfoProvider.java
@@ -1,0 +1,37 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.ide.editor;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.breadcrumbs.BreadcrumbsProvider;
+import com.jetbrains.lang.dart.DartLanguage;
+import com.jetbrains.lang.dart.psi.DartComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+
+public class DartBreadcrumbsInfoProvider implements BreadcrumbsProvider {
+  private static final Logger LOG = Logger.getInstance(DartBreadcrumbsInfoProvider.class);
+
+  @Override
+  public Language[] getLanguages() {
+    return new Language[]{DartLanguage.INSTANCE};
+  }
+
+  @Override
+  public boolean acceptElement(@NotNull PsiElement element) {
+    return (element instanceof DartComponent && ((DartComponent)element).getName() != null);
+  }
+
+  @Override
+  public @NotNull String getElementInfo(@NotNull PsiElement element) {
+    if (element instanceof DartComponent dartComponent) {
+      return Objects.requireNonNullElse(dartComponent.getName(), "");
+    }
+
+    LOG.warn("Unexpected element: " + element.getClass().getName());
+    return "";
+  }
+}


### PR DESCRIPTION
This commit adds basic breadcrumbs support for Dart language in the Dart plugin. It displays the basic breadcrumb information for the Dart files such as the class name, method name, and field name.