### PR TITLE
Add capabilities and modified error response for DTD service methods

### DIFF
--- a/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonRequestHandler.kt
+++ b/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonRequestHandler.kt
@@ -3,6 +3,8 @@ package com.jetbrains.lang.dart.ide.toolingDaemon
 
 import com.google.gson.JsonObject
 
+class DartToolingDaemonResponse(var result: JsonObject?, var error: JsonObject?)
+
 fun interface DartToolingDaemonRequestHandler {
-  fun handleRequest(request: JsonObject): JsonObject
+  fun handleRequest(request: JsonObject): DartToolingDaemonResponse
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -108,10 +108,11 @@ class DartToolingDaemonService private constructor(private val project: Project)
   }
 
   @Suppress("unused") // for the Flutter plugin
-  fun registerServiceMethod(service: String, method: String, consumer: DartToolingDaemonRequestHandler) {
+  fun registerServiceMethod(service: String, method: String, capabilities: JsonObject, consumer: DartToolingDaemonRequestHandler) {
     val params = JsonObject()
     params.addProperty("service", service)
     params.addProperty("method", method)
+    params.add("capabilities", capabilities)
     sendRequest("registerService", params, false) { response ->
       val result = response.getAsJsonObject("result")
       if (result == null) {
@@ -152,7 +153,7 @@ class DartToolingDaemonService private constructor(private val project: Project)
     webSocket.send(requestString)
   }
 
-  private fun sendResponse(id: String, result: JsonObject) {
+  private fun sendResponse(id: String, result: JsonObject?, error: JsonObject? = null) {
     if (!webSocketReady) {
       logger.warn("sendResponse(\"$id\", $result) called when the socket is not ready")
       return
@@ -161,7 +162,11 @@ class DartToolingDaemonService private constructor(private val project: Project)
     val response = JsonObject()
     response.addProperty("jsonrpc", "2.0")
     response.addProperty("id", id)
-    response.add("result", result)
+    if (error == null) {
+      response.add("result", result)
+    } else {
+      response.add("error", error)
+    }
 
     val responseString = response.toString()
     logger.debug("--> $responseString")
@@ -280,12 +285,12 @@ class DartToolingDaemonService private constructor(private val project: Project)
       //}
 
       // Example request to test registering a service method
-      /*
-      registerServiceMethod("Test", "testMethod") { requestParams ->
+      ///*
+      registerServiceMethod("Test", "testMethod", JsonObject()) { requestParams ->
         println(requestParams)
         val params = JsonObject()
         params.addProperty("success", true)
-        params
+        DartToolingDaemonResponse(params, null)
       }
 
       // Try using the service method
@@ -294,7 +299,22 @@ class DartToolingDaemonService private constructor(private val project: Project)
       sendRequest("Test.testMethod", methodParams, false) { response ->
         println(response)
       }
-      */
+
+      registerServiceMethod("Test", "testErrorMethod", JsonObject()) { requestParams ->
+        println(requestParams)
+        val params = JsonObject()
+        params.addProperty("code", 144)
+        params.addProperty("message", "This is an error")
+        DartToolingDaemonResponse(null, params)
+      }
+
+      // Try using the service method
+      val methodParams2 = JsonObject()
+      methodParams2.addProperty("param1", "1")
+      sendRequest("Test.testErrorMethod", methodParams2, false) { response ->
+        println(response)
+      }
+      //*/
     }
 
     override fun onMessage(message: WebSocketMessage) {
@@ -320,8 +340,8 @@ class DartToolingDaemonService private constructor(private val project: Project)
         val params = json["params"].asJsonObject
         val id = json["id"].asString
         ApplicationManager.getApplication().executeOnPooledThread {
-          val result = serviceConsumer.handleRequest(params)
-          sendResponse(id, result)
+          val response = serviceConsumer.handleRequest(params)
+          sendResponse(id, response.result, response.error)
         }
       }
       else {

--- a/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/Dart/src/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -285,7 +285,7 @@ class DartToolingDaemonService private constructor(private val project: Project)
       //}
 
       // Example request to test registering a service method
-      ///*
+      /*
       registerServiceMethod("Test", "testMethod", JsonObject()) { requestParams ->
         println(requestParams)
         val params = JsonObject()
@@ -314,7 +314,7 @@ class DartToolingDaemonService private constructor(private val project: Project)
       sendRequest("Test.testErrorMethod", methodParams2, false) { response ->
         println(response)
       }
-      //*/
+      */
     }
 
     override fun onMessage(message: WebSocketMessage) {


### PR DESCRIPTION
We did some work to standardize how DTD service methods and their responses should look in: https://github.com/dart-lang/sdk/blob/main/pkg/dtd_impl/dtd_common_services.md#responses

This change is to make the Dart plugin compatible with those changes when registering service methods.

Oddly, it seems I get a `data` section (with original request info) in the response, but I'm not sure where that's being added in the code:

```
{
  "jsonrpc": "2.0",
  "error": {
    "code": 144,
    "message": "This is an error",
    "data": {
      "request": {
        "jsonrpc": "2.0",
        "method": "Test.testErrorMethod",
        "id": "5",
        "params": {
          "param1": "1"
        }
      }
    }
  },
  "id": "5"
}
```