### PR TITLE
adds `hashicorp/assert` to list of official providers

### DIFF
--- a/terraform/metadata-crawler/src/main/resources/official-providers.list
+++ b/terraform/metadata-crawler/src/main/resources/official-providers.list
@@ -1,5 +1,6 @@
 hashicorp/ad
 hashicorp/archive
+hashicorp/assert
 hashicorp/aws
 hashicorp/awscc
 hashicorp/azuread


### PR DESCRIPTION
Hey JetBrains folks 👋🏼 

Kerim here, big fan of the Terraform plugin inside GoLand.

I wanted to update this list with the Assert provider @bschaatsbergen and others maintain at https://registry.terraform.io/providers/hashicorp/assert/latest.

Hope this PR makes sense!