### PR TITLE
[Dart] Add 'Sort Members in Dart Code' to project view action menu

### DIFF
--- a/Dart/resources/META-INF/plugin.xml
+++ b/Dart/resources/META-INF/plugin.xml
@@ -297,6 +297,7 @@
     </action>
     <action id="Dart.DartSortMembers" class="com.jetbrains.lang.dart.ide.actions.DartSortMembersAction">
       <add-to-group group-id="CodeFormatGroup" anchor="after" relative-to-action="Dart.DartStyle"/>
+      <add-to-group group-id="ProjectViewPopupMenuModifyGroup" anchor="after" relative-to-action="Dart.DartStyle"/>
     </action>
     <!--<action id="Dart.DartFix" class="com.jetbrains.lang.dart.ide.actions.DartFixAction"/>-->
     <action id="Generate.Constructor.Dart" class="com.jetbrains.lang.dart.ide.generation.DartGenerateConstructorAction">

--- a/Dart/resources/messages/DartBundle.properties
+++ b/Dart/resources/messages/DartBundle.properties
@@ -270,8 +270,8 @@ issue.occurred.with.analysis.server=an issue occurred with the analysis server
 
 action.Dart.DartSortMembers.text=Sort Members in Dart File
 action.Dart.DartSortMembers.description=Sort members in your Dart code
-action.Dart.DartSortMembers.progress.title=Sorting members in Dart file\u2026
-dart.sort.members.action.name.ellipsis=Sort Members in Dart files\u2026
+action.Dart.DartSortMembers.progress.title=Sorting members in Dart code\u2026
+dart.sort.members.action.name.ellipsis=Sort Members in Dart code\u2026
 dart.sort.members.hint.failed=Failed to sort members
 dart.sort.members.hint.already.good=Sort members: members already sorted
 dart.sort.members.hint.success=The code has been successfully sorted
@@ -295,7 +295,7 @@ code.style.settings.label.line.length=&Line length:
 action.Dart.DartFix.text=Run 'dart fix'
 # suppress inspection "UnusedProperty" -- used by DartFixAction, which is temporarily commented out in plugin.xml
 action.Dart.DartFix.description=Run 'dart fix' to fix and migrate the Dart sources
-dart.fix.action.name.ellipsis=Fix Code with dartfix\u2026
+dart.fix.action.name.ellipsis=Fix Code with 'dart fix'\u2026
 
 failed.to.create.file.0.1=Failed to create file {0}:\n{1}
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartFixAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartFixAction.java
@@ -26,7 +26,8 @@ public class DartFixAction extends AbstractDartFileProcessingAction {
   @NotNull
   @Override
   protected String getActionTextForFiles() {
-    return DartBundle.message("dart.fix.action.name.ellipsis"); // because with dialog
+    // Use ellipsis version of action name due to opening confirmation dialog.
+    return DartBundle.message("dart.fix.action.name.ellipsis");
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartSortMembersAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartSortMembersAction.java
@@ -41,7 +41,8 @@ public class DartSortMembersAction extends AbstractDartFileProcessingAction {
   @NotNull
   @Override
   protected String getActionTextForFiles() {
-    return DartBundle.message("dart.sort.members.action.name.ellipsis"); // because with dialog
+    // Use ellipsis version of action name due to opening confirmation dialog.
+    return DartBundle.message("dart.sort.members.action.name.ellipsis");
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartStyleAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartStyleAction.java
@@ -50,7 +50,8 @@ public class DartStyleAction extends AbstractDartFileProcessingAction {
   @NotNull
   @Override
   protected String getActionTextForFiles() {
-    return DartBundle.message("dart.style.action.name.ellipsis"); // because with dialog
+    // Use ellipsis version of action name due to opening confirmation dialog.
+    return DartBundle.message("dart.style.action.name.ellipsis");
   }
 
   @Override


### PR DESCRIPTION
Working on Dart projects that rely on member sorting, this enables much quicker access to the sort member functionality from the project view's action menu.

This PR also adjusts the text to "Sort Members in Dart code" rather than files as it can show up when selecting one or many files. It also aligns better with the the formatting action's text.

\cc @jwren 