### PR TITLE
[Dart] Require Dart 2.12 or later

### DIFF
--- a/Dart/resources/messages/DartBundle.properties
+++ b/Dart/resources/messages/DartBundle.properties
@@ -109,7 +109,6 @@ runner.web.app.configuration.name=Dart Web App
 command.line.run.config.label.dart.file=Dart &file:
 command.line.run.config.label.vm.options=&VM options:
 command.line.run.config.checkbox.enable.asserts=E&nable asserts
-command.line.run.config.checkbox.checked.mode=Checked mode
 command.line.run.config.label.program.arguments=Program a&rguments:
 command.line.run.config.label.working.directory=&Working directory:
 
@@ -125,7 +124,6 @@ webdev.debug.configuration.description=Start Dart web application using the webd
 web.run.config.label.html.file=HTML &file:
 web.run.config.label.webdev.port=Webdev &port:
 choose.html.main.file=Choose HTML File
-old.dart.sdk.for.webdev=Dart SDK {0}+ is required for debugging a Dart web app using webdev, current version: {1}
 
 dart.project.description=Create project for use with the Dart programming language
 project.template.not.selected=Project template is not selected
@@ -144,7 +142,6 @@ working.dir.0=Working dir: {0}
 dart.pub.get.title=Pub Get
 dart.pub.upgrade.title=Pub Upgrade
 dart.pub.outdated.title=Pub Outdated
-dart.pub.build.title=Pub Build
 dart.webdev.build.title=Webdev Build
 dart.pub.cache.repair.title=Pub Repair Cache
 dart.pub.cache.repair.message=<html>The <a href='https://dart.dev/tools/pub/cmd/pub-cache'>pub cache repair</a> command performs a clean reinstall<br/>of all hosted and git packages in the system cache.<br/><br/>Start cache repair?</html>
@@ -347,8 +344,6 @@ action.Dart.stop.dart.webdev.server.description=Stop Dart Webdev Server
 action.DartCopyDtdUriAction.text=Dart: Copy DTD URI to Clipboard
 action.DartCopyDtdUriAction.description=Copy Dart Tooling Daemon URI to clipboard
 
-action.description.run.pub.build=Run 'pub build'
-action.text.pub.build=Pub Build\u2026
 action.text.webdev.build=Webdev Build\u2026
 action.description.run.webdev.build=Run 'webdev build'
 border.breaking.policy=Breaking Policy
@@ -396,7 +391,6 @@ filetype.dart.description=Dart
 validation.info.input.and.output.folders.must.be.different=Input and output folders must be different
 validation.info.output.folder.not.specified=Output folder not specified
 validation.info.input.folder.not.specified=Input folder not specified
-validation.info.build.mode.not.specified=Build mode not specified
 button.browse.dialog.title.output.folder=Output Folder
 button.text.build2=Build
 action.title.dart.rename.refactoring=Dart Rename Refactoring

--- a/Dart/src/com/jetbrains/lang/dart/DartFileListener.java
+++ b/Dart/src/com/jetbrains/lang/dart/DartFileListener.java
@@ -38,7 +38,7 @@ import com.jetbrains.lang.dart.sdk.DartPackagesLibraryProperties;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
-import com.jetbrains.lang.dart.util.DotPackagesFileUtil;
+import com.jetbrains.lang.dart.util.PackageConfigFileUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,10 +68,8 @@ public final class DartFileListener implements AsyncFileListener {
 
       if (event instanceof VFilePropertyChangeEvent) {
         if (((VFilePropertyChangeEvent)event).isRename()) {
-          if (DotPackagesFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getOldValue()) ||
-              DotPackagesFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getNewValue()) ||
-              DotPackagesFileUtil.DOT_PACKAGES.equals(((VFilePropertyChangeEvent)event).getOldValue()) ||
-              DotPackagesFileUtil.DOT_PACKAGES.equals(((VFilePropertyChangeEvent)event).getNewValue())) {
+          if (PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getOldValue()) ||
+              PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getNewValue())) {
             packagesFileEvents.add(event);
           }
 
