### PR TITLE
Optimize proto editing performance

### DIFF
--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/OptionOccurrenceTracker.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/OptionOccurrenceTracker.java
@@ -293,8 +293,11 @@ public class OptionOccurrenceTracker {
   }
 
   private static PbMessageType getFieldType(PbField field) {
+    if (field == null) {
+      return null;
+    }
     PbTypeName typeName = field.getTypeName();
-    if (typeName == null) {
+    if (typeName == null || typeName.getBuiltInType() != null) {
       return null;
     }
     return PbPsiUtil.resolveRefToType(typeName.getEffectiveReference(), PbMessageType.class);

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/PbTextAnnotator.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/annotation/PbTextAnnotator.java
@@ -78,6 +78,15 @@ public class PbTextAnnotator implements Annotator {
       return;
     }
 
+    // Fast check: this annotator only handles specific element types.
+    if (!(element instanceof PbTextField
+        || element instanceof PbTextFieldName
+        || element instanceof PbTextSymbolPath
+        || element instanceof PbTextExtensionName
+        || element instanceof PbTextDomain)) {
+      return;
+    }
+
     // Don't perform any annotations if the element exists within a reserved field.
     if (isReservedFieldOrDescendant(element, holder)) {
       return;

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbFile.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/PbFile.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.protobuf.lang.psi;
 
+import com.google.common.collect.Multimap;
 import com.intellij.psi.impl.PsiFileEx;
 import com.intellij.psi.impl.source.PsiFileWithStubSupport;
 import com.intellij.psi.util.QualifiedName;
@@ -82,6 +83,14 @@ public interface PbFile
   Map<QualifiedName, Collection<PbSymbol>> getLocalQualifiedSymbolMap();
 
   /**
+   * Returns a multimap of all symbols defined in this file.
+   *
+   * @see #getLocalQualifiedSymbolMap()
+   */
+  @NotNull
+  Multimap<QualifiedName, PbSymbol> getLocalQualifiedSymbols();
+
+  /**
    * Returns a map of all fully-qualified symbols exported when this file is imported.
    *
    * <p>Specifically, the result contains the following:
@@ -97,6 +106,14 @@ public interface PbFile
   Map<QualifiedName, Collection<PbSymbol>> getExportedQualifiedSymbolMap();
 
   /**
+   * Returns a multimap of all fully-qualified symbols exported when this file is imported.
+   *
+   * @see #getExportedQualifiedSymbolMap()
+   */
+  @NotNull
+  Multimap<QualifiedName, PbSymbol> getExportedQualifiedSymbols();
+
+  /**
    * Returns a map of all fully-qualified symbols defined in this and imported files.
    *
    * <p>Specifically, the result contains the following:
@@ -110,6 +127,14 @@ public interface PbFile
    */
   @NotNull
   Map<QualifiedName, Collection<PbSymbol>> getFullQualifiedSymbolMap();
+
+  /**
+   * Returns a multimap of all fully-qualified symbols defined in this and imported files.
+   *
+   * @see #getFullQualifiedSymbolMap()
+   */
+  @NotNull
+  Multimap<QualifiedName, PbSymbol> getFullQualifiedSymbols();
 
   /**
    * Returns the {@link PbSymbolOwner} that owns the elements defined in this file. This is either

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbFileImpl.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbFileImpl.java
@@ -219,33 +219,45 @@ public class PbFileImpl extends PsiFileBase implements PbFile {
   }
 
   @Override
-  public @NotNull Map<QualifiedName, Collection<PbSymbol>> getLocalQualifiedSymbolMap() {
+  public @NotNull ImmutableMultimap<QualifiedName, PbSymbol> getLocalQualifiedSymbols() {
     return CachedValuesManager.getCachedValue(
         this,
         () ->
             Result.create(
-                computeLocalQualifiedSymbolMap(), PbCompositeModificationTracker.byElement(this)))
-        .asMap();
+                computeLocalQualifiedSymbolMap(), PbCompositeModificationTracker.byElement(this)));
+  }
+
+  @Override
+  public @NotNull Map<QualifiedName, Collection<PbSymbol>> getLocalQualifiedSymbolMap() {
+    return getLocalQualifiedSymbols().asMap();
+  }
+
+  @Override
+  public @NotNull ImmutableMultimap<QualifiedName, PbSymbol> getExportedQualifiedSymbols() {
+    return CachedValuesManager.getCachedValue(
+        this,
+        () ->
+            Result.create(
+                computeExportedQualifiedSymbolMap(), PbCompositeModificationTracker.byElement(this)));
   }
 
   @Override
   public @NotNull Map<QualifiedName, Collection<PbSymbol>> getExportedQualifiedSymbolMap() {
+    return getExportedQualifiedSymbols().asMap();
+  }
+
+  @Override
+  public @NotNull ImmutableSetMultimap<QualifiedName, PbSymbol> getFullQualifiedSymbols() {
     return CachedValuesManager.getCachedValue(
         this,
         () ->
             Result.create(
-                computeExportedQualifiedSymbolMap(), PbCompositeModificationTracker.byElement(this)))
-        .asMap();
+                computeFullQualifiedSymbolMap(), PbCompositeModificationTracker.byElement(this)));
   }
 
   @Override
   public @NotNull Map<QualifiedName, Collection<PbSymbol>> getFullQualifiedSymbolMap() {
-    return CachedValuesManager.getCachedValue(
-        this,
-        () ->
-            Result.create(
-                computeFullQualifiedSymbolMap(), PbCompositeModificationTracker.byElement(this)))
-        .asMap();
+    return getFullQualifiedSymbols().asMap();
   }
 
   private ImmutableMultimap<QualifiedName, PbSymbol> computeLocalQualifiedSymbolMap() {
@@ -272,9 +284,9 @@ public class PbFileImpl extends PsiFileBase implements PbFile {
     // imports.
     ImmutableMultimap.Builder<QualifiedName, PbSymbol> builder = ImmutableListMultimap.builder();
 
-    getLocalQualifiedSymbolMap().forEach(builder::putAll);
+    builder.putAll(getLocalQualifiedSymbols());
     for (PbFile importedFile : getImportedFileList(/* includePrivate= */ false)) {
-      importedFile.getLocalQualifiedSymbolMap().forEach(builder::putAll);
+      builder.putAll(importedFile.getLocalQualifiedSymbols());
     }
     return builder.build();
   }
