### PR TITLE
Dart plugin config fix

### DIFF
--- a/Dart/Dart-community.iml
+++ b/Dart/Dart-community.iml
@@ -69,4 +69,6 @@
       </library>
     </orderEntry>
   </component>
+  <orderEntry type="module" module-name="intellij.javascript.debugger" />
+  <orderEntry type="module" module-name="intellij.platform.testFramework" scope="TEST" />
 </module>

--- a/Dart/README.md
+++ b/Dart/README.md
@@ -42,30 +42,32 @@ Prerequisites:
    (`intellij` > `idea` > `community` > `main`), click `[+]` and add a module
    dependency on the `Dart-community` module.
 
-4. Open Settings (Preferences) | Version Control | Directory Mappings and add `intellij-plugins` as a 3rd Git root if it's not already there.
+4. Install the "JavaScriptDebugger" plugin, then [add its JAR file to the project SDK's classpath](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#plugin-devkit)
 
-5. The project is ready to use. Use `IDEA` run configuration to start IntelliJ IDEA Community Edition + Dart Plugin from sources.
+5. Open Settings (Preferences) | Version Control | Directory Mappings and add `intellij-plugins` as a 3rd Git root if it's not already there.
 
-6. In order to be able to run tests that use real Dart Analysis Server, do the following:
+6. The project is ready to use. Use `IDEA` run configuration to start IntelliJ IDEA Community Edition + Dart Plugin from sources.
+
+7. In order to be able to run tests that use real Dart Analysis Server, do the following:
    - Make sure you have Dart SDK installed locally. It can be downloaded from the [Dart SDK Archive](https://dart.dev/tools/sdk/archive).
    - Open `Run | Edit Configurations...` dialog.
    - Click `Edit configuration templates...` in the bottom-left corner.
    - Find `JUnit` and add Dart SDK path to the VM Options field like this: `-Ddart.sdk=path/to/real/dart/sdk`. 
      VM Options field is the one that has only `-ea` text by default.
 
-7. To run all Dart plugin tests, right-click the `Dart/testSrc` folder in the Project View and select 'Run all tests'.
+8. To run all Dart plugin tests, right-click the `Dart/testSrc` folder in the Project View and select 'Run all tests'.
    - To run only those tests that do not use real Dart Analysis Server, use context menu of the `Dart/testSrc/com/jetbrains/lang/dart` folder.
      (At the moment of writing, 3 of them are expected to fail: `DartInjectionTest.testRegExp()`, `DartHighlightingTest.testSimplePolymer()`, 
      and `DartHighlightingTest.testScriptSrcPathToPackagesFolder()`.)
    - Tests that use real Dart Analysis Server reside in the `Dart/testSrc/com.jetbrains.dart/analysisServer` folder.
      A few of them are expected to fail.
 
-8. [Optional] To enable internal developer actions add "idea.is.internal=true"
+9. [Optional] To enable internal developer actions add "idea.is.internal=true"
    to the idea.properties file (Help -> Edit Custom Properties...). The menu actions Tools ->
    View PSI Structure... as well as the Tools -> Internal Actions should be
    visible after restarting.
 
-9. Enjoy! All functionality should work. Most of the tests should pass.
+10. Enjoy! All functionality should work. Most of the tests should pass.
    Zero mandatory local changes in `intellij-plugins` repository.
    There should be 3 locally changed files in `intellij-community` repository, each having exactly one added line,
    just keep these files in a separate '~never commit' changelist and do not worry about them:


### PR DESCRIPTION
I'm not really sure if there's another intended way how to get this project to build that I'm missing, but following the current instructions alone fails during the build step.

After adding the plugin to classpath, the IDE still marks the overrides as invalid - although auto-generating them results in identical signatures, so I guess it's just related to where the types referenced in each are defined.