### PR TITLE
[vue] Add support for __VLS_WithSlots introduced in @vue/language-core@2.2.2

### DIFF
--- a/vuejs/src/org/jetbrains/vuejs/model/typed/VueTypedEntitiesProvider.kt
+++ b/vuejs/src/org/jetbrains/vuejs/model/typed/VueTypedEntitiesProvider.kt
@@ -26,7 +26,7 @@ import org.jetbrains.vuejs.model.source.VueEntityDescriptor
 object VueTypedEntitiesProvider {
 
   private val vueComponentTypenameRegex = Regex(
-    """(import\s*\(\s*['"]vue['"]\s*\)\s*\.\s*|vue\s*\.\s*)?(DefineComponent|ComponentOptionsBase|ComponentOptionsMixin|ComponentCustomProps|__VLS_WithTemplateSlots)""")
+    """(import\s*\(\s*['"]vue['"]\s*\)\s*\.\s*|vue\s*\.\s*)?(DefineComponent|ComponentOptionsBase|ComponentOptionsMixin|ComponentCustomProps|__VLS_WithTemplateSlots|__VLS_WithSlots)""")
 
   fun isComponentDefinition(definition: JSQualifiedNamedElement): Boolean {
     if (definition.name == null || definition is JSField) return false


### PR DESCRIPTION
Hello, this is a follow-up to [WEB-69114](https://youtrack.jetbrains.com/issue/WEB-69114/Webstorm-breaks-autocomplete-and-autoimport-when-packaged-components-declared-with-VLSWithTemplateSlots). I had this issue re-appear in my project and found [this comment](https://youtrack.jetbrains.com/issue/WEB-69114/Webstorm-breaks-autocomplete-and-autoimport-when-packaged-components-declared-with-VLSWithTemplateSlots#focus=Comments-27-12401231.0-0) suggesting that the cause was an updated version of `@vue/language-core`.

In this [commit](https://github.com/vuejs/language-tools/commit/c4c0413ecac9bc9223783be32c64a9edbab8eefa) the name of the type `__VLS_WithTemplateSlots` was changed to `__VLS_WithSlots`. I added it to the regex to support both the old and the new type.

This might also fix [WEB-74450](https://youtrack.jetbrains.com/issue/WEB-74450/Reka-UI-type-hinting-issue).

This is my first contribution, so let me know if I forgot anything.