### PR TITLE
IDEA-390158 [error-prone] update error-prone to 2.49.0

### DIFF
--- a/error-prone/resources/library/error-prone.xml
+++ b/error-prone/resources/library/error-prone.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
-  <artifact version="2.42.0" name="error-prone">
-    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.42.0/error_prone_core-2.42.0-with-dependencies.jar"/>
+  <artifact version="2.49.0" name="error-prone">
+    <item url="https://repo1.maven.org/maven2/com/google/errorprone/error_prone_core/2.49.0/error_prone_core-2.49.0-with-dependencies.jar"/>
     <item url="https://repo1.maven.org/maven2/io/github/eisop/dataflow-errorprone/3.41.0-eisop1/dataflow-errorprone-3.41.0-eisop1.jar"/>
   </artifact>
 </artifacts>


### PR DESCRIPTION
Updates the bundled error-prone from 2.42.0 to 2.49.0.

**Why:** "Javac with error-prone" crashes on JDK 26 — error-prone 2.42.0 fails in `ProtectedMembersInFinalClass` on any project containing a `protected record` (invalid source positions on the synthetic canonical constructor), breaking the build. This blocks moving the toolchain to JDK 26. JDK 21/25 are unaffected.

Fixed upstream in error-prone 2.45.0 ("Improved compatibility with latest JDK 26 EA builds"); bumping to the latest 2.49.0.

**Repro** (compile on JDK 26 with "Javac with error-prone"):
```java
class Outer {
  protected record R(int x) {}
}
```
```
error-prone version: 2.42.0
BugPattern: ProtectedMembersInFinalClass
java.lang.IllegalArgumentException: invalid source positions (N, N) for: protected
  at com.google.errorprone.bugpatterns.ProtectedMembersInFinalClass.matchClass(...)
```

| error_prone_core | JDK 26 |
| --- | --- |
| 2.42.0 (current) | crash |
| 2.45.0 | fixed |
| 2.49.0 (this PR) | fixed |

`dataflow-errorprone` stays at `3.41.0-eisop1` (unchanged for 2.49.0).

YouTrack: IDEA-390158
