### PR TITLE
IDEA-306313 Java. Tests. Cucumber: Treat DataTable cells as strings

### DIFF
--- a/cucumber/src/org/jetbrains/plugins/cucumber/psi/GherkinTableCell.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/psi/GherkinTableCell.java
@@ -1,6 +1,6 @@
 package org.jetbrains.plugins.cucumber.psi;
 
-import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiNamedElement;
 
-public interface GherkinTableCell extends GherkinPsiElement, PsiNameIdentifierOwner {
+public interface GherkinTableCell extends GherkinPsiElement, PsiNamedElement {
 }

--- a/cucumber/src/org/jetbrains/plugins/cucumber/psi/GherkinTableCellImpl.java
+++ b/cucumber/src/org/jetbrains/plugins/cucumber/psi/GherkinTableCellImpl.java
@@ -15,7 +15,6 @@ import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNullByDefault;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.cucumber.psi.impl.GherkinPsiElementBase;
 
 @ApiStatus.Internal
@@ -53,11 +52,6 @@ public class GherkinTableCellImpl extends GherkinPsiElementBase implements Gherk
   @Override
   public String getName() {
     return getText();
-  }
-
-  @Override
-  public @Nullable PsiElement getNameIdentifier() {
-    return PsiTreeUtil.getChildOfType(this, LeafPsiElement.class);
   }
 
   @Override

--- a/cucumber/test/org/jetbrains/plugins/cucumber/inspections/NonAsciiCharactersInspectionTest.java
+++ b/cucumber/test/org/jetbrains/plugins/cucumber/inspections/NonAsciiCharactersInspectionTest.java
@@ -1,0 +1,31 @@
+package org.jetbrains.plugins.cucumber.inspections;
+
+import com.intellij.codeInspection.NonAsciiCharactersInspection;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.jetbrains.plugins.cucumber.psi.GherkinFileType;
+
+public class NonAsciiCharactersInspectionTest extends BasePlatformTestCase {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    myFixture.enableInspections(NonAsciiCharactersInspection.class);
+  }
+
+  public void testNoWarningForNonAsciiCharacters() {
+    myFixture.configureByText(GherkinFileType.INSTANCE, """
+      Feature: Sample feature
+      
+        Scenario Outline: Non-ASCII character param "<param>"
+          Given A list of values
+          Examples:
+            | ü |
+            | ß |
+            | ö |
+            | Ж |
+            | Г |
+      """);
+
+    myFixture.checkHighlighting();
+  }
+}


### PR DESCRIPTION
This fixes a bug where DataTable cells are treated as identifiers by the analyzer, which would in turn make IntelliJ warn about using non-ascii characters in cell values.

The non-ascii character inspection is configured to warn on identifiers by default.