### PR TITLE
WEB-79648 Angular: preserve event attribute values on completion

### DIFF
--- a/Angular/angular-backend/src/org/angular2/Angular2Framework.kt
+++ b/Angular/angular-backend/src/org/angular2/Angular2Framework.kt
@@ -1,12 +1,14 @@
 // Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package org.angular2
 
+import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.javascript.web.WebFramework
 import com.intellij.javascript.web.html.WebFrameworkHtmlFileType
 import com.intellij.lang.Language
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.polySymbols.PolySymbolQualifiedName
+import com.intellij.polySymbols.completion.PolySymbolCodeCompletionItem
 import com.intellij.polySymbols.html.attributes.HtmlAttributeSymbolDescriptor
 import com.intellij.polySymbols.html.attributes.HtmlAttributeSymbolInfo
 import com.intellij.polySymbols.html.elements.HtmlElementSymbolDescriptor
@@ -14,6 +16,8 @@ import com.intellij.polySymbols.html.elements.HtmlElementSymbolInfo
 import com.intellij.polySymbols.query.PolySymbolNamesProvider
 import com.intellij.polySymbols.query.PolySymbolNamesProvider.Target.NAMES_QUERY
 import com.intellij.polySymbols.query.PolySymbolNamesProvider.Target.RENAME_QUERY
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.xml.XmlAttribute
 import com.intellij.psi.xml.XmlTag
 import icons.AngularIcons
 import org.angular2.codeInsight.attributes.Angular2AttributeDescriptor
@@ -75,6 +79,16 @@ class Angular2Framework : WebFramework() {
 
   override fun getAttributeNameCodeCompletionFilter(tag: XmlTag): Angular2AttributeNameCodeCompletionFilter =
     Angular2AttributeNameCodeCompletionFilter(tag)
+
+  override fun shouldInsertAttributeValue(
+    parameters: CompletionParameters,
+    item: PolySymbolCodeCompletionItem,
+    info: HtmlAttributeSymbolInfo,
+  ): Boolean {
+    val attribute = PsiTreeUtil.getParentOfType(parameters.position, XmlAttribute::class.java)
+
+    return attribute?.valueElement == null && super.shouldInsertAttributeValue(parameters, item, info)
+  }
 
   override fun getNames(
     qualifiedName: PolySymbolQualifiedName,

--- a/Angular/angular-tests/test/org/angular2/codeInsight/Angular2CustomEventCompletionTest.kt
+++ b/Angular/angular-tests/test/org/angular2/codeInsight/Angular2CustomEventCompletionTest.kt
@@ -1,0 +1,34 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package org.angular2.codeInsight
+
+import com.intellij.polySymbols.testFramework.enableIdempotenceChecksOnEveryCache
+import org.angular2.Angular2TestCase
+import org.angular2.TestTsGoProxy
+import org.angular2.TestTsNode
+import org.junit.Test
+
+@TestTsNode
+@TestTsGoProxy
+class Angular2CustomEventCompletionTest : Angular2TestCase("completion/customEvents") {
+
+  override fun setUp() {
+    super.setUp()
+    enableIdempotenceChecksOnEveryCache()
+  }
+
+  @Test
+  fun testEventWithExistingValue() =
+    doConfiguredTest(dir = true, configureFileName = "eventWithExistingValue.html") {
+      completeBasic()
+      type("d\n")
+      checkResultByFile("$testName/eventWithExistingValue.after.html")
+    }
+
+  @Test
+  fun testModifierWithExistingValue() =
+    doConfiguredTest(dir = true, configureFileName = "modifierWithExistingValue.html") {
+      completeBasic()
+      type("sto\n")
+      checkResultByFile("$testName/modifierWithExistingValue.after.html")
+    }
+}

--- a/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/component.ts
+++ b/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/component.ts
@@ -1,0 +1,11 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+import {Component} from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-test',
+  templateUrl: './eventWithExistingValue.html',
+})
+export class TestComponent {
+  method() {}
+}

--- a/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/eventWithExistingValue.after.html
+++ b/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/eventWithExistingValue.after.html
@@ -1,0 +1,1 @@
+<button (load)="method()"></button>

--- a/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/eventWithExistingValue.html
+++ b/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/eventWithExistingValue.html
@@ -1,0 +1,1 @@
+<button (loa<caret>)="method()"></button>

--- a/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/package.json
+++ b/Angular/angular-tests/testData/completion/customEvents/eventWithExistingValue/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@angular/core": "*"
+  }
+}

--- a/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/component.ts
+++ b/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/component.ts
@@ -1,0 +1,11 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+import {Component} from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-test',
+  templateUrl: './modifierWithExistingValue.html',
+})
+export class TestComponent {
+  onClick(): void {}
+}

--- a/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/custom-user-events.web-types.json
+++ b/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/custom-user-events.web-types.json
@@ -1,0 +1,47 @@
+{
+  "name": "custom",
+  "version": "1.0",
+  "contributions": {
+    "js": {
+      "ng-custom-events": [
+        {
+          "name": "Custom modifiers for declarative events handling",
+          "priority": "normal",
+          "pattern": {
+            "template": [
+              {
+                "items": {
+                  "path": "/js/events",
+                  "includeVirtual": false
+                },
+                "template": [
+                  "#item:event"
+                ]
+              },
+              {
+                "items": "ng-event-plugins-modifiers",
+                "template": [
+                  ".",
+                  "#...",
+                  "#item:modifier"
+                ],
+                "priority": "high",
+                "repeat": true,
+                "unique": true,
+                "required": false
+              }
+            ]
+          },
+          "ng-event-plugins-modifiers": [
+            {
+              "name": "prevent"
+            },
+            {
+              "name": "stop"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/modifierWithExistingValue.after.html
+++ b/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/modifierWithExistingValue.after.html
@@ -1,0 +1,1 @@
+<button (click.stop)="onClick()"></button>

--- a/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/modifierWithExistingValue.html
+++ b/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/modifierWithExistingValue.html
@@ -1,0 +1,1 @@
+<button (click.<caret>)="onClick()"></button>

--- a/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/package.json
+++ b/Angular/angular-tests/testData/completion/customEvents/modifierWithExistingValue/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@angular/core": "*"
+  },
+  "web-types": "custom-user-events.web-types.json"
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/WEB-79648

## Summary

Preserve an existing Angular attribute value when completing event bindings.

For example, completing a custom event modifier in:

```html
<button (click.<caret>)="onClick()"></button>
```

should result in:

```html
<button (click.stop)="onClick()"></button>
```

instead of inserting an additional empty attribute value.

## Problem

Angular event completion uses the common HTML/Poly Symbols attribute completion pipeline.

When a completion item is selected inside an existing Angular event binding, the attribute already has a value, but the default insert logic may still try to insert a new one.

This can produce invalid markup such as:

```html
<button (click.stop)="" )="onClick()"></button>
```

The same behavior can be reproduced with regular Angular events, so it is not specific to custom Web Types.

## Fix

Override `shouldInsertAttributeValue` for Angular and skip value insertion when the current `XmlAttribute` already has a value element.

The regular behavior is preserved for newly created attributes without a value.

## Tests

Added a regression test for custom Angular event modifiers backed by `ng-custom-events` Web Types.

It verifies that completing:

```html
<button (click.<caret>)="onClick()"></button>
```

with `stop` preserves the existing value and produces:

```html
<button (click.stop)="onClick()"></button>
```