@@ -282,9 +294,9 @@ public class PbFileImpl extends PsiFileBase implements PbFile {
   private ImmutableSetMultimap<QualifiedName, PbSymbol> computeFullQualifiedSymbolMap() {
     // Return all local symbols from this file and exported symbols from all imported files.
     ImmutableSetMultimap.Builder<QualifiedName, PbSymbol> builder = ImmutableSetMultimap.builder();
-    getLocalQualifiedSymbolMap().forEach(builder::putAll);
+    builder.putAll(getLocalQualifiedSymbols());
     for (PbFile importedFile : getImportedFileList(/* includePrivate= */ true)) {
-      importedFile.getLocalQualifiedSymbolMap().forEach(builder::putAll);
+      builder.putAll(importedFile.getLocalQualifiedSymbols());
     }
     return builder.build();
   }

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbTextFieldNameMixin.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbTextFieldNameMixin.java
@@ -16,6 +16,7 @@
 package com.intellij.protobuf.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.protobuf.ide.PbCompositeModificationTracker;
 import com.intellij.protobuf.lang.psi.PbField;
 import com.intellij.protobuf.lang.psi.PbNamedTypeElement;
 import com.intellij.protobuf.lang.psi.PbTextExtensionName;
@@ -25,6 +26,8 @@ import com.intellij.protobuf.lang.resolve.PbTextFieldNameReference;
 import com.intellij.protobuf.lang.util.BuiltInType;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.CachedValueProvider.Result;
+import com.intellij.psi.util.CachedValuesManager;
 import org.jetbrains.annotations.Nullable;
 
 abstract class PbTextFieldNameMixin extends PbTextElementBase implements PbTextFieldName {
@@ -35,6 +38,14 @@ abstract class PbTextFieldNameMixin extends PbTextElementBase implements PbTextF
 
   @Override
   public @Nullable PbField getDeclaredField() {
+    return CachedValuesManager.getCachedValue(
+        this,
+        () ->
+            Result.create(
+                computeDeclaredField(), PbCompositeModificationTracker.byElement(this)));
+  }
+
+  private @Nullable PbField computeDeclaredField() {
     PsiReference ref = getEffectiveReference();
     if (ref == null) {
       return null;
@@ -48,6 +59,14 @@ abstract class PbTextFieldNameMixin extends PbTextElementBase implements PbTextF
 
   @Override
   public @Nullable PbNamedTypeElement getDeclaredNamedType() {
+    return CachedValuesManager.getCachedValue(
+        this,
+        () ->
+            Result.create(
+                computeDeclaredNamedType(), PbCompositeModificationTracker.byElement(this)));
+  }
+
+  private @Nullable PbNamedTypeElement computeDeclaredNamedType() {
     PsiReference ref = null;
     PbTextExtensionName extensionName = getExtensionName();
     if (extensionName != null && extensionName.isAnyTypeUrl()) {
@@ -58,7 +77,7 @@ abstract class PbTextFieldNameMixin extends PbTextElementBase implements PbTextF
       PbField field = getDeclaredField();
       if (field != null) {
         PbTypeName typeName = field.getTypeName();
-        if (typeName != null) {
+        if (typeName != null && typeName.getBuiltInType() == null) {
           ref = typeName.getEffectiveReference();
         }
       }

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbTextMessageValueMixin.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/psi/impl/PbTextMessageValueMixin.java
@@ -16,6 +16,7 @@
 package com.intellij.protobuf.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.protobuf.ide.PbCompositeModificationTracker;
 import com.intellij.protobuf.lang.psi.PbMessageType;
 import com.intellij.protobuf.lang.psi.PbNamedTypeElement;
 import com.intellij.protobuf.lang.psi.PbTextField;
@@ -23,6 +24,8 @@ import com.intellij.protobuf.lang.psi.PbTextMessageValue;
 import com.intellij.protobuf.lang.psi.ProtoTokenTypes;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.TokenSet;
+import com.intellij.psi.util.CachedValueProvider.Result;
+import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +43,14 @@ abstract class PbTextMessageValueMixin extends PbTextElementBase implements PbTe
 
   @Override
   public @Nullable PbMessageType getDeclaredMessage() {
+    return CachedValuesManager.getCachedValue(
+        this,
+        () ->
+            Result.create(
+                computeDeclaredMessage(), PbCompositeModificationTracker.byElement(this)));
+  }
+
+  private @Nullable PbMessageType computeDeclaredMessage() {
     PbTextField parentField = PsiTreeUtil.getParentOfType(this, PbTextField.class);
     if (parentField == null) {
       return null;

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/resolve/PbSymbolResolver.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/resolve/PbSymbolResolver.java
@@ -20,21 +20,28 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.Key;
+import com.intellij.protobuf.ide.PbCompositeModificationTracker;
 import com.intellij.protobuf.lang.psi.PbFile;
 import com.intellij.protobuf.lang.psi.PbSymbol;
 import com.intellij.protobuf.lang.psi.PbSymbolOwner;
+import com.intellij.psi.util.CachedValue;
+import com.intellij.psi.util.CachedValueProvider.Result;
+import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.psi.util.QualifiedName;
-import com.intellij.util.SmartList;
-
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 /** Utilities for finding PbSymbol elements using protobuf's scoping and resolution rules. */
 public class PbSymbolResolver {
+
+  private static final Key<CachedValue<PbSymbolResolver>> FILE_RESOLVER_KEY =
+      Key.create("PROTO_FILE_SYMBOL_RESOLVER");
+  private static final Key<CachedValue<PbSymbolResolver>> FILE_EXPORTS_RESOLVER_KEY =
+      Key.create("PROTO_FILE_EXPORTS_SYMBOL_RESOLVER");
 
   private final Multimap<QualifiedName, PbSymbol> symbols;
 
@@ -44,28 +51,39 @@ public class PbSymbolResolver {
 
   /** Returns a PbSymbolResolver that can resolve symbols in the given file and its imports. */
   public static PbSymbolResolver forFile(PbFile file) {
-    return new PbSymbolResolver(convertJdkMapToGuava(file.getFullQualifiedSymbolMap()));
+    return CachedValuesManager.getCachedValue(
+        file,
+        FILE_RESOLVER_KEY,
+        () ->
+            Result.create(
+                new PbSymbolResolver(file.getFullQualifiedSymbols()),
+                PbCompositeModificationTracker.byElement(file)));
   }
 
   /** Returns a PbSymbolResolver that can resolve symbols exported by the given file. */
   public static PbSymbolResolver forFileExports(PbFile file) {
-    return new PbSymbolResolver(convertJdkMapToGuava(file.getExportedQualifiedSymbolMap()));
+    return CachedValuesManager.getCachedValue(
+        file,
+        FILE_EXPORTS_RESOLVER_KEY,
+        () ->
+            Result.create(
+                new PbSymbolResolver(file.getExportedQualifiedSymbols()),
+                PbCompositeModificationTracker.byElement(file)));
   }
 
   /** Returns a PbSymbolResolver that can resolve symbols exported by the given files. */
   public static PbSymbolResolver forFileExports(List<PbFile> files) {
+    if (files.isEmpty()) {
+      return empty();
+    }
+    if (files.size() == 1) {
+      return forFileExports(files.getFirst());
+    }
     ImmutableSetMultimap.Builder<QualifiedName, PbSymbol> builder = ImmutableSetMultimap.builder();
     for (PbFile file : files) {
-      Multimap<QualifiedName, PbSymbol> multimap = convertJdkMapToGuava(file.getExportedQualifiedSymbolMap());
-      builder.putAll(multimap);
+      builder.putAll(file.getExportedQualifiedSymbols());
     }
     return new PbSymbolResolver(builder.build());
-  }
-
-  private static Multimap<QualifiedName, PbSymbol> convertJdkMapToGuava(Map<QualifiedName, Collection<PbSymbol>> jdkMap) {
-    Multimap<QualifiedName, PbSymbol> multimap = Multimaps.newListMultimap(new HashMap<>(), SmartList::new);
-    jdkMap.forEach((key, value) -> multimap.putAll(key, value));
-    return multimap;
   }
 
   /** Returns an empty PbSymbolResolver. */

--- a/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/resolve/PbTextFieldNameReference.java
+++ b/protobuf/protoeditor-core/src/com/intellij/protobuf/lang/resolve/PbTextFieldNameReference.java
@@ -106,10 +106,12 @@ public class PbTextFieldNameReference extends PsiReferenceBase<PbTextFieldName> 
 
       // Make sure that group fields use the capitalized type name rather than the lowercase field
       // name.
-      PbGroupDefinition group =
-          PbPsiUtil.resolveRefToType(fieldType.getEffectiveReference(), PbGroupDefinition.class);
-      if (group != null && !name.equals(group.getName())) {
-        return null;
+      if (fieldType.getBuiltInType() == null && !name.equals(field.getName())) {
+        PbGroupDefinition group =
+            PbPsiUtil.resolveRefToType(fieldType.getEffectiveReference(), PbGroupDefinition.class);
+        if (group != null && !name.equals(group.getName())) {
+          return null;
+        }
       }
 
       return field;


### PR DESCRIPTION
* Cache getDeclaredField() and getDeclaredNamedType() on PbTextFieldNameMixin (or cache the effective PsiReference instance on the element).
* Short-circuit resolveNamedFieldInType in PbTextFieldNameReference: skip the PbGroupDefinition check if fieldType.getBuiltInType() != null or if name.equals(field.getName()).
* Short-circuit getFieldType(field) in OptionOccurrenceTracker: return null immediately if typeName == null || typeName.getBuiltInType() != null.
* Filter early in PbTextAnnotator.annotate(): only run isReservedFieldOrDescendant if element instanceof PbTextElement and matches one of the handled target types.

Fixes: [IJPL-253320](https://youtrack.jetbrains.com/issue/IJPL-253320) Performance issues with codeInsight and prototext files