### PR TITLE
Add register service method for DTD

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -274,8 +274,8 @@ class DartToolingDaemonService private constructor(private val project: Project)
       //}
 
       // Example request to test registering a service method
-      registerServiceMethod("Test", "testMethod") {request ->
-        println(request)
+      registerServiceMethod("Test", "testMethod") {requestParams ->
+        println(requestParams)
         val params = JsonObject()
         params.addProperty("success", true)
         params

--- a/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonServiceConsumer.kt
+++ b/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonServiceConsumer.kt
@@ -1,0 +1,8 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.ide.toolingDaemon
+
+import com.google.gson.JsonObject
+
+fun interface DartToolingDaemonServiceConsumer {
+  fun received(request: JsonObject): JsonObject
+}


### PR DESCRIPTION
This is for enabling the Flutter plugin to register a service method for navigating to code, something that can be requested by a user from Flutter DevTools. More info on service methods: https://github.com/dart-lang/sdk/blob/main/pkg/dtd_impl/dtd_protocol.md#service-methods

Example DTD interactions in logs (comments for clarifying two-client interaction):
```
INFO - #c.j.l.d.i.d.DartDevToolsService - Starting Dart DevTools, sdk 3.5.0-321.0.dev
INFO - #c.j.l.d.i.t.DartToolingDaemonService - Connected to DTD successfully
FINE - #c.j.l.d.i.t.DartToolingDaemonService - --> {"jsonrpc":"2.0","method":"FileSystem.setIDEWorkspaceRoots","id":"1","params":{"roots":["file:///Users/helinx/IdeaProjects/hello_flutter_external/android","file:///Users/helinx/IdeaProjects/hello_flutter_external"],"secret":"qzgLfkLrkpov0FXC"}}
// client 1 registers service
FINE - #c.j.l.d.i.t.DartToolingDaemonService - --> {"jsonrpc":"2.0","method":"registerService","id":"2","params":{"service":"Test","method":"testMethod"}}
FINE - #c.j.l.d.i.t.DartToolingDaemonService - <-- {"jsonrpc":"2.0","result":{"type":"Success"},"id":"1"}
FINE - #c.j.l.d.i.t.DartToolingDaemonService - <-- {"jsonrpc":"2.0","result":{"type":"Success"},"id":"2"}

// client 2 calls service method
FINE - #c.j.l.d.i.t.DartToolingDaemonService - --> {"jsonrpc":"2.0","method":"Test.testMethod","id":"3","params":{"param1":"1"}}

// client 1 receives service method request
FINE - #c.j.l.d.i.t.DartToolingDaemonService - <-- {"jsonrpc":"2.0","method":"Test.testMethod","id":0,"params":{"param1":"1"}}

// client 1 sends service method response
FINE - #c.j.l.d.i.t.DartToolingDaemonService - --> {"jsonrpc":"2.0","id":"0","result":{"success":true}}

// client 2 receives response
FINE - #c.j.l.d.i.t.DartToolingDaemonService - <-- {"jsonrpc":"2.0","result":{"success":true},"id":"3"}
```