### PR TITLE
Initial commit for issue WEB-7671 Allow Handlebars/Mustache expression delimiters to be changed from the defaults

### DIFF
--- a/handlebars/src/com/dmarcotte/handlebars/config/HbConfig.java
+++ b/handlebars/src/com/dmarcotte/handlebars/config/HbConfig.java
@@ -11,6 +11,14 @@ import org.jetbrains.annotations.Nullable;
 import static com.dmarcotte.handlebars.config.Property.*;
 
 public final class HbConfig {
+  public static String getCustomDelimiters() {
+    return getStringPropertyValue(Property.CUSTOM_DELIMITERS);
+  }
+
+  public static void setCustomDelimiters(String delimiters) {
+    setStringPropertyValue(Property.CUSTOM_DELIMITERS, delimiters);
+  }
+
 
   public static boolean isAutoGenerateCloseTagEnabled() {
     return getBooleanPropertyValue(AUTO_GENERATE_CLOSE_TAG);

--- a/handlebars/src/com/dmarcotte/handlebars/config/Property.java
+++ b/handlebars/src/com/dmarcotte/handlebars/config/Property.java
@@ -8,6 +8,21 @@ import org.jetbrains.annotations.NotNull;
  * Formalizes the properties which we will persist using {@link com.intellij.ide.util.PropertiesComponent}
  */
 enum Property {
+  CUSTOM_DELIMITERS {
+    @Override
+    public @NotNull String getStringName() {
+      return "handlebars.custom.delimiters";
+    }
+
+    @Override
+    public @NotNull String getDefault() {
+      return ""; // Default is empty string (no custom delimiters)
+    }
+
+    public static final String ENABLED = "enabled";
+    public static final String DISABLED = "disabled";
+  },
+
   AUTO_GENERATE_CLOSE_TAG {
     @Override
     public @NotNull String getStringName() {


### PR DESCRIPTION
Trying to finish this enhancement as it it would help very many companies and teams i (including mine)

As it is normal practice to use a custom delimiter for "first pass" hydration and reserve "{{ }}" mustache templates for second pass. Also people have requested "{% %}". This PR will allow one or more custom delimiters to be used and no longer considered error in the file they are embedded in