### PR TITLE
[Dart] Fold parameter lists that expand over a single line

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/folding/DartFoldingBuilder.java
+++ b/Dart/src/com/jetbrains/lang/dart/folding/DartFoldingBuilder.java
@@ -73,7 +73,8 @@ public final class DartFoldingBuilder extends CustomFoldingBuilder implements Du
       DartIfStatement.class,
       DartForStatement.class,
       DartWhileStatement.class,
-      DartDoWhileStatement.class);
+      DartDoWhileStatement.class,
+      DartFormalParameterList.class);
     foldComments(descriptors, psiElements, fileHeaderRange);                           // 4. Comments and comment sequences
     foldClassBodies(descriptors, dartFile);                                            // 5. Class bodies
     foldFunctionBodies(descriptors, psiElements);                                      // 6. Function bodies
@@ -91,6 +92,7 @@ public final class DartFoldingBuilder extends CustomFoldingBuilder implements Du
     foldAssertExpressions(descriptors, psiElements);                                   // 11. Assert statements
     foldIfStatements(descriptors, psiElements);                                        // 12.1. If statements
     foldLoopStatements(descriptors, psiElements);                                      // 12.2. For, while, do while statements
+    foldParameterLists(descriptors, psiElements);                                      // 13.  Parameter list
   }
 
   @Override
@@ -136,6 +138,7 @@ public final class DartFoldingBuilder extends CustomFoldingBuilder implements Du
     if (psiElement instanceof DartArguments) return PAREN_DOTS;                                  // 10.  Constructor invocations
     if (psiElement instanceof DartAssertStatement) return DOT_DOT_DOT;                           // 11.  Assert statements
     if (psiElement instanceof DartBlock) return BRACE_DOTS;                                      // 12.  Block statements
+    if (psiElement instanceof DartFormalParameterList) return PAREN_DOTS;                        // 13.  Parameter list
 
     return DOT_DOT_DOT;
   }
@@ -455,6 +458,19 @@ public final class DartFoldingBuilder extends CustomFoldingBuilder implements Du
 
       if (dartBlock != null && dartBlock.textContains('\n')) {
         descriptors.add(new FoldingDescriptor(dartBlock, dartBlock.getTextRange()));
+      }
+    }
+  }
+
+  private static void foldParameterLists(@NotNull final List<FoldingDescriptor> descriptors,
+                                         @NotNull final Collection<PsiElement> psiElements) {
+    for (PsiElement psiElement : psiElements) {
+      DartFormalParameterList paramList;
+      if (psiElement instanceof DartFormalParameterList) {
+        paramList = ((DartFormalParameterList)psiElement);
+        if(paramList.textContains('\n')) {
+          descriptors.add(new FoldingDescriptor(paramList, paramList.getTextRange()));
+        }
       }
     }
   }

--- a/Dart/testData/folding/DartFormalParameterList.dart
+++ b/Dart/testData/folding/DartFormalParameterList.dart
@@ -1,0 +1,40 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+library foo;
+
+class A <fold text='{...}' expand='true'>{
+int x, y, z;
+A(this.x, this.y, this.z);
+}</fold>
+
+class B <fold text='{...}' expand='true'>{
+int a, b, c, d, e;
+B<fold text='(...)' expand='true'>(
+this.a,
+this.b,
+this.c,
+this.d,
+this.e
+)</fold>;
+}</fold>
+
+class C <fold text='{...}' expand='true'>{
+int a, b, c, d, e;
+B<fold text='(...)' expand='true'>({
+this.a,
+this.b,
+this.c,
+this.d,
+this.e
+})</fold>;
+}</fold>
+
+class D <fold text='{...}' expand='true'>{
+int a, b, c, d, e;
+B<fold text='(...)' expand='true'>([
+this.a,
+this.b,
+this.c,
+this.d,
+this.e
+])</fold>;
+}</fold>

--- a/Dart/testSrc/com/jetbrains/lang/dart/folding/DartFoldingTest.java
+++ b/Dart/testSrc/com/jetbrains/lang/dart/folding/DartFoldingTest.java
@@ -157,4 +157,6 @@ public class DartFoldingTest extends DartCodeInsightFixtureTestCase {
   public void testCustomRegions() {
     doTest();
   }
+
+  public void testDartFormalParameterList() { doTest(); }
 }


### PR DESCRIPTION
@alexander-doroshko 

https://youtrack.jetbrains.com/issue/IDEA-328380/Dart-Unable-to-fold-multiline-method-signatures-calls-and-other-blocks