### PR TITLE
Allow using "@" (at sign) in Gherkin step names

### DIFF
--- a/cucumber/src/org/jetbrains/plugins/cucumber/psi/GherkinLexer.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/psi/GherkinLexer.java
@@ -177,7 +177,7 @@ public class GherkinLexer extends LexerBase {
       myCurrentToken = GherkinTokenTypes.COLON;
       myPosition++;
     }
-    else if (c == '@') {
+    else if (c == '@' && myState != STATE_AFTER_STEP_KEYWORD) {
       myCurrentToken = GherkinTokenTypes.TAG;
       myPosition++;
       while (myPosition < myEndOffset && isValidTagChar(myBuffer.charAt(myPosition))) {

--- a/cucumber/test/org/jetbrains/plugins/cucumber/psi/GherkinLexerTest.java
+++ b/cucumber/test/org/jetbrains/plugins/cucumber/psi/GherkinLexerTest.java
@@ -172,6 +172,17 @@ public class GherkinLexerTest extends TestCase {
     );
   }
 
+  public void testAtSignInStepName() {
+    doTest(
+      """
+        Feature: test
+          Scenario: test
+            Given @Team is a child of the group @Class""",
+      "FEATURE_KEYWORD:0-7", "COLON:7-8", "WHITE_SPACE:8-9", "TEXT:9-13", "WHITE_SPACE:13-16", "SCENARIO_KEYWORD:16-24",
+      "COLON:24-25", "WHITE_SPACE:25-26", "TEXT:26-30", "WHITE_SPACE:30-35", "STEP_KEYWORD:35-40", "WHITE_SPACE:40-41", "TEXT:41-77"
+    );
+  }
+
   private static void doTest(String text, String... expectedTokens) {
     Lexer lexer = new GherkinLexer(new MockGherkinKeywordProvider());
     lexer.start(text);


### PR DESCRIPTION
This will allow steps like 'And @Group is a child of @ParentGroup' for those who use such custom syntax for variables in tests.
Note: It doesn't contradict with Gherkin specifications as Gherkin tags (which have the similar syntax) are not allowed inside test steps.