@@ -82,8 +80,7 @@ public final class DartFileListener implements AsyncFileListener {
         }
       }
       else {
-        if (DotPackagesFileUtil.PACKAGE_CONFIG_JSON.equals(PathUtil.getFileName(event.getPath())) ||
-            DotPackagesFileUtil.DOT_PACKAGES.equals(PathUtil.getFileName(event.getPath()))) {
+        if (PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(PathUtil.getFileName(event.getPath()))) {
           packagesFileEvents.add(event);
         }
 
@@ -137,15 +134,9 @@ public final class DartFileListener implements AsyncFileListener {
       if (module == null || !DartSdkLibUtil.isDartSdkEnabled(module)) continue;
 
       Map<String, String> packagesMap = null;
-      VirtualFile packagesFile = DotPackagesFileUtil.findPackageConfigJsonFile(pubspecFile.getParent());
+      VirtualFile packagesFile = PackageConfigFileUtil.findPackageConfigJsonFile(pubspecFile.getParent());
       if (packagesFile != null) {
-        packagesMap = DotPackagesFileUtil.getPackagesMapFromPackageConfigJsonFile(packagesFile);
-      }
-      else {
-        packagesFile = DotPackagesFileUtil.findDotPackagesFile(pubspecFile.getParent());
-        if (packagesFile != null) {
-          packagesMap = DotPackagesFileUtil.getPackagesMap(packagesFile);
-        }
+        packagesMap = PackageConfigFileUtil.getPackagesMapFromPackageConfigJsonFile(packagesFile);
       }
 
       if (packagesMap != null) {
@@ -358,7 +349,7 @@ public final class DartFileListener implements AsyncFileListener {
           if (file == null) continue;
 
           VirtualFile dartRoot = file.getParent();
-          if (dartRoot != null && file.getName().equals(DotPackagesFileUtil.PACKAGE_CONFIG_JSON)) {
+          if (dartRoot != null && file.getName().equals(PackageConfigFileUtil.PACKAGE_CONFIG_JSON)) {
             dartRoot = dartRoot.getParent();
           }
           VirtualFile pubspec = dartRoot == null ? null : dartRoot.findChild(PUBSPEC_YAML);

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartEditorNotificationsProvider.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartEditorNotificationsProvider.java
@@ -14,7 +14,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -53,7 +52,7 @@ public final class DartEditorNotificationsProvider implements EditorNotification
 
       final DartSdk sdk = DartSdk.getDartSdk(project);
       if (sdk != null && DartSdkLibUtil.isDartSdkEnabled(module)) {
-        return fileEditor -> new PubActionsPanel(fileEditor, sdk);
+        return fileEditor -> new PubActionsPanel(fileEditor);
       }
     }
 
@@ -116,14 +115,11 @@ public final class DartEditorNotificationsProvider implements EditorNotification
   }
 
   private static final class PubActionsPanel extends EditorNotificationPanel {
-    private PubActionsPanel(@NotNull FileEditor fileEditor, @NotNull DartSdk sdk) {
+    private PubActionsPanel(@NotNull FileEditor fileEditor) {
       super(fileEditor, null, EditorColors.GUTTER_BACKGROUND, Status.Info);
       createActionLabel(DartBundle.message("pub.get"), "Dart.pub.get");
       createActionLabel(DartBundle.message("pub.upgrade"), "Dart.pub.upgrade");
-
-      if (StringUtil.compareVersionNumbers(sdk.getVersion(), DartPubOutdatedAction.MIN_SDK_VERSION) >= 0) {
-        createActionLabel(DartBundle.message("pub.outdated"), "Dart.pub.outdated");
-      }
+      createActionLabel(DartBundle.message("pub.outdated"), "Dart.pub.outdated");
 
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
       createActionLabel(DartBundle.message("webdev.build"), "Dart.build");

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
@@ -36,7 +36,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.NlsContexts
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowId
@@ -105,8 +104,7 @@ abstract class DartPubActionBase : AnAction(), DumbAware {
 
     if (sdk == null) return
 
-    val useDartPub = StringUtil.compareVersionNumbers(sdk.version, DART_PUB_MIN_SDK_VERSION) >= 0
-    val exeFile = if (useDartPub) File(DartSdkUtil.getDartExePath(sdk)) else File(DartSdkUtil.getPubPath(sdk))
+    val exeFile = File(DartSdkUtil.getDartExePath(sdk))
 
     if (!exeFile.isFile) {
       if (allowModalDialogs) {
@@ -186,25 +184,12 @@ abstract class DartPubActionBase : AnAction(), DumbAware {
     private const val GROUP_DISPLAY_ID: @NonNls String = "Dart Pub Tool"
     private val PUB_TOOL_WINDOW_CONTENT_INFO_KEY = Key.create<PubToolWindowContentInfo>("PUB_TOOL_WINDOW_CONTENT_INFO_KEY")
 
-    private const val DART_PUB_MIN_SDK_VERSION = "2.10"
-    private const val DART_RUN_TEST_MIN_SDK_VERSION = "2.11"
-
     private val ourInProgress = AtomicBoolean(false)
 
     @JvmStatic
-    fun isUseDartRunTestInsteadOfPubRunTest(dartSdk: DartSdk): Boolean =
-      StringUtil.compareVersionNumbers(dartSdk.version, DART_RUN_TEST_MIN_SDK_VERSION) >= 0
-
-    @JvmStatic
     fun setupPubExePath(commandLine: GeneralCommandLine, dartSdk: DartSdk) {
-      val useDartPub = StringUtil.compareVersionNumbers(dartSdk.version, DART_PUB_MIN_SDK_VERSION) >= 0
-      if (useDartPub) {
-        commandLine.withExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(dartSdk)))
-        commandLine.addParameter("pub")
-      }
-      else {
-        commandLine.withExePath(FileUtil.toSystemDependentName(DartSdkUtil.getPubPath(dartSdk)))
-      }
+      commandLine.withExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(dartSdk)))
+      commandLine.addParameter("pub")
     }
 
     @JvmStatic

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubBuildAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubBuildAction.java
@@ -17,23 +17,15 @@ public class DartPubBuildAction extends DartPubActionBase {
   @Override
   public void update(@NotNull AnActionEvent e) {
     super.update(e);
-    final Project project = e.getProject();
-    if (project != null && DartWebdev.INSTANCE.useWebdev(DartSdk.getDartSdk(project))) {
-      e.getPresentation().setText(DartBundle.message("action.text.webdev.build"));
-      e.getPresentation().setDescription(DartBundle.message("action.description.run.webdev.build"));
-    }
-    else {
-      e.getPresentation().setText(DartBundle.message("action.text.pub.build"));
-      e.getPresentation().setDescription(DartBundle.message("action.description.run.pub.build"));
-    }
+    e.getPresentation().setText(DartBundle.message("action.text.webdev.build"));
+    e.getPresentation().setDescription(DartBundle.message("action.description.run.webdev.build"));
   }
 
   @Override
   protected @NotNull @NlsContexts.DialogTitle String getTitle(final @NotNull Project project, final @NotNull VirtualFile pubspecYamlFile) {
     final String projectName = PubspecYamlUtil.getDartProjectName(pubspecYamlFile);
     final String prefix = projectName == null ? "" : ("[" + projectName + "] ");
-    return prefix + DartBundle
-      .message(DartWebdev.INSTANCE.useWebdev(DartSdk.getDartSdk(project)) ? "dart.webdev.build.title" : "dart.pub.build.title");
+    return prefix + DartBundle.message("dart.webdev.build.title");
   }
 
   @Override
@@ -47,12 +39,8 @@ public class DartPubBuildAction extends DartPubActionBase {
     final DartSdk sdk = DartSdk.getDartSdk(project);
     if (sdk == null) return null; // can't happen, already checked
 
-    if (DartWebdev.INSTANCE.useWebdev(sdk)) {
-      if (!DartWebdev.INSTANCE.ensureWebdevActivated(project)) return null;
+    if (!DartWebdev.INSTANCE.ensureWebdevActivated(project)) return null;
 
-      return new String[]{"global", "run", "webdev", "build", "--output=" + dialog.getInputFolder() + ":" + dialog.getOutputFolder()};
-    }
-
-    return new String[]{"build", "--mode=" + dialog.getPubBuildMode(), "--output=" + dialog.getOutputFolder()};
+    return new String[]{"global", "run", "webdev", "build", "--output=" + dialog.getInputFolder() + ":" + dialog.getOutputFolder()};
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubBuildDialog.form
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubBuildDialog.form
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.jetbrains.lang.dart.ide.actions.DartPubBuildDialog">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="339" height="227"/>
+      <xy x="20" y="20" width="350" height="101"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <vspacer id="5e117">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="15373" class="com.intellij.ui.components.JBLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelFor value="7a153"/>
@@ -24,76 +24,16 @@
       </component>
       <component id="7a153" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myOutputFolderField">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="250" height="-1"/>
           </grid>
         </constraints>
         <properties/>
       </component>
-      <grid id="3e5c3" binding="myBuildModePanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="205e" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="10d13" class="com.intellij.ui.components.JBLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="messages/DartBundle" key="dart.build.dialog.label.build.mode"/>
-            </properties>
-          </component>
-          <component id="a895c" class="com.intellij.ui.components.JBRadioButton" binding="myDebugRadioButton">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="messages/DartBundle" key="dart.build.dialog.radio.button.debug"/>
-            </properties>
-          </component>
-          <component id="2906a" class="com.intellij.ui.components.JBRadioButton" binding="myOtherRadioButton">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="messages/DartBundle" key="dart.build.dialog.radio.button.other"/>
-            </properties>
-          </component>
-          <component id="6345e" class="javax.swing.JTextField" binding="myOtherModeTextField">
-            <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
-          <vspacer id="be575">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-                <minimum-size width="-1" height="10"/>
-                <preferred-size width="-1" height="10"/>
-                <maximum-size width="-1" height="10"/>
-              </grid>
-            </constraints>
-          </vspacer>
-          <component id="7565d" class="com.intellij.ui.components.JBRadioButton" binding="myReleaseRadioButton">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <selected value="true"/>
-              <text resource-bundle="messages/DartBundle" key="dart.build.dialog.radio.button.release"/>
-            </properties>
-          </component>
-        </children>
-      </grid>
-      <grid id="205e" binding="myInputFolderPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
         </constraints>
         <properties/>
         <border type="none"/>

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubBuildDialog.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubBuildDialog.java
@@ -12,26 +12,13 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.wm.IdeFocusManager;
-import com.intellij.ui.components.JBRadioButton;
 import com.jetbrains.lang.dart.DartBundle;
-import com.jetbrains.lang.dart.pubServer.DartWebdev;
-import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.awt.event.ActionListener;
 
 public class DartPubBuildDialog extends DialogWrapper {
-
-  private static final String DART_PUB_BUILD_MODE_KEY = "DART_PUB_BUILD_MODE";
-  private static final String DART_PUB_CUSTOM_BUILD_MODE_KEY = "DART_PUB_CUSTOM_BUILD_MODE";
-
-  private static final String RELEASE_MODE = "release";
-  private static final String DEBUG_MODE = "debug";
-  private static final String OTHER_MODE = "other";
-  private static final String DEFAULT_MODE = RELEASE_MODE;
 
   private static final String DART_BUILD_INPUT_KEY = "DART_BUILD_INPUT_KEY";
   private static final String DEFAULT_INPUT_FOLDER = "web";
@@ -39,37 +26,19 @@ public class DartPubBuildDialog extends DialogWrapper {
   private static final String DEFAULT_OUTPUT_FOLDER = "build";
 
   private JPanel myMainPanel;
-  private JPanel myBuildModePanel;
-  private JBRadioButton myReleaseRadioButton;
-  private JBRadioButton myDebugRadioButton;
-  private JBRadioButton myOtherRadioButton;
-  private JTextField myOtherModeTextField;
 
-  private JPanel myInputFolderPanel;
   private JTextField myInputFolderTextField;
 
   private TextFieldWithBrowseButton myOutputFolderField;
 
   private final @NotNull Project myProject;
-  private final boolean myUseWebdev;
 
   public DartPubBuildDialog(final @NotNull Project project, final @NotNull VirtualFile packageDir) {
     super(project);
     myProject = project;
 
-    myUseWebdev = DartWebdev.INSTANCE.useWebdev(DartSdk.getDartSdk(project));
-    setTitle(DartBundle.message(myUseWebdev ? "dart.webdev.build.title" : "dart.pub.build.title"));
+    setTitle(DartBundle.message("dart.webdev.build.title"));
     setOKButtonText(DartBundle.message("button.text.build2"));
-
-    final ActionListener listener = e -> updateControls();
-    myReleaseRadioButton.addActionListener(listener);
-    myDebugRadioButton.addActionListener(listener);
-    myOtherRadioButton.addActionListener(listener);
-    myOtherRadioButton.addActionListener(e -> {
-      if (myOtherRadioButton.isSelected()) {
-        IdeFocusManager.getInstance(myProject).requestFocus(myOtherModeTextField, true);
-      }
-    });
 
     var packagePathSlash = FileUtil.toSystemDependentName(packageDir.getPath() + "/");
     myOutputFolderField.addBrowseFolderListener(
@@ -103,34 +72,8 @@ public class DartPubBuildDialog extends DialogWrapper {
   private void reset() {
     final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(myProject);
 
-    if (myUseWebdev) {
-      myBuildModePanel.setVisible(false);
-      myInputFolderTextField.setText(propertiesComponent.getValue(DART_BUILD_INPUT_KEY, DEFAULT_INPUT_FOLDER));
-    }
-    else {
-      myInputFolderPanel.setVisible(false);
-
-      final String mode = propertiesComponent.getValue(DART_PUB_BUILD_MODE_KEY, DEFAULT_MODE);
-      if (mode.equals(RELEASE_MODE)) {
-        myReleaseRadioButton.setSelected(true);
-      }
-      else if (mode.equals(DEBUG_MODE)) {
-        myDebugRadioButton.setSelected(true);
-      }
-      else {
-        myOtherRadioButton.setSelected(true);
-      }
-
-      myOtherModeTextField.setText(propertiesComponent.getValue(DART_PUB_CUSTOM_BUILD_MODE_KEY, ""));
-    }
-
+    myInputFolderTextField.setText(propertiesComponent.getValue(DART_BUILD_INPUT_KEY, DEFAULT_INPUT_FOLDER));
     myOutputFolderField.setText(propertiesComponent.getValue(DART_BUILD_OUTPUT_KEY, DEFAULT_OUTPUT_FOLDER));
-
-    updateControls();
-  }
-
-  private void updateControls() {
-    myOtherModeTextField.setEnabled(myOtherRadioButton.isSelected());
   }
 
   @Override
@@ -139,18 +82,8 @@ public class DartPubBuildDialog extends DialogWrapper {
   }
 
   @Override
-  public @Nullable JComponent getPreferredFocusedComponent() {
-    if (myOtherRadioButton.isSelected()) return myOtherModeTextField;
-    return null;
-  }
-
-  @Override
   protected @Nullable ValidationInfo doValidate() {
-    if (!myUseWebdev && myOtherRadioButton.isSelected() && StringUtil.isEmptyOrSpaces(myOtherModeTextField.getText())) {
-      return new ValidationInfo(DartBundle.message("validation.info.build.mode.not.specified"));
-    }
-
-    if (myUseWebdev && myInputFolderTextField.getText().trim().isEmpty()) {
+    if (myInputFolderTextField.getText().trim().isEmpty()) {
       return new ValidationInfo(DartBundle.message("validation.info.input.folder.not.specified"));
     }
 
@@ -158,7 +91,7 @@ public class DartPubBuildDialog extends DialogWrapper {
       return new ValidationInfo(DartBundle.message("validation.info.output.folder.not.specified"));
     }
 
-    if (myUseWebdev && myInputFolderTextField.getText().trim().equals(myOutputFolderField.getText().trim())) {
+    if (myInputFolderTextField.getText().trim().equals(myOutputFolderField.getText().trim())) {
       return new ValidationInfo(DartBundle.message("validation.info.input.and.output.folders.must.be.different"));
     }
 
@@ -174,29 +107,11 @@ public class DartPubBuildDialog extends DialogWrapper {
   private void saveDialogState() {
     final PropertiesComponent propertiesComponent = PropertiesComponent.getInstance(myProject);
 
-    if (myUseWebdev) {
-      final String inputPath = StringUtil.nullize(myInputFolderTextField.getText().trim());
-      propertiesComponent.setValue(DART_BUILD_INPUT_KEY, inputPath, DEFAULT_INPUT_FOLDER);
-    }
-    else {
-      final String mode = myReleaseRadioButton.isSelected() ? RELEASE_MODE
-                                                            : myDebugRadioButton.isSelected() ? DEBUG_MODE
-                                                                                              : OTHER_MODE;
-      propertiesComponent.setValue(DART_PUB_BUILD_MODE_KEY, mode, DEFAULT_MODE);
-
-      if (myOtherRadioButton.isSelected()) {
-        propertiesComponent.setValue(DART_PUB_CUSTOM_BUILD_MODE_KEY, myOtherModeTextField.getText().trim());
-      }
-    }
+    final String inputPath = StringUtil.nullize(myInputFolderTextField.getText().trim());
+    propertiesComponent.setValue(DART_BUILD_INPUT_KEY, inputPath, DEFAULT_INPUT_FOLDER);
 
     final String outputPath = StringUtil.nullize(myOutputFolderField.getText().trim());
     propertiesComponent.setValue(DART_BUILD_OUTPUT_KEY, outputPath, DEFAULT_OUTPUT_FOLDER);
-  }
-
-  public @NotNull String getPubBuildMode() {
-    if (myReleaseRadioButton.isSelected()) return RELEASE_MODE;
-    if (myDebugRadioButton.isSelected()) return DEBUG_MODE;
-    return myOtherModeTextField.getText().trim();
   }
 
   public @NotNull String getInputFolder() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubOutdatedAction.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubOutdatedAction.java
@@ -4,7 +4,6 @@ package com.jetbrains.lang.dart.ide.actions;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.sdk.DartSdk;
@@ -13,15 +12,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DartPubOutdatedAction extends DartPubActionBase {
-  public static final String MIN_SDK_VERSION = "2.8";
-
   @Override
   public void update(@NotNull AnActionEvent e) {
     super.update(e);
 
     final Project project = e.getProject();
     DartSdk sdk = project != null ? DartSdk.getDartSdk(project) : null;
-    if (sdk == null || StringUtil.compareVersionNumbers(sdk.getVersion(), MIN_SDK_VERSION) < 0) {
+    if (sdk == null) {
       e.getPresentation().setEnabledAndVisible(false);
     }
   }

--- a/Dart/src/com/jetbrains/lang/dart/ide/inspections/DartOutdatedDependenciesInspection.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/inspections/DartOutdatedDependenciesInspection.java
@@ -19,14 +19,13 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartBundle;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.flutter.FlutterUtil;
 import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
 import com.jetbrains.lang.dart.psi.DartFile;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
-import com.jetbrains.lang.dart.util.DotPackagesFileUtil;
+import com.jetbrains.lang.dart.util.PackageConfigFileUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.intellij.lang.annotations.Language;
 import org.jetbrains.annotations.NonNls;
@@ -69,9 +68,7 @@ public final class DartOutdatedDependenciesInspection extends LocalInspectionToo
 
     if (FlutterUtil.isPubspecDeclaringFlutter(pubspecFile)) return null; // 'pub get' will fail anyway
 
-    VirtualFile packagesFile = DartAnalysisServerService.isDartSdkVersionSufficientForPackageConfigJson(sdk)
-                               ? DotPackagesFileUtil.getPackageConfigJsonFile(project, pubspecFile)
-                               : pubspecFile.getParent().findChild(DotPackagesFileUtil.DOT_PACKAGES);
+    VirtualFile packagesFile = PackageConfigFileUtil.getPackageConfigJsonFile(project, pubspecFile);
 
     if (packagesFile == null) {
       return createProblemDescriptors(manager, psiFile, pubspecFile, DartBundle.message("pub.get.never.done"));

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/introduce/DartServerExtractLocalVariableHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/introduce/DartServerExtractLocalVariableHandler.java
@@ -46,7 +46,7 @@ public class DartServerExtractLocalVariableHandler implements RefactoringActionH
   @Override
   public void invoke(final @NotNull Project project, final Editor editor, PsiFile file, DataContext dataContext) {
     final DartSdk sdk = DartSdk.getDartSdk(project);
-    if (sdk == null || StringUtil.compareVersionNumbers(sdk.getVersion(), "1.14") < 0) {
+    if (sdk == null) {
       return;
     }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/refactoring/moveFile/DartServerMoveDartFileHandler.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/refactoring/moveFile/DartServerMoveDartFileHandler.java
@@ -36,8 +36,7 @@ public final class DartServerMoveDartFileHandler extends MoveFileHandler {
       return false;
     }
     final Project project = psiFile.getProject();
-    final DartSdk dartSdk = DartSdk.getDartSdk(project);
-    if (dartSdk == null || !DartAnalysisServerService.isDartSdkVersionSufficientForMoveFileRefactoring(dartSdk)) {
+    if (DartSdk.getDartSdk(project) == null) {
       return false;
     }
     return DartAnalysisServerService.getInstance(project).isInIncludedRoots(psiFile.getVirtualFile());
@@ -88,12 +87,16 @@ public final class DartServerMoveDartFileHandler extends MoveFileHandler {
   }
 
   @Override
-  public @Nullable @Unmodifiable List<UsageInfo> findUsages(@NotNull PsiFile psiFile, @NotNull PsiDirectory newParent, boolean searchInComments, boolean searchInNonJavaFiles) {
+  public @Nullable @Unmodifiable List<UsageInfo> findUsages(@NotNull PsiFile psiFile,
+                                                            @NotNull PsiDirectory newParent,
+                                                            boolean searchInComments,
+                                                            boolean searchInNonJavaFiles) {
     return null;
   }
 
   @Override
-  public void retargetUsages(@Unmodifiable @NotNull List<? extends UsageInfo> usageInfos, @NotNull Map<PsiElement, PsiElement> oldToNewMap) {
+  public void retargetUsages(@Unmodifiable @NotNull List<? extends UsageInfo> usageInfos,
+                             @NotNull Map<PsiElement, PsiElement> oldToNewMap) {
   }
 
   @Override

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class DartCommandLineRunnerParameters implements Cloneable {
   private @Nullable @NlsSafe String myFilePath = null;
   private @Nullable @NlsSafe String myVMOptions = null;
-  private boolean myCheckedModeOrEnableAsserts = true;
+  private boolean myAssertsEnabled = true;
   private @Nullable @NlsSafe String myArguments = null;
   private @Nullable @NlsSafe String myWorkingDirectory = null;
   private @NotNull Map<String, String> myEnvs = new LinkedHashMap<>();
@@ -67,19 +67,13 @@ public class DartCommandLineRunnerParameters implements Cloneable {
     myVMOptions = vmOptions;
   }
 
-  /**
-   * For Dart 2 it means 'enable asserts' flag; for Dart 1 - 'checked mode' flag
-   */
   @OptionTag("checkedMode") // compatibility
-  public boolean isCheckedModeOrEnableAsserts() {
-    return myCheckedModeOrEnableAsserts;
+  public boolean areAssertsEnabled() {
+    return myAssertsEnabled;
   }
 
-  /**
-   * For Dart 2 it means 'enable asserts' flag; for Dart 1 - 'checked mode' flag
-   */
-  public void setCheckedModeOrEnableAsserts(final boolean checkedModeOrEnableAsserts) {
-    myCheckedModeOrEnableAsserts = checkedModeOrEnableAsserts;
+  public void setAssertsEnabled(final boolean assertsEnabled) {
+    myAssertsEnabled = assertsEnabled;
   }
 
   public @Nullable @NlsSafe String getArguments() {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Consumer;
 import com.intellij.util.net.NetUtils;
@@ -194,13 +193,8 @@ public class DartCommandLineRunningState extends CommandLineState {
       }
     }
 
-    if (myRunnerParameters.isCheckedModeOrEnableAsserts()) {
-      if (StringUtil.compareVersionNumbers(sdk.getVersion(), "2") < 0) {
-        addVmOption(sdk, commandLine, "--checked");
-      }
-      else {
-        addVmOption(sdk, commandLine, "--enable-asserts");
-      }
+    if (myRunnerParameters.areAssertsEnabled()) {
+      addVmOption(sdk, commandLine, "--enable-asserts");
     }
 
     if (DefaultDebugExecutor.EXECUTOR_ID.equals(getEnvironment().getExecutor().getId())) {

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/ui/DartCommandLineConfigurationEditorForm.form
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/ui/DartCommandLineConfigurationEditorForm.form
@@ -85,7 +85,7 @@
           <labelLocation value="West"/>
         </properties>
       </component>
-      <component id="62b97" class="com.intellij.ui.components.JBCheckBox" binding="myCheckedModeOrEnableAssertsCheckBox">
+      <component id="62b97" class="com.intellij.ui.components.JBCheckBox" binding="myEnableAssertsCheckBox">
         <constraints>
           <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/ui/DartCommandLineConfigurationEditorForm.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/ui/DartCommandLineConfigurationEditorForm.java
@@ -20,7 +20,6 @@ import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunnerParameters;
-import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -30,7 +29,7 @@ public class DartCommandLineConfigurationEditorForm extends SettingsEditor<DartC
   private JLabel myDartFileLabel;
   private TextFieldWithBrowseButton myFileField;
   private RawCommandLineEditor myVMOptions;
-  private JBCheckBox myCheckedModeOrEnableAssertsCheckBox;
+  private JBCheckBox myEnableAssertsCheckBox;
   private RawCommandLineEditor myArguments;
   private TextFieldWithBrowseButton myWorkingDirectory;
   private EnvironmentVariablesComponent myEnvironmentVariables;
@@ -38,17 +37,11 @@ public class DartCommandLineConfigurationEditorForm extends SettingsEditor<DartC
   public DartCommandLineConfigurationEditorForm(final Project project) {
     initDartFileTextWithBrowse(project, myFileField);
 
-    myWorkingDirectory.addBrowseFolderListener(project, FileChooserDescriptorFactory.createSingleFolderDescriptor().withTitle(DartBundle.message("dialog.title.select.working.directory")));
+    myWorkingDirectory.addBrowseFolderListener(project, FileChooserDescriptorFactory.createSingleFolderDescriptor()
+      .withTitle(DartBundle.message("dialog.title.select.working.directory")));
 
-    final DartSdk sdk = DartSdk.getDartSdk(project);
-    if (sdk != null && StringUtil.compareVersionNumbers(sdk.getVersion(), "2") < 0) {
-      myCheckedModeOrEnableAssertsCheckBox.setText(DartBundle.message("command.line.run.config.checkbox.checked.mode"));
-      myCheckedModeOrEnableAssertsCheckBox.setMnemonic('c');
-    }
-    else {
-      myCheckedModeOrEnableAssertsCheckBox.setText(DartBundle.message("command.line.run.config.checkbox.enable.asserts"));
-      myCheckedModeOrEnableAssertsCheckBox.setMnemonic('l');
-    }
+    myEnableAssertsCheckBox.setText(DartBundle.message("command.line.run.config.checkbox.enable.asserts"));
+    myEnableAssertsCheckBox.setMnemonic('l');
 
     // 'Environment variables' is the widest label, anchored by myDartFileLabel
     myDartFileLabel.setPreferredSize(myEnvironmentVariables.getLabel().getPreferredSize());
@@ -83,7 +76,7 @@ public class DartCommandLineConfigurationEditorForm extends SettingsEditor<DartC
     myFileField.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(parameters.getFilePath())));
     myArguments.setText(StringUtil.notNullize(parameters.getArguments()));
     myVMOptions.setText(StringUtil.notNullize(parameters.getVMOptions()));
-    myCheckedModeOrEnableAssertsCheckBox.setSelected(parameters.isCheckedModeOrEnableAsserts());
+    myEnableAssertsCheckBox.setSelected(parameters.areAssertsEnabled());
     myWorkingDirectory.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(parameters.getWorkingDirectory())));
     myEnvironmentVariables.setEnvs(parameters.getEnvs());
     myEnvironmentVariables.setPassParentEnvs(parameters.isIncludeParentEnvs());
@@ -96,7 +89,7 @@ public class DartCommandLineConfigurationEditorForm extends SettingsEditor<DartC
     parameters.setFilePath(StringUtil.nullize(FileUtil.toSystemIndependentName(myFileField.getText().trim()), true));
     parameters.setArguments(StringUtil.nullize(myArguments.getText(), true));
     parameters.setVMOptions(StringUtil.nullize(myVMOptions.getText(), true));
-    parameters.setCheckedModeOrEnableAsserts(myCheckedModeOrEnableAssertsCheckBox.isSelected());
+    parameters.setAssertsEnabled(myEnableAssertsCheckBox.isSelected());
     parameters.setWorkingDirectory(StringUtil.nullize(FileUtil.toSystemIndependentName(myWorkingDirectory.getText().trim()), true));
     parameters.setEnvs(myEnvironmentVariables.getEnvs());
     parameters.setIncludeParentEnvs(myEnvironmentVariables.isPassParentEnvs());

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfigurationProducer.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfigurationProducer.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.xml.util.HtmlUtil;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.jetbrains.annotations.NotNull;
@@ -60,7 +59,7 @@ public final class DartWebdevConfigurationProducer extends LazyRunConfigurationP
   private static @Nullable VirtualFile getRunnableHtmlFileFromContext(@NotNull ConfigurationContext context) {
     final Project project = context.getProject();
     final DartSdk dartSdk = DartSdk.getDartSdk(project);
-    if (dartSdk == null || dartSdk.getVersion().isEmpty() || !DartAnalysisServerService.isDartSdkVersionSufficientForWebdev(dartSdk)) {
+    if (dartSdk == null || dartSdk.getVersion().isEmpty()) {
       return null;
     }
 

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevParameters.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevParameters.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartBundle;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
@@ -71,12 +70,6 @@ public class DartWebdevParameters implements Cloneable {
     if (dartSdk == null) {
       throw new RuntimeConfigurationError(DartBundle.message("dart.sdk.is.not.configured"),
                                           () -> DartConfigurable.openDartSettings(project));
-    }
-    final String dartSdkVersion = dartSdk.getVersion();
-    if (!dartSdkVersion.isEmpty() &&
-        !DartAnalysisServerService.isDartSdkVersionSufficientForWebdev(dartSdk)) {
-      throw new RuntimeConfigurationError(
-        DartBundle.message("old.dart.sdk.for.webdev", DartAnalysisServerService.MIN_WEBDEV_SDK_VERSION, dartSdkVersion));
     }
 
     // check html file

--- a/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
+++ b/Dart/src/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
@@ -7,7 +7,6 @@ import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
-import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.filters.UrlFilter;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
@@ -29,7 +28,6 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartBundle;
-import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
@@ -46,14 +44,14 @@ public class DartTestRunningState extends DartCommandLineRunningState {
   private static final String RUN_COMMAND = "run";
   private static final String TEST_PACKAGE_SPEC = "test";
   private static final String EXPANDED_REPORTER_OPTION = "-r json";
-  public static final String DART_VM_OPTIONS_ENV_VAR = "DART_VM_OPTIONS";
 
   public DartTestRunningState(final @NotNull ExecutionEnvironment environment) throws ExecutionException {
     super(environment);
   }
 
   @Override
-  public @NotNull ExecutionResult execute(final @NotNull Executor executor, final @NotNull ProgramRunner<?> runner) throws ExecutionException {
+  public @NotNull ExecutionResult execute(final @NotNull Executor executor, final @NotNull ProgramRunner<?> runner)
+    throws ExecutionException {
     final ProcessHandler processHandler = startProcess();
     final ConsoleView consoleView = createConsole(getEnvironment());
     consoleView.attachToProcess(processHandler);
@@ -149,7 +147,7 @@ public class DartTestRunningState extends DartCommandLineRunningState {
     }
 
     params.setArguments(builder.toString());
-    params.setCheckedModeOrEnableAsserts(false);
+    params.setAssertsEnabled(false);
     // working directory is not configurable in UI because there's only one valid value that we calculate ourselves
     params.setWorkingDirectory(params.computeProcessWorkingDirectory(project));
 
@@ -158,13 +156,7 @@ public class DartTestRunningState extends DartCommandLineRunningState {
 
   @Override
   protected void setupExePath(@NotNull GeneralCommandLine commandLine, @NotNull DartSdk sdk) {
-    boolean useDartTest = DartPubActionBase.isUseDartRunTestInsteadOfPubRunTest(sdk);
-    if (useDartTest) {
-      commandLine.setExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk)));
-    }
-    else {
-      commandLine.setExePath(FileUtil.toSystemDependentName(DartSdkUtil.getPubPath(sdk)));
-    }
+    commandLine.setExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk)));
   }
 
   @Override
@@ -174,31 +166,7 @@ public class DartTestRunningState extends DartCommandLineRunningState {
 
   @Override
   protected void addVmOption(@NotNull DartSdk sdk, @NotNull GeneralCommandLine commandLine, @NotNull String option) {
-    boolean useDartTest = DartPubActionBase.isUseDartRunTestInsteadOfPubRunTest(sdk);
-    if (useDartTest) {
-      super.addVmOption(sdk, commandLine, option);
-      return;
-    }
-
-    // SDK 2.9 and older
-    final String arguments = StringUtil.notNullize(myRunnerParameters.getArguments());
-    if (DefaultRunExecutor.EXECUTOR_ID.equals(getEnvironment().getExecutor().getId()) &&
-        option.startsWith("--enable-vm-service:") &&
-        (arguments.startsWith("-p ") || arguments.contains(" -p "))) {
-      // When we start browser-targeted tests then there are 2 dart processes spawned: parent (pub) and child (tests).
-      // If we add --enable-vm-service option to the DART_VM_OPTIONS env var then it will apply for both processes and will obviously
-      // fail for the child process (because the port will be already occupied by the parent one).
-      // Setting --enable-vm-service option for the parent process doesn't make much sense, so we skip it.
-      return;
-    }
-
-    String options = commandLine.getEnvironment().get(DART_VM_OPTIONS_ENV_VAR);
-    if (StringUtil.isEmpty(options)) {
-      commandLine.getEnvironment().put(DART_VM_OPTIONS_ENV_VAR, option);
-    }
-    else {
-      commandLine.getEnvironment().put(DART_VM_OPTIONS_ENV_VAR, options + " " + option);
-    }
+    super.addVmOption(sdk, commandLine, option);
   }
 
   DartTestRunnerParameters getParameters() {

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
@@ -55,9 +55,7 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
   private boolean myIntellijLiveValidationEnabled = false;
 
   private boolean myDartCreateCalcStarted;
-  private boolean myStagehandCalcStarted;
   private List<DartProjectTemplate> myDartCreateTemplates;// not-null means that it's been already calculated
-  private List<DartProjectTemplate> myStagehandTemplates;// not-null means that it's been already calculated
 
   public DartGeneratorPeer() {
     // set initial values before initDartSdkControls() because listeners should not be triggered on initialization
@@ -117,42 +115,23 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
       return;
     }
 
-    boolean useDartCreate = Stagehand.isUseDartCreate(sdkPath);
-    if (useDartCreate) {
-      if (myDartCreateCalcStarted) {
-        if (myDartCreateTemplates != null) {
-          showTemplates(myDartCreateTemplates);
-        }
-        else {
-          // Calculation in progress, just wait.
-          myLoadingTemplatesPanel.setVisible(true);
-          myLoadedTemplatesPanel.setVisible(false);
-        }
+    if (myDartCreateCalcStarted) {
+      if (myDartCreateTemplates != null) {
+        showTemplates(myDartCreateTemplates);
       }
       else {
-        myDartCreateCalcStarted = true;
-        startLoadingTemplates(useDartCreate);
+        // Calculation in progress, just wait.
+        myLoadingTemplatesPanel.setVisible(true);
+        myLoadedTemplatesPanel.setVisible(false);
       }
     }
     else {
-      if (myStagehandCalcStarted) {
-        if (myStagehandTemplates != null) {
-          showTemplates(myStagehandTemplates);
-        }
-        else {
-          // Calculation in progress, just wait.
-          myLoadingTemplatesPanel.setVisible(true);
-          myLoadedTemplatesPanel.setVisible(false);
-        }
-      }
-      else {
-        myStagehandCalcStarted = true;
-        startLoadingTemplates(useDartCreate);
-      }
+      myDartCreateCalcStarted = true;
+      startLoadingTemplates();
     }
   }
 
-  private void startLoadingTemplates(boolean useDartCreate) {
+  private void startLoadingTemplates() {
     myLoadingTemplatesPanel.setVisible(true);
     myLoadingTemplatesPanel.setPreferredSize(myLoadedTemplatesPanel.getPreferredSize());
 
@@ -170,12 +149,7 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
         myLoadingTemplatesPanel.remove(asyncProcessIcon);
         Disposer.dispose(asyncProcessIcon);
 
-        if (useDartCreate) {
-          myDartCreateTemplates = templates;
-        }
-        else {
-          myStagehandTemplates = templates;
-        }
+        myDartCreateTemplates = templates;
 
         // it's better to call onSdkPathChanged() but not showTemplates() directly as sdk path could have been changed during this long calculation
         onSdkPathChanged();

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -30,7 +30,6 @@ import java.util.List;
 public abstract class DartProjectTemplate {
 
   private static final Stagehand STAGEHAND = new Stagehand();
-  private static List<DartProjectTemplate> ourStagehandTemplateCache;
   private static List<DartProjectTemplate> ourDartCreateTemplateCache;
 
   private static final Logger LOG = Logger.getInstance(DartProjectTemplate.class.getName());
@@ -80,36 +79,17 @@ public abstract class DartProjectTemplate {
   }
 
   private static @NotNull List<DartProjectTemplate> getStagehandTemplates(@NotNull String sdkRoot) {
-    boolean useDartCreate = Stagehand.isUseDartCreate(sdkRoot);
-
-    if (useDartCreate) {
-      if (ourDartCreateTemplateCache != null) {
-        return ourDartCreateTemplateCache;
-      }
-    }
-    else {
-      if (ourStagehandTemplateCache != null) {
-        return ourStagehandTemplateCache;
-      }
-    }
-
-    STAGEHAND.install(sdkRoot);
-    final List<StagehandDescriptor> templates = STAGEHAND.getAvailableTemplates(sdkRoot);
-
-    if (useDartCreate) {
-      ourDartCreateTemplateCache = new ArrayList<>();
-      for (StagehandDescriptor template : templates) {
-        ourDartCreateTemplateCache.add(new StagehandTemplate(STAGEHAND, template));
-      }
+    if (ourDartCreateTemplateCache != null) {
       return ourDartCreateTemplateCache;
     }
-    else {
-      ourStagehandTemplateCache = new ArrayList<>();
-      for (StagehandDescriptor template : templates) {
-        ourStagehandTemplateCache.add(new StagehandTemplate(STAGEHAND, template));
-      }
-      return ourStagehandTemplateCache;
+
+    final List<StagehandDescriptor> templates = STAGEHAND.getAvailableTemplates(sdkRoot);
+
+    ourDartCreateTemplateCache = new ArrayList<>();
+    for (StagehandDescriptor template : templates) {
+      ourDartCreateTemplateCache.add(new StagehandTemplate(STAGEHAND, template));
     }
+    return ourDartCreateTemplateCache;
   }
 
   static void createWebRunConfiguration(final @NotNull Module module, final @NotNull VirtualFile htmlFile) {

--- a/Dart/src/com/jetbrains/lang/dart/projectWizard/Stagehand.java
+++ b/Dart/src/com/jetbrains/lang/dart/projectWizard/Stagehand.java
@@ -9,8 +9,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.SystemProperties;
-import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -22,15 +20,9 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
+// TODO: Rename this and related classes away from "stagehand",
+//   as templates are now retrieved and bootstrapped with `dart create`.
 public class Stagehand {
-
-  private static final String DART_CREATE_MIN_SDK_VERSION = "2.10";
-
-  static boolean isUseDartCreate(@NotNull String sdkHomePath) {
-    String version = DartSdkUtil.getSdkVersion(sdkHomePath);
-    return version != null && StringUtil.compareVersionNumbers(version, DART_CREATE_MIN_SDK_VERSION) >= 0;
-  }
-
   public static class StagehandDescriptor {
     public final @NotNull @NonNls String myId;
     public final @NotNull @NlsSafe String myLabel;
@@ -70,30 +62,11 @@ public class Stagehand {
     return new CapturingProcessHandler(command).runProcess(timeoutInSeconds * 1000, false);
   }
 
-  private static ProcessOutput runPubGlobal(@NotNull String sdkRoot,
-                                            @Nullable String workingDirectory,
-                                            int timeoutInSeconds,
-                                            @NotNull String pubEnvVarSuffix,
-                                            String... pubParameters) throws ExecutionException {
-    final GeneralCommandLine command = new GeneralCommandLine()
-      .withExePath(DartSdkUtil.getPubPath(sdkRoot))
-      .withWorkDirectory(workingDirectory)
-      .withEnvironment(DartPubActionBase.PUB_ENV_VAR_NAME, DartPubActionBase.getPubEnvValue() + ".stagehand" + pubEnvVarSuffix);
-
-    command.addParameter("global");
-    command.addParameters(pubParameters);
-
-    return new CapturingProcessHandler(command).runProcess(timeoutInSeconds * 1000, false);
-  }
-
   public void generateInto(final @NotNull String sdkRoot,
                            final @NotNull VirtualFile projectDirectory,
                            final @NotNull String templateId) throws ExecutionException {
-    ProcessOutput output = isUseDartCreate(sdkRoot)
-                           ? runDartCreate(sdkRoot, projectDirectory.getParent().getPath(), 30, "--force", "--no-pub", "--template",
-                                           templateId, projectDirectory.getName())
-                           : runPubGlobal(sdkRoot, projectDirectory.getPath(), 30, "", "run", "stagehand", "--author",
-                                          SystemProperties.getUserName(), templateId);
+    ProcessOutput output = runDartCreate(sdkRoot, projectDirectory.getParent().getPath(), 30, "--force", "--no-pub", "--template",
+                                         templateId, projectDirectory.getName());
 
     if (output.getExitCode() != 0) {
       throw new ExecutionException(output.getStderr());
@@ -102,9 +75,7 @@ public class Stagehand {
 
   public List<StagehandDescriptor> getAvailableTemplates(final @NotNull String sdkRoot) {
     try {
-      ProcessOutput output = isUseDartCreate(sdkRoot)
-                             ? runDartCreate(sdkRoot, null, 10, "--list-templates")
-                             : runPubGlobal(sdkRoot, null, 10, "", "run", "stagehand", "--machine");
+      ProcessOutput output = runDartCreate(sdkRoot, null, 10, "--list-templates");
 
       int exitCode = output.getExitCode();
 
@@ -126,11 +97,6 @@ public class Stagehand {
           obj.optString("entrypoint")));
       }
 
-      if (!isUseDartCreate(sdkRoot)) {
-        // Sort the stagehand templates lexically by name.
-        result.sort((one, two) -> one.myLabel.compareToIgnoreCase(two.myLabel));
-      }
-
       return result;
     }
     catch (ExecutionException | JSONException e) {
@@ -138,16 +104,5 @@ public class Stagehand {
     }
 
     return EMPTY;
-  }
-
-  public void install(final @NotNull String sdkRoot) {
-    if (isUseDartCreate(sdkRoot)) return;
-
-    try {
-      runPubGlobal(sdkRoot, null, 60, ".activate", "activate", "stagehand");
-    }
-    catch (ExecutionException e) {
-      LOG.info(e);
-    }
   }
 }

--- a/Dart/src/com/jetbrains/lang/dart/psi/DartPackageAwareFileReference.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/DartPackageAwareFileReference.java
@@ -9,11 +9,10 @@ import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferen
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
-import com.jetbrains.lang.dart.util.DotPackagesFileUtil;
+import com.jetbrains.lang.dart.util.PackageConfigFileUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -49,12 +48,7 @@ class DartPackageAwareFileReference extends FileReference {
       DartSdk sdk = DartSdk.getDartSdk(project);
       VirtualFile packagesFile;
       if (sdk != null && pubspecYamlFile != null) {
-        if (DartAnalysisServerService.isDartSdkVersionSufficientForPackageConfigJson(sdk)) {
-          packagesFile = DotPackagesFileUtil.getPackageConfigJsonFile(project, pubspecYamlFile);
-        }
-        else {
-          packagesFile = pubspecYamlFile.getParent().findChild(DotPackagesFileUtil.DOT_PACKAGES);
-        }
+        packagesFile = PackageConfigFileUtil.getPackageConfigJsonFile(project, pubspecYamlFile);
       }
       else {
         packagesFile = null;

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFileReference.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartFileReference.java
@@ -1,9 +1,7 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.psi.impl;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
@@ -17,9 +15,7 @@ import com.jetbrains.lang.dart.psi.DartFile;
 import com.jetbrains.lang.dart.psi.DartImportStatement;
 import com.jetbrains.lang.dart.psi.DartUriElement;
 import com.jetbrains.lang.dart.resolve.DartResolver;
-import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
-import com.jetbrains.lang.dart.util.DartUrlResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -80,26 +76,6 @@ public class DartFileReference implements PsiPolyVariantReference {
 
   @Override
   public PsiElement bindToElement(final @NotNull PsiElement element) throws IncorrectOperationException {
-    if (element instanceof PsiFile) {
-      final VirtualFile contextFile = DartResolveUtil.getRealVirtualFile(myUriElement.getContainingFile());
-      final VirtualFile targetFile = DartResolveUtil.getRealVirtualFile(((PsiFile)element));
-      final Project project = myUriElement.getProject();
-      final DartSdk dartSdk = DartSdk.getDartSdk(project);
-      if (dartSdk != null && !DartAnalysisServerService.isDartSdkVersionSufficientForMoveFileRefactoring(dartSdk)) {
-        if (contextFile != null && targetFile != null) {
-          final String newUri = DartUrlResolver.getInstance(myUriElement.getProject(), contextFile).getDartUrlForFile(targetFile);
-          if (newUri.startsWith(DartUrlResolver.PACKAGE_PREFIX)) {
-            return updateUri(newUri);
-          }
-          else if (newUri.startsWith(DartUrlResolver.FILE_PREFIX)) {
-            final String relativePath = FileUtil.getRelativePath(contextFile.getParent().getPath(), targetFile.getPath(), '/');
-            if (relativePath != null) {
-              return updateUri(relativePath);
-            }
-          }
-        }
-      }
-    }
     return myUriElement;
   }
 

--- a/Dart/src/com/jetbrains/lang/dart/psi/impl/DartUriElementBase.java
+++ b/Dart/src/com/jetbrains/lang/dart/psi/impl/DartUriElementBase.java
@@ -2,21 +2,17 @@
 package com.jetbrains.lang.dart.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartLanguage;
-import com.jetbrains.lang.dart.psi.DartFile;
 import com.jetbrains.lang.dart.psi.DartImportStatement;
 import com.jetbrains.lang.dart.psi.DartUriElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class DartUriElementBase extends DartPsiCompositeElementImpl implements DartUriElement {
-
-  private static final Condition<PsiFileSystemItem> DART_FILE_OR_DIR_FILTER = item -> item.isDirectory() || item instanceof DartFile;
 
   public DartUriElementBase(final @NotNull ASTNode node) {
     super(node);

--- a/Dart/src/com/jetbrains/lang/dart/pubServer/DartWebdev.kt
+++ b/Dart/src/com/jetbrains/lang/dart/pubServer/DartWebdev.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NlsSafe
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.jetbrains.lang.dart.DartBundle
 import com.jetbrains.lang.dart.ide.actions.DartPubActionBase
@@ -19,12 +18,6 @@ private val LOG = logger<DartWebdev>()
 
 object DartWebdev {
   var activated: Boolean = false
-
-  fun useWebdev(sdk: DartSdk?): Boolean {
-    if (sdk == null) return false
-    val sdkVersion = sdk.version
-    return StringUtil.compareVersionNumbers(sdkVersion, "2") >= 0
-  }
 
   /**
    * @return `false` only if explicitly cancelled by user

--- a/Dart/src/com/jetbrains/lang/dart/pubServer/PubServerPathHandler.kt
+++ b/Dart/src/com/jetbrains/lang/dart/pubServer/PubServerPathHandler.kt
@@ -32,7 +32,7 @@ private class PubServerPathHandler : WebServerPathHandler {
     isCustomHost: Boolean,
   ): Boolean {
     val sdk = DartSdk.getDartSdk(project)
-    if (sdk == null || StringUtil.compareVersionNumbers(sdk.version, "1.6") < 0) {
+    if (sdk == null) {
       return false
     }
 
@@ -77,7 +77,9 @@ private fun getServedDirAndPathForPubServer(project: Project, path: String): Pai
     val parentDir = dir.parent
     if (parentDir?.findChild(PubspecYamlUtil.PUBSPEC_YAML) != null) {
       val name = dir.nameSequence
-      if (StringUtil.equals(name, "build") || StringUtil.equals(name, "lib") || StringUtil.equals(name, DartUrlResolver.PACKAGES_FOLDER_NAME)) {
+      if (StringUtil.equals(name, "build") || StringUtil.equals(name, "lib") || StringUtil.equals(name,
+                                                                                                  DartUrlResolver.PACKAGES_FOLDER_NAME)
+      ) {
         // contents of "build" folder should be served by the IDE internal web server directly, i.e. without pub serve
         return null
       }

--- a/Dart/src/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
@@ -19,7 +19,6 @@ import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
 import com.intellij.util.PairConsumer;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.index.DartLibraryIndex;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryProperties;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryType;
@@ -203,15 +202,9 @@ public final class DartUrlResolverImpl extends DartUrlResolver {
     final VirtualFile baseDir = myPubspecYamlFile == null ? null : myPubspecYamlFile.getParent();
     if (myPubspecYamlFile == null || baseDir == null) return;
 
-    Map<String, String> packagesMap;
-    if (myDartSdk == null || DartAnalysisServerService.isDartSdkVersionSufficientForPackageConfigJson(myDartSdk)) {
-      VirtualFile packagesFile = DotPackagesFileUtil.getPackageConfigJsonFile(myProject, myPubspecYamlFile);
-      packagesMap = packagesFile != null ? DotPackagesFileUtil.getPackagesMapFromPackageConfigJsonFile(packagesFile) : null;
-    }
-    else {
-      VirtualFile packagesFile = baseDir.findChild(DotPackagesFileUtil.DOT_PACKAGES);
-      packagesMap = packagesFile != null ? DotPackagesFileUtil.getPackagesMap(packagesFile) : null;
-    }
+    VirtualFile packagesFile = PackageConfigFileUtil.getPackageConfigJsonFile(myProject, myPubspecYamlFile);
+    Map<String, String> packagesMap =
+      packagesFile != null ? PackageConfigFileUtil.getPackagesMapFromPackageConfigJsonFile(packagesFile) : null;
 
     if (packagesMap != null) {
       for (Map.Entry<String, String> entry : packagesMap.entrySet()) {

--- a/Dart/src/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
+++ b/Dart/src/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
@@ -26,9 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public final class DotPackagesFileUtil {
-
-  public static final String DOT_PACKAGES = ".packages";
+public final class PackageConfigFileUtil {
 
   public static final String DART_TOOL_DIR = ".dart_tool";
   public static final String PACKAGE_CONFIG_JSON = "package_config.json";
@@ -82,17 +80,6 @@ public final class DotPackagesFileUtil {
       }
     }
 
-    return null;
-  }
-
-  public static @Nullable VirtualFile findDotPackagesFile(@Nullable VirtualFile dir) {
-    while (dir != null) {
-      final VirtualFile file = dir.findChild(DOT_PACKAGES);
-      if (file != null && !file.isDirectory()) {
-        return file;
-      }
-      dir = dir.getParent();
-    }
     return null;
   }
 
@@ -152,7 +139,7 @@ public final class DotPackagesFileUtil {
       jsonElement = JsonParser.parseString(fileContentsStr);
     }
     catch (Exception e) {
-      Logger.getInstance(DotPackagesFileUtil.class).info(e);
+      Logger.getInstance(PackageConfigFileUtil.class).info(e);
       return null;
     }
 


### PR DESCRIPTION
Increase the minimum supported Dart SDK to 2.12, which is the release which added support for null safety and finalized the consolidation on the combined `dart` CLI tool. This simplifies plugin development as a lot of tooling changed before the 2.12 release, requiring a lot of conditional behavior that is relatively hard to maintain.

---

### Justification and background

Dart 2.12 [was released on 2021-03-04](https://github.com/dart-lang/sdk/releases/tag/2.12.0), so over 4 years ago now. With the release of Dart 3 (May 2023), the Dart team stopped supporting language versions before 2.12 and [highlighted most packages support null safety](https://medium.com/dartlang/announcing-dart-3-53f065a10635#5b2a).

Beyond this, the Flutter IntelliJ plugin has implemented a [support policy](https://github.com/flutter/flutter-intellij?tab=readme-ov-file#flutter-sdk-compatibility) only supporting SDKs from the previous two years. As of the most recent release, they only support [Flutter 3.13 or later](https://github.com/flutter/flutter-intellij/blob/dd99416eed7cceea032acfa730d94fee00ecabc5/flutter-idea/src/io/flutter/sdk/FlutterSdkVersion.java#L30), which comes with Dart 3.1.

In this PR I set 2.12 as the minimum instead of 3.0 or 3.1 for two reasons:

- Incrementally migrating to an increased minimum, for easier review, fewer opportunities for regressions, and an additional notice period for developers.
- Continue supporting the few Dart developers that might not be running their apps with sound null safety, therefore needing an SDK before 3.0. I expect the minimum SDK version can later be increased to 2.19 while still supporting this group, but eventually support for SDKs before 3.0 should be dropped as well.

### Included changes

- Increased the minimum SDK version to "2.12.0".
- Removed checks for versions before 2.12 and if there was one, removed the branch for earlier versions.
- Removed support for the long-removed pub serve and `pub build` command, in favor of webdev.
  - Some related files, classes, methods, etc. should eventually be renamed due to this cleanup.
- Removed support for stagehand for project templates, only supporting `dart create`.
  - Some related files, classes, methods, etc. should eventually be renamed due to this cleanup.
- Consolidated the "asserts enabled or checked mode" setting to just "asserts enabled" now that Dart 1 is no longer supported.
- Remove messages from the bundle that are no longer used due to removed messages and forms.

